### PR TITLE
fix(package.json): Add license key

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -16,6 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/optimizely/javascript-sdk.git"
   },
+  "license": "Apache-2.0",
   "keywords": [
     "optimizely"
   ],


### PR DESCRIPTION
## Summary

- Add [`license`](https://docs.npmjs.com/files/package.json#license) key to the manifest

This addresses the warning that is currently being logged during `npm install @optimizely/optimizely-sdk`:
```
npm WARN @optimizely/optimizely-sdk@2.1.1 No license field.
```
and fixes this on our NPM page:
![screen shot 2018-07-03 at 12 17 13 pm](https://user-images.githubusercontent.com/20175438/42240111-137c72ac-7ebb-11e8-8f37-1399668ef7d9.png)

## Test plan
```sh
rm -r node_modules ; npm install
...
```
No warnings!