### PR TITLE
docs(README): Add credits and additional code

### DIFF
--- a/packages/optimizely-sdk/README.md
+++ b/packages/optimizely-sdk/README.md
@@ -67,3 +67,49 @@ npm run test-xbrowser
 
 [.travis.yml](/.travis.yml) contains the definitions for `BROWSER_STACK_USERNAME` and `BROWSER_STACK_ACCESS_KEY` used in CI. These values are Optimizely's BrowserStack credentials, encrypted with our Travis CI public key. These creds can be rotated by following [these docs](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml).
 
+## Credits
+
+First-party code (under lib/) is copyright Optimizely, Inc. and contributors, licensed under Apache 2.0.
+
+## Additional code
+
+Prod dependencies are as follows:
+
+```json
+{
+  "json-schema@0.2.3": {
+    "licenses": [
+      "AFLv2.1",
+      "BSD"
+    ],
+    "publisher": "Kris Zyp",
+    "repository": "https://github.com/kriszyp/json-schema"
+  },
+  "lodash@4.17.10": {
+    "licenses": "MIT",
+    "publisher": "John-David Dalton",
+    "repository": "https://github.com/lodash/lodash"
+  },
+  "murmurhash@0.0.2": {
+    "licenses": "MIT*",
+    "repository": "https://github.com/perezd/node-murmurhash"
+  },
+  "sprintf@0.1.5": {
+    "licenses": "BSD-3-Clause",
+    "publisher": "Moritz Peters",
+    "repository": "https://github.com/maritz/node-sprintf"
+  },
+  "uuid@3.2.1": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kelektiv/node-uuid"
+  }
+}
+```
+
+To regenerate this, run the following command:
+
+```sh
+npx license-checker --production --json | jq 'map_values({ licenses, publisher, repository }) | del(.[][] | nulls)'
+```
+
+and remove the self (`@optimizely/optimizely-sdk`) entry.

--- a/packages/optimizely-sdk/README.md
+++ b/packages/optimizely-sdk/README.md
@@ -71,7 +71,7 @@ npm run test-xbrowser
 
 First-party code (under lib/) is copyright Optimizely, Inc. and contributors, licensed under Apache 2.0.
 
-## Additional code
+## Additional Code
 
 Prod dependencies are as follows:
 


### PR DESCRIPTION
Marcelo's asked us to add "Credits" and "Additional Code" sections, where:

> "Credits" is for dependencies that Optimizely distributes (i.e. any code that they download from us, for example, from a repo we set up). If there is a dependency that the customer separately installs / pulls from some non-Optimizely source, then that goes into the "Additional Code" section. The Python SDK, for example, has a few runtime dependencies like `pip` that the customer needs to install when setting up their application environment, but these are not distributed by Optimizely.

I take this to mean Credits is the code checked into this repo (including vendored deps, of which javascript-sdk has none), and "Additional Code" is any other code that is required for prod usage.