### PR TITLE
fix(track): Batch decision payloads into the same array in the snapshot.

### DIFF
--- a/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
@@ -782,6 +782,59 @@ describe('lib/core/event_builder', function() {
         assert.deepEqual(actualParams, expectedParams);
       });
 
+      it('should create the correct snapshot for multiple experiments attached to the event', function() {
+        var expectedParams = {
+          url: 'https://logx.optimizely.com/v1/events',
+          httpVerb: 'POST',
+          params: {
+            'account_id': '12001',
+            'project_id': '111001',
+            'visitors': [{
+              'visitor_id': 'testUser',
+              'attributes': [],
+              'snapshots': [{
+                'decisions': [{
+                  'variation_id': '111128',
+                  'experiment_id': '111127',
+                  'campaign_id': '4'
+                }, {
+                  'variation_id': '122228',
+                  'experiment_id': '122227',
+                  'campaign_id': '5'
+                }],
+                'events': [{
+                  'timestamp': Math.round(new Date().getTime()),
+                  'entity_id': '111100',
+                  'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c',
+                  'key': 'testEventWithMultipleExperiments'
+                }]
+              }]
+            }],
+            'revision': '42',
+            'client_name': 'node-sdk',
+            'client_version': packageJSON.version,
+            'anonymize_ip': false,
+          }
+        };
+
+        var eventOptions = {
+          clientEngine: 'node-sdk',
+          clientVersion: packageJSON.version,
+          configObj: configObj,
+          eventKey: 'testEventWithMultipleExperiments',
+          logger: mockLogger,
+          userId: 'testUser',
+          experimentsToVariationMap: {
+            '111127': '111128',
+            '122227': '122228'
+          },
+        };
+
+        var actualParams = eventBuilder.getConversionEvent(eventOptions);
+
+        assert.deepEqual(actualParams, expectedParams);
+      });
+
       describe('and event tags are passed it', function() {
         it('should create proper params for getConversionEvent with event tags', function() {
           var expectedParams = {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -1272,16 +1272,7 @@ describe('lib/optimizely', function() {
                   'campaign_id': '4',
                   'experiment_id': '111127',
                   'variation_id': '111129'
-                }],
-                'events': [{
-                  'entity_id': '111100',
-                  'timestamp': Math.round(new Date().getTime()),
-                  'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c',
-                  'key': 'testEventWithMultipleExperiments',
-                }]
-              },
-              {
-                'decisions': [{
+                }, {
                   'campaign_id': '5',
                   'experiment_id': '122227',
                   'variation_id': '122229'


### PR DESCRIPTION
Before it was many snapshots, each with exactly one decision and one conversion event. This is not accurate because decisions for the experiments attached to the same event should be in the same snapshot.

Only conversion events need to have this special logic, because impression events only come from `activate` and `isFeatureEnabled` API (and transitively, `getEnabledFeatures`), which all submit a single impression event for just one experiment. 