### PR TITLE
feat(package.json): Codify supported Node.js in engines property

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@optimizely/optimizely-sdk",
   "version": "2.1.1",
-  "description": "JavaScript SDK package for Optimizely X Full Stack",
+  "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
   "scripts": {
@@ -17,13 +17,16 @@
     "url": "git+https://github.com/optimizely/javascript-sdk.git"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "keywords": [
     "optimizely"
   ],
   "bugs": {
     "url": "https://github.com/optimizely/javascript-sdk/issues"
   },
-  "homepage": "https://github.com/optimizely/javascript-sdk#readme",
+  "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/optimizely-sdk",
   "dependencies": {
     "json-schema": "^0.2.3",
     "lodash": "^4.0.0",


### PR DESCRIPTION
## Summary

- Add [`engines`](https://docs.npmjs.com/files/package.json#engines) property, which will warn users if they `npm install` us and are on a ye olde Node.js version
- Call this package's README the "homepage", rather than the one in the repo root which makes kind of a weird first impression
- Delete extraneous word in package description

## Test plan
Ran `>=4.0.0` through http://jubianchi.github.io/semver-check/ to make sure it allows/denies versions in the way I expect.