### PR TITLE
chore: fix all lint warnings

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -68,7 +68,7 @@ DecisionService.prototype.getVariation = function(experimentKey, userId, attribu
   if (!fns.isEmpty(attributes)) {
     if (attributes.hasOwnProperty(enums.CONTROL_ATTRIBUTES.BUCKETING_ID)) {
       bucketingId = attributes[enums.CONTROL_ATTRIBUTES.BUCKETING_ID];
-      this.logger.log(LOG_LEVEL.DEBUG, sprintf('Setting the bucketing ID to %s.', bucketingId))
+      this.logger.log(LOG_LEVEL.DEBUG, sprintf('Setting the bucketing ID to %s.', bucketingId));
     }
   }
 

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -360,7 +360,7 @@ describe('lib/core/decision_service', function() {
 
     var testUserAttributes = {
       'browser_type': 'firefox',
-    }
+    };
     var userAttributesWithBucketingId = {
       'browser_type': 'firefox',
       '$opt_bucketing_id': '123456789'
@@ -436,7 +436,7 @@ describe('lib/core/decision_service', function() {
       var userProfileServiceInstance = {
         lookup: function () {
         },
-      }
+      };
       userProfileLookupStub = sinon.stub(userProfileServiceInstance, 'lookup');
       userProfileLookupStub.returns({
         user_id: 'test_user',

--- a/packages/optimizely-sdk/lib/core/event_builder/index.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.js
@@ -66,7 +66,7 @@ function getCommonEventParams(options) {
         key: attributeKey,
         type: CUSTOM_ATTRIBUTE_FEATURE_TYPE,
         value: attributes[attributeKey],
-      });      
+      });
     }
   });
 
@@ -77,7 +77,7 @@ function getCommonEventParams(options) {
       type: CUSTOM_ATTRIBUTE_FEATURE_TYPE,
       value: botFiltering,
     });
-  };
+  }
   return commonParams;
 }
 

--- a/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
@@ -290,7 +290,7 @@ describe('lib/core/event_builder', function() {
 
         assert.deepEqual(actualParams, expectedParams);
       });
-     
+
       it('should fill in userFeatures for user agent and bot filtering (bot filtering enabled)', function() {
         var v4ConfigObj = projectConfig.createProjectConfig(testData.getTestProjectConfigWithFeatures());
         var expectedParams = {

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -141,7 +141,7 @@ module.exports = {
     var hasReservedPrefix = attributeKey.indexOf(RESERVED_ATTRIBUTE_PREFIX) === 0;
     if (attribute) {
       if (hasReservedPrefix) {
-        logger.log(LOG_LEVEL.WARN, 
+        logger.log(LOG_LEVEL.WARN,
                    sprintf('Attribute %s unexpectedly has reserved prefix %s; using attribute ID instead of reserved attribute name.', attributeKey, RESERVED_ATTRIBUTE_PREFIX));
       }
       return attribute.id;
@@ -372,7 +372,7 @@ module.exports = {
       } else {
         // catching improperly formatted experiments
         logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.IMPROPERLY_FORMATTED_EXPERIMENT, MODULE_NAME, experimentKey));
-        return null
+        return null;
       }
     } catch (ex) {
       // catching experiment not in datafile

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -217,7 +217,7 @@ describe('lib/core/project_config', function() {
     var testData = testDatafile.getTestProjectConfig();
     var configObj;
     var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
-      
+
     beforeEach(function() {
       configObj = projectConfig.createProjectConfig(testData);
       sinon.stub(createdLogger, 'log');
@@ -258,22 +258,22 @@ describe('lib/core/project_config', function() {
 
     it('should return null for invalid attribute key in getAttributeId', function() {
       assert.isNull(projectConfig.getAttributeId(configObj, 'invalidAttributeKey', createdLogger));
-      sinon.assert.calledWithExactly(createdLogger.log, 
-                                     LOG_LEVEL.DEBUG, 
-                                     'PROJECT_CONFIG: Unrecognized attribute invalidAttributeKey provided. Pruning before sending event to Optimizely.')
+      sinon.assert.calledWithExactly(createdLogger.log,
+                                     LOG_LEVEL.DEBUG,
+                                     'PROJECT_CONFIG: Unrecognized attribute invalidAttributeKey provided. Pruning before sending event to Optimizely.');
     });
 
     it('should return null for invalid attribute key in getAttributeId', function() {
       // Adding attribute in key map with reserved prefix
       configObj.attributeKeyMap['$opt_some_reserved_attribute'] = {
-        id: '42', 
+        id: '42',
         key: '$opt_some_reserved_attribute'
       };
       assert.strictEqual(projectConfig.getAttributeId(configObj, '$opt_some_reserved_attribute', createdLogger), '42');
-      sinon.assert.calledWithExactly(createdLogger.log, 
-                                     LOG_LEVEL.WARN, 
-                                     'Attribute $opt_some_reserved_attribute unexpectedly has reserved prefix $opt_; using attribute ID instead of reserved attribute name.')
-    });    
+      sinon.assert.calledWithExactly(createdLogger.log,
+                                     LOG_LEVEL.WARN,
+                                     'Attribute $opt_some_reserved_attribute unexpectedly has reserved prefix $opt_; using attribute ID instead of reserved attribute name.');
+    });
 
     it('should retrieve event ID for valid event key in getEventId', function() {
       assert.strictEqual(projectConfig.getEventId(configObj, 'testEvent'), '111095');
@@ -365,21 +365,21 @@ describe('lib/core/project_config', function() {
     });
 
     describe('feature management', function() {
-      var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+      var featureManagementLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
       beforeEach(function() {
         configObj = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
-        sinon.stub(createdLogger, 'log');
+        sinon.stub(featureManagementLogger, 'log');
       });
 
       afterEach(function() {
-        createdLogger.log.restore();
+        featureManagementLogger.log.restore();
       });
 
       describe('getVariableForFeature', function() {
         it('should return a variable object for a valid variable and feature key', function() {
           var featureKey = 'test_feature_for_experiment';
           var variableKey = 'num_buttons';
-          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, createdLogger);
+          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, featureManagementLogger);
           assert.deepEqual(result, {
             type: 'integer',
             key: 'num_buttons',
@@ -391,28 +391,28 @@ describe('lib/core/project_config', function() {
         it('should return null for an invalid variable key and a valid feature key', function() {
           var featureKey = 'test_feature_for_experiment';
           var variableKey = 'notARealVariable____';
-          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, createdLogger);
+          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledOnce(createdLogger.log);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "notARealVariable____" associated with feature with key "test_feature_for_experiment" is not in datafile.');
+          sinon.assert.calledOnce(featureManagementLogger.log);
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "notARealVariable____" associated with feature with key "test_feature_for_experiment" is not in datafile.');
         });
 
         it('should return null for an invalid feature key', function() {
           var featureKey = 'notARealFeature_____';
           var variableKey = 'num_buttons';
-          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, createdLogger);
+          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledOnce(createdLogger.log);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key notARealFeature_____ is not in datafile.');
+          sinon.assert.calledOnce(featureManagementLogger.log);
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key notARealFeature_____ is not in datafile.');
         });
 
         it('should return null for an invalid variable key and an invalid feature key', function() {
           var featureKey = 'notARealFeature_____';
           var variableKey = 'notARealVariable____';
-          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, createdLogger);
+          var result = projectConfig.getVariableForFeature(configObj, featureKey, variableKey, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledOnce(createdLogger.log);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key notARealFeature_____ is not in datafile.');
+          sinon.assert.calledOnce(featureManagementLogger.log);
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key notARealFeature_____ is not in datafile.');
         });
       });
 
@@ -420,40 +420,40 @@ describe('lib/core/project_config', function() {
         it('returns a value for a valid variation and variable', function() {
           var variation = configObj.variationIdMap['594096'];
           var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, '2');
 
           variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.is_button_animated;
-          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, 'true');
 
           variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.button_txt;
-          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, 'Buy me NOW');
 
           variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.button_width;
-          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, '20.25');
         });
 
         it('returns null for a null variation', function() {
           var variation = null;
           var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, null);
         });
 
         it('returns null for a null variable', function() {
           var variation = configObj.variationIdMap['594096'];
           var variable = null;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, null);
         });
 
         it('returns null for a null variation and null variable', function() {
           var variation = null;
           var variable = null;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, null);
         });
 
@@ -464,67 +464,67 @@ describe('lib/core/project_config', function() {
             variables: [],
           };
           var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, null);
         });
 
         it('returns the variable default value if the variation does not have a value for this variable', function() {
           var variation = configObj.variationIdMap['595008']; // This variation has no variable values associated with it
           var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
-          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, createdLogger);
+          var result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, '10');
         });
       });
 
       describe('getTypeCastValue', function() {
         it('can cast a boolean', function() {
-          var result = projectConfig.getTypeCastValue('true', FEATURE_VARIABLE_TYPES.BOOLEAN, createdLogger);
+          var result = projectConfig.getTypeCastValue('true', FEATURE_VARIABLE_TYPES.BOOLEAN, featureManagementLogger);
           assert.strictEqual(result, true);
-          result = projectConfig.getTypeCastValue('false', FEATURE_VARIABLE_TYPES.BOOLEAN, createdLogger);
+          result = projectConfig.getTypeCastValue('false', FEATURE_VARIABLE_TYPES.BOOLEAN, featureManagementLogger);
           assert.strictEqual(result, false);
         });
 
         it('can cast an integer', function() {
-          var result = projectConfig.getTypeCastValue('50', FEATURE_VARIABLE_TYPES.INTEGER, createdLogger);
+          var result = projectConfig.getTypeCastValue('50', FEATURE_VARIABLE_TYPES.INTEGER, featureManagementLogger);
           assert.strictEqual(result, 50);
-          var result = projectConfig.getTypeCastValue('-7', FEATURE_VARIABLE_TYPES.INTEGER, createdLogger);
+          var result = projectConfig.getTypeCastValue('-7', FEATURE_VARIABLE_TYPES.INTEGER, featureManagementLogger);
           assert.strictEqual(result, -7);
-          var result = projectConfig.getTypeCastValue('0', FEATURE_VARIABLE_TYPES.INTEGER, createdLogger);
+          var result = projectConfig.getTypeCastValue('0', FEATURE_VARIABLE_TYPES.INTEGER, featureManagementLogger);
           assert.strictEqual(result, 0);
         });
 
         it('can cast a double', function() {
-          var result = projectConfig.getTypeCastValue('89.99', FEATURE_VARIABLE_TYPES.DOUBLE, createdLogger);
+          var result = projectConfig.getTypeCastValue('89.99', FEATURE_VARIABLE_TYPES.DOUBLE, featureManagementLogger);
           assert.strictEqual(result, 89.99);
-          var result = projectConfig.getTypeCastValue('-257.21', FEATURE_VARIABLE_TYPES.DOUBLE, createdLogger);
+          var result = projectConfig.getTypeCastValue('-257.21', FEATURE_VARIABLE_TYPES.DOUBLE, featureManagementLogger);
           assert.strictEqual(result, -257.21);
-          var result = projectConfig.getTypeCastValue('0', FEATURE_VARIABLE_TYPES.DOUBLE, createdLogger);
+          var result = projectConfig.getTypeCastValue('0', FEATURE_VARIABLE_TYPES.DOUBLE, featureManagementLogger);
           assert.strictEqual(result, 0);
-          var result = projectConfig.getTypeCastValue('10', FEATURE_VARIABLE_TYPES.DOUBLE, createdLogger);
+          var result = projectConfig.getTypeCastValue('10', FEATURE_VARIABLE_TYPES.DOUBLE, featureManagementLogger);
           assert.strictEqual(result, 10);
         });
 
         it('can return a string unmodified', function() {
-          var result = projectConfig.getTypeCastValue('message', FEATURE_VARIABLE_TYPES.STRING, createdLogger);
+          var result = projectConfig.getTypeCastValue('message', FEATURE_VARIABLE_TYPES.STRING, featureManagementLogger);
           assert.strictEqual(result, 'message');
         });
 
         it('returns null and logs an error for an invalid boolean', function() {
-          var result = projectConfig.getTypeCastValue('notabool', FEATURE_VARIABLE_TYPES.BOOLEAN, createdLogger);
+          var result = projectConfig.getTypeCastValue('notabool', FEATURE_VARIABLE_TYPES.BOOLEAN, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notabool to type boolean, returning null.');
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notabool to type boolean, returning null.');
         });
 
         it('returns null and logs an error for an invalid integer', function() {
-          var result = projectConfig.getTypeCastValue('notanint', FEATURE_VARIABLE_TYPES.INTEGER, createdLogger);
+          var result = projectConfig.getTypeCastValue('notanint', FEATURE_VARIABLE_TYPES.INTEGER, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notanint to type integer, returning null.');
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notanint to type integer, returning null.');
         });
 
         it('returns null and logs an error for an invalid double', function() {
-          var result = projectConfig.getTypeCastValue('notadouble', FEATURE_VARIABLE_TYPES.DOUBLE, createdLogger);
+          var result = projectConfig.getTypeCastValue('notadouble', FEATURE_VARIABLE_TYPES.DOUBLE, featureManagementLogger);
           assert.strictEqual(result, null);
-          sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notadouble to type double, returning null.');
+          sinon.assert.calledWithExactly(featureManagementLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value notadouble to type double, returning null.');
         });
       });
     });
@@ -555,7 +555,7 @@ describe('lib/core/project_config', function() {
       var variation = projectConfig.getForcedVariation(configObj, 'definitely_not_valid_exp_key', 'user1', createdLogger);
       assert.strictEqual(variation, null);
     });
-  })
+  });
 
   describe('#setForcedVariation', function() {
     var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
@@ -690,7 +690,7 @@ describe('lib/core/project_config', function() {
       assert.strictEqual(variation2, 'controlLaunched');
 
       //reset for one of the experiments
-      var didSetVariationAgain = projectConfig.setForcedVariation(configObj, 'testExperiment', 'user1', null, createdLogger);
+      projectConfig.setForcedVariation(configObj, 'testExperiment', 'user1', null, createdLogger);
       assert.strictEqual(didSetVariation, true);
 
       var variation = projectConfig.getForcedVariation(configObj, 'testExperiment', 'user1', createdLogger);

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -56,7 +56,8 @@ module.exports = {
       }
     }
 
-    if (config.skipJSONValidation == null) {
+    // Explicitly check for null or undefined
+    if (config.skipJSONValidation == null) { // eslint-disable-line eqeqeq
       config.skipJSONValidation = true;
     }
 

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -41,8 +41,8 @@ describe('javascript-sdk', function() {
         xhr = sinon.useFakeXMLHttpRequest();
         global.XMLHttpRequest = xhr;
         requests = [];
-        xhr.onCreate = function (xhr) {
-            requests.push(xhr);
+        xhr.onCreate = function (req) {
+            requests.push(req);
         };
       });
 
@@ -124,7 +124,7 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation, true);
 
         var variation = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
         done();
       });
 
@@ -140,13 +140,13 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation, true);
 
         var variation = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
 
         var didSetVariation2 = optlyInstance.setForcedVariation('testExperiment', 'testUser', null);
         assert.strictEqual(didSetVariation2, true);
 
         var variation2 = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation2, null)
+        assert.strictEqual(variation2, null);
         done();
       });
 
@@ -166,10 +166,10 @@ describe('javascript-sdk', function() {
 
 
         var variation = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
 
         var variation2 = optlyInstance.getForcedVariation('testExperimentLaunched', 'testUser');
-        assert.strictEqual(variation2, 'controlLaunched')
+        assert.strictEqual(variation2, 'controlLaunched');
         done();
       });
 
@@ -191,10 +191,10 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation2, true);
 
         var variation = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
 
         var variation2 = optlyInstance.getForcedVariation('testExperimentLaunched', 'testUser');
-        assert.strictEqual(variation2, null)
+        assert.strictEqual(variation2, null);
         done();
       });
 
@@ -216,10 +216,10 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation2, true);
 
         var variation = optlyInstance.getForcedVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
 
         var variation2 = optlyInstance.getForcedVariation('testExperimentLaunched', 'testUser');
-        assert.strictEqual(variation2, 'variationLaunched')
+        assert.strictEqual(variation2, 'variationLaunched');
         done();
       });
 
@@ -235,13 +235,13 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation, true);
 
         var variation = optlyInstance.getVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'control')
+        assert.strictEqual(variation, 'control');
 
         var didSetVariation2 = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'variation');
         assert.strictEqual(didSetVariation2, true);
 
         var variation = optlyInstance.getVariation('testExperiment', 'testUser');
-        assert.strictEqual(variation, 'variation')
+        assert.strictEqual(variation, 'variation');
         done();
       });
 
@@ -257,7 +257,7 @@ describe('javascript-sdk', function() {
         assert.strictEqual(didSetVariation, true);
 
         var variation = optlyInstance.getVariation('testExperimentNotRunning', 'testUser');
-        assert.strictEqual(variation, null)
+        assert.strictEqual(variation, null);
 
         done();
       });

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -291,7 +291,7 @@ describe('lib/optimizely', function() {
       });
       bucketStub.returns('111129');
 
-      var activate = instance.activate('testExperiment', 'testUser');;
+      var activate = instance.activate('testExperiment', 'testUser');
 
       assert.strictEqual(activate, 'variation');
       eventDispatcherPromise.then(function() {
@@ -302,7 +302,7 @@ describe('lib/optimizely', function() {
                                                'testUser',
                                                'testExperiment'));
         done();
-      })
+      });
     });
 
     it('should execute a custom dispatchEvent\'s promise in track', function(done) {
@@ -317,7 +317,7 @@ describe('lib/optimizely', function() {
       });
       bucketStub.returns('111129');
 
-      var activate = instance.activate('testExperiment', 'testUser');;
+      var activate = instance.activate('testExperiment', 'testUser');
 
       assert.strictEqual(activate, 'variation');
       instance.track('testEvent', 'testUser');
@@ -329,9 +329,9 @@ describe('lib/optimizely', function() {
                                                'testEvent',
                                                'testUser'));
         done();
-      })
+      });
     });
-  })
+  });
 
   describe('APIs', function() {
     var optlyInstance;
@@ -662,7 +662,7 @@ describe('lib/optimizely', function() {
         sinon.assert.callCount(createdLogger.log, 3);
 
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
 
         var logMessage1 = createdLogger.log.args[1][1];
         assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_NOT_IN_EXPERIMENT, 'DECISION_SERVICE', 'testUser', 'testExperimentWithAudiences'));
@@ -676,7 +676,7 @@ describe('lib/optimizely', function() {
         sinon.assert.callCount(createdLogger.log, 3);
 
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
 
         var logMessage1 = createdLogger.log.args[1][1];
         assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_NOT_IN_EXPERIMENT, 'DECISION_SERVICE', 'testUser', 'groupExperiment1'));
@@ -776,7 +776,7 @@ describe('lib/optimizely', function() {
           sinon.assert.calledThrice(createdLogger.log);
 
           var logMessage0 = createdLogger.log.args[0][1];
-          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','user1'));
+          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'user1'));
           var logMessage1 = createdLogger.log.args[1][1];
           assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_FORCED_IN_VARIATION, 'DECISION_SERVICE', 'user1', 'control'));
 
@@ -1219,7 +1219,7 @@ describe('lib/optimizely', function() {
 
         sinon.assert.callCount(createdLogger.log, 4);
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
         var logMessage1 = createdLogger.log.args[1][1];
         assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_NOT_IN_EXPERIMENT, 'DECISION_SERVICE', 'testUser', 'testExperimentWithAudiences'));
         var logMessage2 = createdLogger.log.args[2][1];
@@ -1242,7 +1242,7 @@ describe('lib/optimizely', function() {
         optlyInstance.track('testEvent', 'testUser');
         sinon.assert.notCalled(eventDispatcher.dispatchEvent);
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
         var logMessage1 = createdLogger.log.args[1][1];
         assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.NOT_TRACKING_USER_FOR_EXPERIMENT, 'OPTIMIZELY', 'testUser', 'testExperiment'));
       });
@@ -1320,9 +1320,9 @@ describe('lib/optimizely', function() {
         assert.deepEqual(eventDispatcherCall[0], expectedObj);
 
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
         var logMessage1 = createdLogger.log.args[1][1];
-        assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
         var logMessage2 = createdLogger.log.args[2][1];
         assert.strictEqual(logMessage2, sprintf(LOG_MESSAGES.EXPERIMENT_NOT_RUNNING, 'DECISION_SERVICE', 'testExperimentNotRunning'));
         var logMessage3 = createdLogger.log.args[3][1];
@@ -1421,7 +1421,7 @@ describe('lib/optimizely', function() {
           sinon.assert.calledThrice(createdLogger.log);
 
           var logMessage0 = createdLogger.log.args[0][1];
-          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','user1'));
+          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'user1'));
           var logMessage1 = createdLogger.log.args[1][1];
           assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_FORCED_IN_VARIATION, 'DECISION_SERVICE', 'user1', 'control'));
 
@@ -1524,7 +1524,7 @@ describe('lib/optimizely', function() {
         sinon.assert.calledThrice(createdLogger.log);
 
         var logMessage0 = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','testUser'));
+        assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'testUser'));
         var logMessage1 = createdLogger.log.args[1][1];
         assert.strictEqual(logMessage1, sprintf(LOG_MESSAGES.USER_NOT_IN_EXPERIMENT, 'DECISION_SERVICE', 'testUser', 'testExperimentWithAudiences'));
         var logMessage2 = createdLogger.log.args[2][1];
@@ -1591,7 +1591,7 @@ describe('lib/optimizely', function() {
           sinon.assert.calledTwice(createdLogger.log);
 
           var logMessage0 = createdLogger.log.args[0][1];
-          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION,'PROJECT_CONFIG','user1'));
+          assert.strictEqual(logMessage0, sprintf(LOG_MESSAGES.USER_HAS_NO_FORCED_VARIATION, 'PROJECT_CONFIG', 'user1'));
           var logMessage = createdLogger.log.args[1][1];
           assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.USER_FORCED_IN_VARIATION, 'DECISION_SERVICE', 'user1', 'control'));
         });

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -27,8 +27,8 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         xhr = sinon.useFakeXMLHttpRequest();
         global.XMLHttpRequest = xhr;
         requests = [];
-        xhr.onCreate = function (xhr) {
-            requests.push(xhr);
+        xhr.onCreate = function (req) {
+            requests.push(req);
         };
       });
 

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -53,7 +53,7 @@ module.exports = {
     };
 
     var requestCallback = function(error, response, body) {
-      if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400 && callback && typeof callback == 'function') {
+      if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400 && callback && typeof callback === 'function') {
         callback();
       }
     };

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
@@ -51,7 +51,7 @@ describe('lib/plugins/event_dispatcher/node', function() {
 
         eventDispatcher.dispatchEvent(eventObj)
         .on('response', function(response) {
-          assert.isTrue(response.statusCode == 200);
+          assert.isTrue(response.statusCode === 200);
           done();
         })
         .on('error', function(error) {

--- a/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
@@ -77,7 +77,7 @@ describe('lib/plugins/logger', function() {
         defaultLogger.setLogLevel(undefined);
         expect(defaultLogger.logLevel).to.equal(LOG_LEVEL.ERROR);
 
-        defaultLogger.setLogLevel("abc");
+        defaultLogger.setLogLevel('abc');
         expect(defaultLogger.logLevel).to.equal(LOG_LEVEL.ERROR);
       });
     });

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -251,7 +251,7 @@ var config = {
 
 var getParsedAudiences = [{
   name: 'Firefox users',
-  conditions: ["and", ["or", ["or", {"name": "browser_type", "type": "custom_attribute", "value": "firefox"}]]],
+  conditions: ['and', ['or', ['or', {'name': 'browser_type', 'type': 'custom_attribute', 'value': 'firefox'}]]],
   id: '11154'
 }];
 


### PR DESCRIPTION
- Use `npm run lint -- --fix` for most issues, and manually fix the rest