### PR TITLE
feat(utils): Add ConfigCache and ClientCache

### DIFF
--- a/packages/optimizely-sdk/lib/utils/async_cache.js
+++ b/packages/optimizely-sdk/lib/utils/async_cache.js
@@ -13,6 +13,8 @@ const enums = {
     YES_AWAIT: 'await',
   },
 
+  // Use a plain object as a unique value, against which to compare strict equality.
+  // Symbols were invented for this purpose, but those are non-transpilable ES2015.
   UNCHANGED: {},
 };
 
@@ -20,7 +22,7 @@ exports.enums = enums;
 
 /**
  * A read-through cache for any kinds of values which require async work to refresh.
- * LiveCache...
+ * AsyncCache...
  *   - lets you synchronously seed a cache entry with a given value,
  *   - offers configurable semantics for async entry access, and
  *   - ensures at most one pending refresh per entry at a time.
@@ -29,15 +31,18 @@ exports.enums = enums;
  * lest things blow up:
  *   1) __refresh, a function (key, currentValue) => Promise<value>
  *   2) __onGetAsync, which decides how to handle `getAsync` calls.
+ *
+ * Additionally, concrete subclasses may invoke __execRefresh(key) to trigger the
+ * refresh of an entry.
  */
-exports.LiveCache = class LiveCache {
+exports.AsyncCache = class AsyncCache {
   constructor() {
     // Map key -> { value, lastModified, pendingPromise }
     this.cache = {};
     // Map key -> Array<function>
     this.listeners = {};
 
-    // TODO: Blow up if extra methods aren't defined.
+    // TODO: Fail fast if extra methods aren't defined.
   }
 
   /**

--- a/packages/optimizely-sdk/lib/utils/client_cache.js
+++ b/packages/optimizely-sdk/lib/utils/client_cache.js
@@ -1,10 +1,10 @@
 const rp = require('request-promise-native');
 
 const { PollingConfigCache } = require('./config_cache');
-const { LiveCache, enums } = require('./live_cache');
+const { AsyncCache, enums } = require('./async_cache');
 const Optimizely = require('../index.node');
 
-exports.ClientCache = class ClientCache extends LiveCache {
+exports.ClientCache = class ClientCache extends AsyncCache {
   constructor({
     clientArgsThunk = () => ({}),
     // An __onGetAsync passed down to the inner ConfigCache.

--- a/packages/optimizely-sdk/lib/utils/client_cache.js
+++ b/packages/optimizely-sdk/lib/utils/client_cache.js
@@ -1,0 +1,91 @@
+const rp = require('request-promise-native');
+
+const { PollingConfigCache } = require('./config_cache');
+const { LiveCache, enums } = require('./live_cache');
+const Optimizely = require('../index.node');
+
+exports.ClientCache = class ClientCache extends LiveCache {
+  constructor({
+    clientArgsThunk = () => ({}),
+    // An __onGetAsync passed down to the inner ConfigCache.
+    configOnGetAsync = () => enums.refreshDirectives.YES_AWAIT,
+  } = {}) {
+    super();
+
+    this.configCache = new PollingConfigCache({
+      requester: (url, headers) => rp({
+        uri: url,
+        headers,
+        simple: false, // Allow non-2xx responses (such as 304 Not Modified) to fulfill
+        resolveWithFullResponse: true,
+      }),
+
+      onGetAsync: configOnGetAsync,
+    });
+
+    this.__clientArgsThunk = clientArgsThunk;
+    this.__tracked = {};
+  }
+
+  // For ClientCache, a getAsync _always_ means getting whatever the underlying
+  // ConfigCache is going to give you. That means always awaiting a refresh.
+  __onGetAsync() {
+    return enums.refreshDirectives.YES_AWAIT;
+  }
+
+
+  // TODO: Override seed
+
+  /**
+   * Ensure the cached Client for the given key is making decisions based on the config
+   * within this.configCache. _May_ involve losing per-instance state. In particular,
+   * forcedVariations and notificationListeners are lost. TODO: Fix this.
+   */
+  async __refresh(configKey, { client: currentClient, config: currentConfig } = {}) {
+    const newConfig = await this.configCache.getAsync(configKey);
+
+    if (newConfig === currentConfig) {
+      return enums.UNCHANGED;
+    }
+
+    const newClient = Optimizely.createInstance({
+      datafile: newConfig,
+      ...this.__clientArgsThunk(),
+    });
+
+    // Now that this configKey is known to us, make sure we stay current with it
+    // and update as the config changes.
+    this.__ensureSubscribedToChanges(configKey);
+
+    return {
+      client: newClient,
+      config: newConfig,
+    };
+  }
+
+  get(key) {
+    if (this.cache[key] && this.cache[key].value) {
+      return this.cache[key].value.client;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * @param {string} configKey
+   *        Identifies the entry which this ClientCache should ensure that
+   *        it will refresh whenever this.configCache emits a change event
+   *        on the associated underlying config.
+   */
+  __ensureSubscribedToChanges(configKey) {
+    if (this.__tracked[configKey]) {
+      return;
+    }
+
+    this.configCache.on(configKey, (newConfig) => {
+      this.__refresh(configKey, this.get(configKey));
+    });
+
+    this.__tracked[configKey] = true;
+  }
+}

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -1,151 +1,47 @@
-const enums = {
-  // Possible directives for `getAsync`.
-  // In all variants, a cache miss => await and fulfill with the refreshed entry.
-  refreshDirectives: {
-    // On hit, fulfill with the cached entry.
-    ONLY_IF_CACHE_MISS: 'only',
-
-    // On hit, fulfill with cached entry and asynchronously refresh the cache,
-    // akin to 'stale-while-revalidate'.
-    YES_DONT_AWAIT: 'dontawait',
-
-    // On hit, await and fulfill with the refreshed entry.
-    YES_AWAIT: 'await',
-  },
-};
-
-exports.enums = enums;
+const { LiveCache, enums } = require('./live_cache');
 
 /**
  * A ConfigCache that syncs by polling the CDN.
  */
-exports.PollingConfigCache = class PollingConfigCache {
+exports.PollingConfigCache = class PollingConfigCache extends LiveCache {
   constructor({
     // An async function (url: string, headers: Object) => Promise<{headers, body}, Error> to make HTTP requests.
     requester,
     // A function that decides how to handle `getAsync` calls.
-    onGetAsync = () => enums.refreshDirectives.YES_AWAIT,
+    __onGetAsync = () => enums.refreshDirectives.YES_AWAIT,
     // The period of the polling, in ms.
     pollPeriod = 5000,
   } = {}) {
-    Object.assign(this, { requester, onGetAsync, pollPeriod });
 
-    // Map key -> { value, lastModified, pendingPromise, headers }
-    this.cache = {};
-    // Map key -> Array<function>
-    this.listeners = {};
+    super();
+    Object.assign(this, { requester, __onGetAsync, pollPeriod });
   }
 
   /**
-   * Seed a cache entry with an initial value.
-   * The entry will then be maintained fresh via the cache's synchronization mechanism.
-   * The given inital value can be read back via `get` synchronously after this method returns.
-   *
-   * If you want to seed the cache but don't have access to a value (say, from localStorage
-   * or the filesystem), then you're probably looking to fetch it from the network.
-   * `cache.getAsync(key)` is what you want to do then.
-   *
-   * No effect if a cached value already exists for the given key.
+   * Kick off a request, marking an entry as pending along the way. Idempotent.
    *
    * @param {string} configKey
-   *        The config to add to the cache.
-   * @param {Config} initialValue
-   *        An initial value to put in the cache, enabling immediate use of `get`.
+   * @returns {Promise}
+   *        Rejects with fetch or timeout errors.
+   *        Fulfills otherwise, with a boolean indicating whether the config was updated.
    */
-  seed(configKey, initialValue) {
-    // Entry already exists and has a value => no-op.
-    if (this.get(configKey)) {
-      return;
+  async __refresh(configKey, currentValue = {}) {
+    // For now, let configKeys be URLs to configs.
+    const headers = currentValue.headers || {};
+    console.log('Requesting with headers', headers);
+
+    const response = await this.requester(configKey, headers);
+
+    if (response.statusCode === 304) {
+      return enums.UNCHANGED;
     }
 
-    // Pending entries => just set the initial value, if one was given.
-    if (this.__isPending(configKey)) {
-      this.cache[configKey].value = initialValue;
-      return;
-    }
+    // TODO: Status codes other than 200 and 304?
 
-    // Never-before-seen configKey => make a new entry.
-    this.cache[configKey] = {
-      value: initialValue,
-      lastModified: Date.now(),
+    return {
+      config: response.body,
+      headers: this.__getNextReqHeaders(response.headers),
     };
-
-    return;
-  }
-
-  /**
-   * @returns {boolean}
-   *        True iff the cache is aware of the key and has a sync in progress.
-   */
-  __isPending(configKey) {
-    return this.cache[configKey] && this.cache[configKey].pendingPromise;
-  }
-
-  /**
-   * Synchronous cache access. 
-   * Use this after the cache is warm to quickly get configs.
-   *
-   * @param {string} configKey
-   * @returns {Config=}
-   *        If cache hit, the value from cache.
-   *        Otherwise, null.
-   */
-  get(configKey) {
-    if (this.cache[configKey] && this.cache[configKey].value) {
-      return this.cache[configKey].value;
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * The thing to use if you're willing to risk added latency from network I/O for
-   * (generally) surely getting _some_ revision of the requested config.
-   *
-   * @param {string} configKey
-   * @param {refreshDirective=} override
-   *        If defined, overrides this.onGetAsync's directive.
-   * @param {number=} timeout
-   *        How long to wait for a response, if refreshing.
-   * @returns {Promise<Client, Error>}
-   *        Fulfills ASAP in accord with the result of `onGetAsync` or the given override.
-   *        Rejects on network error or timeout.
-   */
-  async getAsync(configKey, override, timeout = 5000) {
-    const currentEntry = this.cache[configKey];
-
-    if (!this.get('configKey')) {
-      // In all cases, a cache miss means awaiting until a value is obtained.
-      await this.__refresh(configKey, timeout);
-      return this.cache[configKey].value;
-    }
-
-    // Cache hit! But depending on the onGetAsync-computed directive (or a provided
-    // override), we may do different things.
-    const directive = override || this.onGetAsync(configKey, currentEntry);
-
-    switch (directive) {
-      case enums.refreshDirectives.ONLY_IF_CACHE_MISS:
-        return Promise.resolve(this.get(configKey));
-
-      case enums.refreshDirectives.YES_DONT_AWAIT:
-        this.__refresh(configKey, timeout);
-        return this.get(configKey);
-
-      case enums.refreshDirectives.YES_AWAIT:
-        await this.__refresh(configKey, timeout);
-        return this.get(configKey);
-    }
-  }
-
-  // Register subscribers to events named after config keys, to be invoked on entry update
-  // with the old, new, and metadata values of the entry.
-  on(configKey, fn) {
-    if (!this.listeners[configKey]) {
-      this.listeners[configKey] = [];
-    }
-
-    this.listeners[configKey].push(fn);
   }
 
   /**
@@ -165,81 +61,18 @@ exports.PollingConfigCache = class PollingConfigCache {
     };
   }
 
-  /**
-   * Kick off a request, marking an entry as pending along the way. Idempotent.
-   *
-   * @param {string} configKey
-   * @param {number} timeout
-   *        How long to wait for a response from the CDN before resolving in rejection, in ms.
-   * @returns {Promise}
-   *        Rejects with fetch or timeout errors.
-   *        Fulfills otherwise, with a boolean indicating whether the config was updated.
-   */
-  async __refresh(configKey, timeout) {
-    // Idempotency: An entry has at most one pending request at any moment.
-    if (this.__isPending(configKey)) {
-      return this.cache[configKey].pendingPromise;
-    }
-
-    // TODO: Do something with timeout, maybe.
-
-    // Ensure there's an entry to mark pending at all.
-    if (!this.cache[configKey]) {
-      this.cache[configKey] = {};
-    }
-
-    // For now, let configKeys be URLs to configs.
-    console.log('Requesting with headers', this.cache[configKey].headers || {})
-    const start = Date.now();
-    const request = this.requester(configKey, this.cache[configKey].headers || {});
-
-    this.cache[configKey].pendingPromise = request;
-
-    const response = await request;
-    const end = Date.now();
-
-    if (response.statusCode === 304) {
-      console.log('Not modified');
-      this.cache[configKey].pendingPromise = null;
-      return false;
-    }
-
-    // TODO: Status codes other than 200 and 304?
-
-    const oldEntry = this.cache[configKey];
-    const newEntry = {
-      value: response.body,
-      lastModified: Date.now(),
-      pendingPromise: null,
-      headers: this.__getNextReqHeaders(response.headers),
-    };
-
-    this.cache[configKey] = newEntry;
-
-    this.__emit(configKey, newEntry, { start, end });
-
-    console.log('Refreshed');
-    return true;
-  }
-
-  __emit(eventName, ...args) {
-    for (let fn of this.listeners[eventName] || []) {
-      fn(...args);
-    }
-  }
-
   // TODO: Add interval on first entry, and #clear (which also kills interval)
 }
 
-const LazyConfigCache = () => new PollingConfigCache({
-  onGetAsync: () => enums.refreshDirectives.ONLY_IF_CACHE_MISS,
-});
-
-const StaleWhileRevalidateConfigCache = () => new PollingConfigCache({
-  onGetAsync: () => enums.refreshDirectives.YES_DONT_AWAIT,
-});
-
-const StronglyConsistentConfigCache = () => new PollingConfigCache({
-  onGetAsync: () => enums.refreshDirectives.YES_AWAIT,
-});
+//const LazyConfigCache = () => new PollingConfigCache({
+//  __onGetAsync: () => enums.refreshDirectives.ONLY_IF_CACHE_MISS,
+//});
+//
+//const StaleWhileRevalidateConfigCache = () => new PollingConfigCache({
+//  __onGetAsync: () => enums.refreshDirectives.YES_DONT_AWAIT,
+//});
+//
+//const StronglyConsistentConfigCache = () => new PollingConfigCache({
+//  __onGetAsync: () => enums.refreshDirectives.YES_AWAIT,
+//});
 

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -86,7 +86,7 @@ exports.ConfigCache = class ConfigCache {
 
   /**
    * Synchronous cache access. 
-   * Main use case: After the cache is warm, to quickly get configs.
+   * Use this after the cache is warm to quickly get configs.
    *
    * @param {string} configKey
    * @returns {Config=}
@@ -104,7 +104,6 @@ exports.ConfigCache = class ConfigCache {
   /**
    * The thing to use if you're willing to risk added latency from network I/O for
    * (generally) surely getting _some_ revision of the requested config.
-   * Main use case: 
    *
    * @param {string} configKey
    * @param {refreshDirective=} override

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -8,13 +8,15 @@ exports.PollingConfigCache = class PollingConfigCache extends LiveCache {
     // An async function (url: string, headers: Object) => Promise<{headers, body}, Error> to make HTTP requests.
     requester,
     // A function that decides how to handle `getAsync` calls.
-    __onGetAsync = () => enums.refreshDirectives.YES_AWAIT,
+    onGetAsync = () => enums.refreshDirectives.YES_AWAIT,
     // The period of the polling, in ms.
     pollPeriod = 5000,
   } = {}) {
 
     super();
-    Object.assign(this, { requester, __onGetAsync, pollPeriod });
+    this.__onGetAsync = onGetAsync;
+
+    Object.assign(this, { requester, pollPeriod });
   }
 
   /**

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -17,10 +17,11 @@ exports.PollingConfigCache = class PollingConfigCache extends LiveCache {
     this.__onGetAsync = onGetAsync;
 
     Object.assign(this, { requester, pollPeriod });
+    this.__intervalFn = null;
   }
 
   /**
-   * Kick off a request, marking an entry as pending along the way. Idempotent.
+   * Kick off a request, marking an entry as pending along the way.
    *
    * @param {string} configKey
    * @returns {Promise}

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -40,9 +40,13 @@ exports.ConfigCache = class ConfigCache {
   }
 
   /**
-   * Add an entry to the cache, which will be maintained fresh per the cache's
-   * synchronization mechanism. If called with an inital value, that value can be read
-   * back via `get` synchronously after this method returns.
+   * Seed a cache entry with an initial value.
+   * The entry will then be maintained fresh via the cache's synchronization mechanism.
+   * The given inital value can be read back via `get` synchronously after this method returns.
+   *
+   * If you want to seed the cache but don't have access to a value (say, from localStorage
+   * or the filesystem), then you must want to fetch from the network instead.
+   * `await cache.getAsync(key)` is what you want to do then.
    *
    * No effect if a cached value already exists for the given key.
    *

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -1,9 +1,9 @@
-const { LiveCache, enums } = require('./live_cache');
+const { AsyncCache, enums } = require('./async_cache');
 
 /**
  * A ConfigCache that syncs by polling the CDN.
  */
-exports.PollingConfigCache = class PollingConfigCache extends LiveCache {
+exports.PollingConfigCache = class PollingConfigCache extends AsyncCache {
   constructor({
     // An async function (url: string, headers: Object) => Promise<{headers, body}, Error> to make HTTP requests.
     requester,

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -27,7 +27,7 @@ exports.ConfigCache = class ConfigCache {
 
     // The following two params are only used if mode === POLL.
     onGetAsync = () => enums.refreshDirectives.YES_DONT_AWAIT,
-    intervalPeriod = 5000,
+    pollPeriod = 5000,
   }) {
     if (mode === enums.modes.PUSH) {
       throw new Error('enums.modes.PUSH is not implemented yet; use POLL instead');
@@ -36,7 +36,7 @@ exports.ConfigCache = class ConfigCache {
     // Map key -> { value, lastModified, pendingPromise: Promise= }
     this.cache = {};
 
-    this.intervalPeriod = intervalPeriod;
+    this.pollPeriod = pollPeriod;
   }
 
   /**
@@ -67,7 +67,7 @@ exports.ConfigCache = class ConfigCache {
       return;
     }
 
-    // Never-before-seen configKey => make a new entry
+    // Never-before-seen configKey => make a new entry.
     this.cache[configKey] = {
       value: initialValue,
       lastModified: Date.now(),

--- a/packages/optimizely-sdk/lib/utils/config_cache.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.js
@@ -1,0 +1,168 @@
+const enums = {
+  modes: {
+    POLL: 'poll',
+    PUSH: 'push',
+  },
+
+  // Possible directives for `getAsync`; only meaningful when mode === POLL.
+  // In all variants, a cache miss => await and fulfill with the refreshed entry.
+  refreshDirectives: {
+    // On hit, fulfill with the cached entry.
+    ONLY_IF_CACHE_MISS: 'only',
+
+    // On hit, fulfill with cached entry and asynchronously refresh the cache,
+    // akin to 'stale-while-revalidate'.
+    YES_DONT_AWAIT: 'dontawait',
+
+    // On hit, await and fulfill with the refreshed entry.
+    YES_AWAIT: 'await',
+  },
+};
+
+exports.enums = enums;
+
+exports.ConfigCache = class ConfigCache {
+  constructor({
+    mode = enums.modes.PUSH,
+
+    // The following two params are only used if mode === POLL.
+    onGetAsync = () => enums.refreshDirectives.YES_DONT_AWAIT,
+    intervalPeriod = 5000,
+  }) {
+    if (mode === enums.modes.PUSH) {
+      throw new Error('enums.modes.PUSH is not implemented yet; use POLL instead');
+    }
+
+    // Map key -> { value, lastModified, pendingPromise: Promise= }
+    this.cache = {};
+
+    this.intervalPeriod = intervalPeriod;
+  }
+
+  /**
+   * Add an entry to the cache, which will be maintained fresh per the cache's
+   * synchronization mechanism. If called with an inital value, that value can be read
+   * back via `get` synchronously after this method returns.
+   *
+   * No effect if a cached value already exists for the given key.
+   *
+   * @param {string} configKey
+   *        The config to add to the cache.
+   * @param {Config} initialValue
+   *        An initial value to put in the cache, enabling immediate use of `get`.
+   */
+  seed(configKey, initialValue) {
+    // Entry already exists and has a value => no-op.
+    if (this.get(configKey)) {
+      return;
+    }
+
+    // Pending entries => just set the initial value, if one was given.
+    if (this.__isPending(configKey)) {
+      this.cache[configKey] = initialValue;
+      return;
+    }
+
+    // Never-before-seen configKey => make a new entry
+    this.cache[configKey] = {
+      value: initialValue,
+      lastModified: Date.now(),
+    };
+
+    return;
+  }
+
+  /**
+   * @returns {boolean}
+   *        True iff the cache is aware of the key and has a sync in progress.
+   */
+  __isPending(configKey) {
+    return this.cache[configKey] && this.cache[configKey].pendingPromise;
+  }
+
+  /**
+   * Synchronous cache access. 
+   * Main use case: After the cache is warm, to quickly get configs.
+   *
+   * @param {string} configKey
+   * @returns {Config=}
+   *        If cache hit, the value from cache.
+   *        Otherwise, null.
+   */
+  get(configKey) {
+    if (this.cache[configKey] && this.cache[configKey].value) {
+      return this.cache[configKey].value;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * The thing to use if you're willing to risk added latency from network I/O for
+   * (generally) surely getting _some_ revision of the requested config.
+   * Main use case: 
+   *
+   * @param {string} configKey
+   * @param {refreshDirective=} override
+   *        If defined, overrides this.onGetAsync's directive.
+   * @param {number=} timeout
+   *        How long to wait for a response, if refreshing.
+   * @returns {Promise<Client, Error>}
+   *        If mode === POLL, fulfills ASAP in accord with the result of `onGetAsync` or
+   *          the given override.
+   *        If mode === PUSH, fulfills ASAP after at least one whole config has been received.
+   *        In both modes, rejects on network or timeout error.
+   */
+  async getAsync(configKey, override, timeout = 5000) {
+    const currentEntry = this.cache[configKey];
+
+    // In all cases, a cache miss means awaiting until a value is obtained.
+    if (!currentEntry) {
+      await this.refreshWithPull(configKey);
+      return this.cache[configKey];
+    }
+
+    // Cache hit! But depending on the onGetAsync-computed directive (or a provided
+    // override), we may do different things.
+    const directive = override || this.onGetAsync(configKey, currentEntry);
+
+    switch (directive) {
+      case enums.refreshDirectives.ONLY_IF_CACHE_MISS:
+        return Promise.resolve(this.get(configKey));
+
+      case enums.refreshDirectives.YES_DONT_AWAIT:
+        this.refreshWithPull(configKey);
+        return this.get(configKey);
+
+      case enums.refreshDirectives.YES_AWAIT:
+        await this.refreshWithPull(configKey);
+        return this.get(configKey);
+    }
+  }
+
+  // Register subscribers to events named after config keys, to be invoked on entry update
+  // with the old, new, and metadata values of the entry.
+  on(configKey, fn) {
+    throw new Error('Not yet implemented');
+  }
+
+  async __refreshWithPull(configKey) {
+    // request from CDN and store in cache
+  }
+}
+
+const LazyConfigCache = () => new ConfigCache({
+  mode: enums.modes.POLL,
+  onGetAsync: () => enums.refreshDirectives.ONLY_IF_CACHE_MISS,
+});
+
+const StaleWhileRevalidateConfigCache = () => new ConfigCache({
+  mode: enums.modes.POLL,
+  onGetAsync: () => enums.refreshDirectives.YES_DONT_AWAIT,
+});
+
+const StronglyConsistentConfigCache = () => new ConfigCache({
+  mode: enums.modes.POLL,
+  onGetAsync: () => enums.refreshDirectives.YES_AWAIT,
+});
+

--- a/packages/optimizely-sdk/lib/utils/config_cache.tests.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.tests.js
@@ -1,0 +1,55 @@
+
+
+const { assert }  = require('chai');
+
+const { ConfigCache, enums } = require('./config_cache');
+
+describe('lib/utils/config_cache', () => {
+  describe('ConfigCache', () => {
+    let cache;
+
+    it('throws if constructed in PUSH mode', () => {
+      assert.throws(() => new ConfigCache({ mode: enums.modes.PUSH }));
+    });
+
+    describe('#get', () => {
+      beforeEach(() => {
+        cache = new ConfigCache({ mode: enums.modes.POLL });
+      });
+
+      context('entry is absent', () => {
+        context('no override is given', () => {
+          it('returns null', () => {
+            assert.strictEqual(cache.get('missingKey'), null);
+          });
+        });
+      });
+
+      context('entry is present', () => {
+        beforeEach(() => {
+          // Set entry
+          cache.seed('key', 'value');
+        });
+
+        it('returns that entry', () => {
+          assert.equal(cache.get('key'), 'value');
+        });
+      });
+    });
+
+    describe('#getAsync', () => {
+      context('mode is PUSH', () => {
+        context('onGetAsync is ONLY_IF_CACHE_MISS', () => {
+          context('cache hit', () => {
+            it('fulfills ASAP');
+          });
+          context('cache miss', () => {
+            it('fetches');
+          });
+
+          // ...
+        });
+      });
+    });
+  });
+});

--- a/packages/optimizely-sdk/lib/utils/config_cache.tests.js
+++ b/packages/optimizely-sdk/lib/utils/config_cache.tests.js
@@ -2,16 +2,16 @@
 
 const { assert }  = require('chai');
 
-const { PollingConfigCache, enums } = require('./config_cache');
+const { LiveCache, enums } = require('./live_cache');
 
 describe('lib/utils/config_cache', () => {
-  describe('ConfigCache', () => {
+  describe('LiveCache', () => {
     let cache;
 
     describe('#seed', () => {
       context('on a new cache', () => {
         beforeEach(() => {
-          cache = new PollingConfigCache();
+          cache = new LiveCache();
         });
 
         it('sets the value and can be synchronously accessed later', () => {
@@ -50,7 +50,7 @@ describe('lib/utils/config_cache', () => {
 
     describe('#get', () => {
       beforeEach(() => {
-        cache = new PollingConfigCache();
+        cache = new LiveCache();
       });
 
       context('entry is absent', () => {

--- a/packages/optimizely-sdk/lib/utils/live_cache.js
+++ b/packages/optimizely-sdk/lib/utils/live_cache.js
@@ -177,14 +177,13 @@ exports.LiveCache = class LiveCache {
     if (value === enums.UNCHANGED) {
       console.log('Not modified');
       this.cache[key].pendingPromise = null;
-      return false;
+      return enums.UNCHANGED;
     }
-    // TODO: Fulfill with a Symbol-like obj representing 'UNCHANGED'
 
     this.__set(key, value);
     this.__emit(key, value);
 
-    return true;
+    return value;
   }
 
   __emit(eventName, ...args) {

--- a/packages/optimizely-sdk/lib/utils/live_cache.js
+++ b/packages/optimizely-sdk/lib/utils/live_cache.js
@@ -1,0 +1,217 @@
+const enums = {
+  // Possible directives for `getAsync`.
+  // In all variants, a cache miss => await and fulfill with the refreshed entry.
+  refreshDirectives: {
+    // On hit, fulfill with the cached entry.
+    ONLY_IF_CACHE_MISS: 'only',
+
+    // On hit, fulfill with cached entry and asynchronously refresh the cache,
+    // akin to 'stale-while-revalidate'.
+    YES_DONT_AWAIT: 'dontawait',
+
+    // On hit, await and fulfill with the refreshed entry.
+    YES_AWAIT: 'await',
+  },
+
+  UNCHANGED: {},
+};
+
+exports.enums = enums;
+
+/**
+ * A read-through cache for any kinds of values which require async work to refresh.
+ * LiveCache...
+ *   - lets you synchronously seed a cache entry with a given value,
+ *   - offers configurable semantics for async entry access, and
+ *   - ensures at most one pending refresh per entry at a time.
+ *
+ * It is an abstract class; implementations must define at least two extra methods,
+ * lest things blow up:
+ *   1) __refresh, a function (key, currentValue) => Promise<value>
+ *   2) __onGetAsync, which decides how to handle `getAsync` calls.
+ */
+exports.LiveCache = class LiveCache {
+  constructor() {
+    // Map key -> { value, lastModified, pendingPromise }
+    this.cache = {};
+    // Map key -> Array<function>
+    this.listeners = {};
+
+    // TODO: Blow up if extra methods aren't defined.
+  }
+
+  /**
+   * Seed a cache entry with an initial value.
+   * The entry will then be maintained fresh via the cache's synchronization mechanism.
+   * The given inital value can be read back via `get` synchronously after this method returns.
+   *
+   * If you want to seed the cache but don't have access to a value (say, from localStorage
+   * or the filesystem), then you're probably looking to fetch it from the network.
+   * `cache.getAsync(key)` is what you want to do then.
+   *
+   * No effect if a cached value already exists for the given key.
+   *
+   * @param {string} key
+   *        The new entry to add to the chace.
+   * @param {Config} initialValue
+   *        An initial value to put in the cache, enabling immediate use of `get`.
+   */
+  seed(key, initialValue) {
+    // Entry already exists and has a value => no-op.
+    if (this.get(key)) {
+      return;
+    }
+
+    // Pending entries => just set the initial value, if one was given.
+    if (this.__isPending(key)) {
+      this.__set(key, initialValue, false);
+      return;
+    }
+
+    // Never-before-seen key => make a new entry.
+    this.__set(key, initialValue);
+
+    return;
+  }
+
+  /**
+   * @returns {boolean}
+   *        True iff the cache is aware of the key and has a sync in progress.
+   */
+  __isPending(key) {
+    return this.cache[key] && this.cache[key].pendingPromise;
+  }
+
+  /**
+   * Synchronous cache access. 
+   * Use this after the cache is warm to quickly get values.
+   *
+   * @param {string} key
+   * @returns {*=}
+   *        If cache hit, the value from cache.
+   *        Otherwise, null.
+   */
+  get(key) {
+    if (this.cache[key] && this.cache[key].value) {
+      return this.cache[key].value;
+    } else {
+      return null;
+    }
+  }
+
+  __set(key, value, clearPending = true) {
+    const entry = this.cache[key];
+
+    entry.value = value;
+    entry.lastModified = Date.now();
+
+    if (clearPending) {
+      entry.pendingPromise = null;
+    }
+  }
+
+  /**
+   * The thing to use if you're willing to risk added latency from I/O for (generally)
+   * surely getting _some_ value.
+   *
+   * @param {string} key
+   * @param {refreshDirective=} override
+   *        If defined, overrides this.__onGetAsync's directive.
+   * @returns {Promise<Client, Error>}
+   *        Fulfills ASAP in accord with the result of `__onGetAsync` or the given override.
+   *        Rejects on refresh error.
+   */
+  async getAsync(key, override) {
+    if (!this.get(key)) {
+      // In all cases, a cache miss means awaiting until a value is obtained.
+      await this.__execRefresh(key);
+      return this.get(key);
+    }
+
+    const currentEntry = this.cache[key];
+
+    // Cache hit! But depending on the __onGetAsync-computed directive (or a provided
+    // override), we may do different things.
+    const directive = override || this.__onGetAsync(key, currentEntry);
+
+    switch (directive) {
+      case enums.refreshDirectives.ONLY_IF_CACHE_MISS:
+        return Promise.resolve(this.get(key));
+
+      case enums.refreshDirectives.YES_DONT_AWAIT:
+        this.__execRefresh(key);
+        return this.get(key);
+
+      case enums.refreshDirectives.YES_AWAIT:
+        await this.__execRefresh(key);
+        return this.get(key);
+    }
+  }
+
+  /**
+   * Kick off a refresh, marking an entry as pending along the way. Idempotent.
+   *
+   * @param {string} key
+   * @returns {Promise}
+   *        Rejects with refresh error.
+   *        Fulfills otherwise, with a boolean indicating whether the config was updated.
+   */
+  async __execRefresh(key) {
+    // Idempotency: An entry has at most one pending request at any moment.
+    if (this.__isPending(key)) {
+      return this.cache[key].pendingPromise;
+    }
+
+    // Ensure there's an entry to mark pending at all.
+    if (!this.cache[key]) {
+      this.cache[key] = {};
+    }
+
+    // For now, let keys be URLs to configs.
+    const request = this.__refresh(key, this.cache[key].value);
+
+    this.cache[key].pendingPromise = request;
+
+    const value = await request;
+
+    if (value === enums.UNCHANGED) {
+      console.log('Not modified');
+      this.cache[key].pendingPromise = null;
+      return false;
+    }
+    // TODO: Fulfill with a Symbol-like obj representing 'UNCHANGED'
+
+    this.__set(key, value);
+    this.__emit(key, value);
+
+    return true;
+  }
+
+  __emit(eventName, ...args) {
+    for (let fn of this.listeners[eventName] || []) {
+      fn(...args);
+    }
+  }
+
+  /**
+   * Register subscribers to events named after keys, to be invoked on entry update
+   * with the old, new, and metadata values of the entry.
+   */
+  on(key, fn) {
+    if (!this.listeners[key]) {
+      this.listeners[key] = [];
+    }
+
+    this.listeners[key].push(fn);
+  }
+
+  /**
+   * Invoke listeners that are subscribed to the given event.
+   */
+  __emit(eventName, ...args) {
+    for (let fn of this.listeners[eventName] || []) {
+      fn(...args);
+    }
+  }
+}
+

--- a/packages/optimizely-sdk/lib/utils/test.js
+++ b/packages/optimizely-sdk/lib/utils/test.js
@@ -12,10 +12,13 @@ const configCache = new PollingConfigCache({
   //requester: (url, headers) => window.fetch(url, { headers });
 });
 
+const TEST_KEY = 'https://cdn.optimizely.com/json/8351122416.json';
+
 async function main() {
-  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
-  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
-  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
+  configCache.getAsync(TEST_KEY);
+  configCache.on(TEST_KEY, () => {
+    console.log('TEST_KEY listener invoked');
+  });
 }
 
 main();

--- a/packages/optimizely-sdk/lib/utils/test.js
+++ b/packages/optimizely-sdk/lib/utils/test.js
@@ -1,0 +1,22 @@
+const rp = require('request-promise-native');
+
+const { PollingConfigCache } = require('./config_cache');
+
+const configCache = new PollingConfigCache({
+  requester: (url, headers) => rp({
+    uri: url,
+    headers,
+    simple: false, // Allow non-2xx responses (such as 304 Not Modified) to fulfill
+    resolveWithFullResponse: true,
+  }),
+  //requester: (url, headers) => window.fetch(url, { headers });
+});
+
+async function main() {
+  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
+  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
+  await configCache.getAsync('https://cdn.optimizely.com/json/8351122416.json');
+}
+
+main();
+

--- a/packages/optimizely-sdk/lib/utils/test.js
+++ b/packages/optimizely-sdk/lib/utils/test.js
@@ -1,6 +1,7 @@
 const rp = require('request-promise-native');
 
 const { PollingConfigCache } = require('./config_cache');
+const { ClientCache } = require('./client_cache');
 
 const configCache = new PollingConfigCache({
   requester: (url, headers) => rp({
@@ -12,13 +13,13 @@ const configCache = new PollingConfigCache({
   //requester: (url, headers) => window.fetch(url, { headers });
 });
 
+const clientCache = new ClientCache();
+
 const TEST_KEY = 'https://cdn.optimizely.com/json/8351122416.json';
 
 async function main() {
-  configCache.getAsync(TEST_KEY);
-  configCache.on(TEST_KEY, () => {
-    console.log('TEST_KEY listener invoked');
-  });
+  console.log(await clientCache.getAsync(TEST_KEY));
+  console.log(await clientCache.getAsync(TEST_KEY));
 }
 
 main();


### PR DESCRIPTION
## Summary

- Add public types `PollingConfigCache` and `ClientCache`, both of which are implementations of a [currently] private type `AsyncCache`

How to review this: start with `AsyncCache`, then move on to the other types. It is a bit like the popular [async-cache](https://www.npmjs.com/package/async-cache) package, but with some differences. My implementation:

- Is a class, so can be `extend`ed, having methods overridden (like `seed`, whose semantics are quite different for `ClientCache` than they are for `PollingConfigCache`).
- Lacks any notions of entry expiration or eviction, since our dataset is small (Full Stack configs).
- Subclasses may own refreshing entries by calling `__execRefresh(key)`.

This doesn't yet define an _interface_ `ConfigCache`, but that could easily be done when the time comes.

## Test plan
Currently some very basic unit tests; need to flesh those out before merging. Some manual tests have validated basic `getAsync` use of both types, at-most-one-in-flight behavior, and support for tracking headers so `PollingConfigCache` can get 304 responses from the CDN.