### PR TITLE
Revert "chore(publish): add prepare hook (#108)"

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -18,8 +18,7 @@
     "build-prod-umd": "webpack -p lib/index.browser.js dist/optimizely.browser.umd.min.js --output-library=optimizelyClient --output-library-target=umd",
     "lint": "eslint lib/**",
     "cover": "istanbul cover _mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js",
-    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
-    "prepare": "npm test && npm run build"
+    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This reverts commit 1ee3a843d0ccaca0425a13ac27120cab7e30283f.

For some reason this breaks when travis runs it as a "branch" build,
even though it didn't break as a PR build.