### PR TITLE
Remove redundant pathing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./tests.js",
+    "test": "mocha ./tests.js",
     "build": "webpack index.js dist/optimizely.min.js",
     "lint": "eslint lib/**"
   },


### PR DESCRIPTION
Manually prepending `$(npm bin)` to dependencies is redundant in npm scripts. Npm already prepends `$(npm bin)` to `$PATH` before executing scripts.