### PR TITLE
chore(ci): Restore Node.js 10.x to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ node_js:
 - '6'
 - '8'
 - '9'
-# TODO(#102): restore node/10 config
-- '10.0'
+- '10'
 branches:
   only:
   - master
@@ -17,7 +16,7 @@ env:
   - secure: U0GGZw46rJowBtH9gVluIrerB40u2b3uZpH0HsOdLlsXCCaTVk4JXX/JPVPashWAFLC7Enk3UOE4ofeEpVd0wbG6CxtG9/gklc2U2tvkqsdPpFZKaRrXoUzCyyPOmHEC2mXDXctbrncmttM4APaceRfbdTBEZIIfyLJadomjWylA61szFE9IZjvJpiwJO2xa5HI9GVRu3yXJci+riJux+JsDmfJ1hNwv3waMeeg/scddUH0hfgq69ftGs8cpMlYiO20eh32S7uPF7/IJTH1fDJjVKYQZwpypkF6AeI+od5CFTY1ajb25eaBNXThLS0Bo9ZJE/8Sogvon21dEJkt/ClY6R341InbAFXZvz7jyQAisvh0I4zxcu0VUCfh7bEUl6GXMO8VJnyxHEfqB+AIT2RoMXckkhulwiNUsJYH1yJ8mjnLvZq85mWBCp4n4jg0K6Wf46lHpjnHOVpLyLyoFGfiPf90AQVL02AJ3/ia8RkMuj0Ax+AGtiTC/+wy7dsDQOif/VpBNJcx/RciQ24mYOGzAMh4GsUWnXaZ9vXSxliogVNrmIefK5invJ0omv9pIx8NZHTHYGaulh4w6JsliiEq2kH78SlyvSrcsFGTwCY97LLaxiLm/75/Zf+F7LajKC23Fbtnj/LQizitFZqGMJ09DnR52krBAeultqRq8QLM=
 matrix:
   include:
-  - node_js: '10.0'
+  - node_js: '10'
     script: npm run test-xbrowser
 before_install: cd packages/optimizely-sdk
 install: npm install


### PR DESCRIPTION
## Summary

- Re-enable CI against latest Node.js 10.x release

It was disabled in https://github.com/optimizely/javascript-sdk/pull/101, but from the [example failure](https://travis-ci.org/optimizely/javascript-sdk/jobs/380942404) given in that PR, I suspect the bug lies in lerna. No matter now, since lerna has been bypassed since https://github.com/optimizely/javascript-sdk/pull/129.

## Test plan
CI