### PR TITLE
chore(ci): replace node target with v9/v10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 - '6'
 - '8'
 - '9'
+# TODO(#102): restore node/10 config
+- '10.0'
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '4'
 - '6'
 - '8'
-- node
+- '9'
 branches:
   only:
   - master


### PR DESCRIPTION
Travis is erroring ([example](https://travis-ci.org/optimizely/javascript-sdk/jobs/380942404)) when the "node" or "10" target is given, but the tests are passing with node 10 (at least on my machine). Update "node" targets to "9"/"10.0" until this is resolved.

```
$ node --version
v10.0.0
$ npm run test-travis

> @optimizely/optimizely-sdk@2.0.1 test-travis /Users/tbrandt/optly/Projects/javascript-sdk/packages/optimizely-sdk
> npm run test && grunt
...
  362 passing (653ms)
```

Mitigation for #102 