### PR TITLE
fix(test): Suppress logs when NODE_ENV=test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ npm-debug.log
 dist
 node_modules
 lerna-debug.log
+*.swp
 
 coverage/
 

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -78,6 +78,15 @@ Logger.prototype.setLogLevel = function(logLevel) {
  * @private
  */
 Logger.prototype.__shouldLog = function(targetLogLevel) {
+  try {
+    if (process.env.NODE_ENV === 'test') {
+      // Suppress logs during testing.
+      return false;
+    }
+  } catch (e) {
+    // `process` is likely a ReferenceError in non-Node.js environments
+  }
+
   return targetLogLevel >= this.logLevel;
 };
 

--- a/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
@@ -33,9 +33,20 @@ describe('lib/plugins/logger', function() {
     });
 
     describe('log', function() {
+      var nodeEnv;
+
       beforeEach(function() {
         defaultLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
         sinon.stub(defaultLogger, '__consoleLog');
+
+        // The usual rules of turning off logging don't apply here,
+        // since the code under test _is the logger_.
+        nodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+      });
+
+      afterEach(function() {
+        process.env.NODE_ENV = nodeEnv;
       });
 
       it('should log the given message', function() {

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
   "scripts": {
-    "test": "mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js --recursive",
+    "test": "NODE_ENV=test mocha --reporter dot './lib/**/*.tests.js'",
     "test-xbrowser": "karma start karma.bs.conf.js --single-run",
     "lint": "eslint lib/**",
     "cover": "istanbul cover _mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js",


### PR DESCRIPTION
## Summary

- Ensure `console` isn't logged to during unit tests
- Refactor `createInstance` tests.
- Delete superfluous indent in `lib/optimizely > constructor` tests. When viewing the diff in GitHub, try the ['Hide whitespace changes'](https://github.com/optimizely/javascript-sdk/pull/147/files?utf8=%E2%9C%93&diff=split&w=1) option to make this diff clearer.
- Simplify `npm test` definition. The bug here before was a lack of 'single quotes' around the glob pattern, which prevent glob expansion by bash (the interpreter of npm run-scripts).
- Add `*.swp` (vim temporary files) to gitignore

The status quo is noise like [this](https://travis-ci.org/optimizely/javascript-sdk/jobs/399797132). Now,
```sh
$ npm test

> @optimizely/optimizely-sdk@2.1.1 test /Users/swilson/code/javascript-sdk/packages/optimizely-sdk
> NODE_ENV=test mocha --reporter dot './lib/**/*.tests.js'



  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․sandbox.stub(obj, 'meth', val) is deprecated and will be removed from the public API in a future version of sinon.
 Use sandbox.stub(obj, 'meth').callsFake(fn) instead in order to stub a function.
 Use sandbox.stub(obj, 'meth').value(fn) instead in order to stub a non-function value.
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
․sandbox.stub(obj, 'meth', val) is deprecated and will be removed from the public API in a future version of sinon.
 Use sandbox.stub(obj, 'meth').callsFake(fn) instead in order to stub a function.
 Use sandbox.stub(obj, 'meth').value(fn) instead in order to stub a non-function value.
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  372 passing (616ms)
```

With the noise removed, deprecation warnings from Sinon are now clearly visible. Hooray!

Initially I wanted to avoid putting the `NODE_ENV` stuff inside the logger module, instead trying to stub `logger.createInstance` in the appropriate places in the tests. Down this path, I discovered that one issue was that, though the logger in most (all?) tests is properly stubbed, the `optlyInstance` is often constructed _before_ the `createdLogger.log` method is stubbed ([example](https://github.com/optimizely/javascript-sdk/blob/6a3c9a51550a1afbec44f9f4c38edd374d296b35/packages/optimizely-sdk/lib/optimizely/index.tests.js#L343-L357)), which yields the symptom of lots of log messages like
```
[OPTIMIZELY] - INFO Tue Jul 03 2018 22:52:25 GMT+0000 (Coordinated Universal Time) OPTIMIZELY: Datafile is valid.
```
making it through before the stub. (See how many of these are in the example build link above.)

I tried moving the `optlyInstance` construction _after_ `createdLogger.log` was stubbed, but that caused all of the many assertions like [this one](https://github.com/optimizely/javascript-sdk/blob/6a3c9a51550a1afbec44f9f4c38edd374d296b35/packages/optimizely-sdk/lib/optimizely/index.tests.js#L1236-L1237) to start to fail. This was kind of a bummer and I'm not sure how much value asserting exact text of log messages adds, so at this point I pivoted to the `NODE_ENV` approach.

## Test plan
In the master branch, there are 371 tests. In this branch, 372. That's from the `createInstance` refactor, which net created 1 new test:
```
  optimizelyFactory
    APIs
      createInstance
        ✓ should create an instance of optimizely
        config fails validation
          ✓ catches internal errors
          a logger was supplied
            ✓ an error message is submitted to the supplied logger
          a logger was not supplied
            ✓ an error message is submitted to a simple logger
```