### PR TITLE
fix(package): Give Node.js consumers the unbundled package

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@optimizely/optimizely-sdk",
   "version": "2.1.1",
   "description": "JavaScript SDK package for Optimizely X Full Stack",
-  "main": "dist/optimizely.node.js",
+  "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
   "scripts": {
     "test": "mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js --recursive",


### PR DESCRIPTION
I'm not sure it's conventional to distribute pre-bundled packages.