### PR TITLE
chore(release): bump to 2.1.3.

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
 ## [2.1.3] - August 21, 2018
 
 ### Fixed

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Send all decisions for the same event in one snapshot. ([#155](https://github.com/optimizely/javascript-sdk/pull/155))
 - Give Node.js consumers the unbundled package ([#133](https://github.com/optimizely/javascript-sdk/pull/133))
-- Prevent crash when `http`/`https` emits an error by adding an 'error' listener ([#123](https://github.com/optimizely/javascript-sdk/pull/123)
+- Prevent crash when `http`/`https` emits an error by adding an 'error' listener ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
 
 ## 2.1.1
 June 19, 2018

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -6,15 +6,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Deprecated
-* The UMD build of the SDK now assigns the SDK namespace object to `window.optimizelySdk` rather than to `window.optimizelyClient`. The old name still works, but on its first access a deprecation warning is logged to the console. The alias will be removed in the 3.0.0 release.
-
-## [2.1.2] - August 21, 2018
+## [2.1.3] - August 21, 2018
 
 ### Fixed
 - Send all decisions for the same event in one snapshot. ([#155](https://github.com/optimizely/javascript-sdk/pull/155))
 - Give Node.js consumers the unbundled package ([#133](https://github.com/optimizely/javascript-sdk/pull/133))
-- Prevent crash when `http`/`https` emits an error by adding an 'error' listener ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
+
+### Deprecated
+- The UMD build of the SDK now assigns the SDK namespace object to `window.optimizelySdk` rather than to `window.optimizelyClient`. The old name still works, but on its first access a deprecation warning is logged to the console. The alias will be removed in the 3.0.0 release.
+
+## [2.1.2] - June 25, 2018
+
+### Fixed
+- Failure to log success message when event dispatched ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
+- Fix: Don't call success message when event fails to send ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
+
+## [2.0.5] - June 25, 2018
+
+### Fixed
+- Failure to log success message when event dispatched ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
+- Fix: Don't call success message when event fails to send ([#123](https://github.com/optimizely/javascript-sdk/pull/123))
 
 ## 2.1.1
 June 19, 2018

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 * The UMD build of the SDK now assigns the SDK namespace object to `window.optimizelySdk` rather than to `window.optimizelyClient`. The old name still works, but on its first access a deprecation warning is logged to the console. The alias will be removed in the 3.0.0 release.
 
+## [2.1.2] - August 21, 2018
+
+### Fixed
+- Send all decisions for the same event in one snapshot. ([#155](https://github.com/optimizely/javascript-sdk/pull/155))
+- Give Node.js consumers the unbundled package ([#133](https://github.com/optimizely/javascript-sdk/pull/133))
+- Prevent crash when `http`/`https` emits an error by adding an 'error' listener ([#123](https://github.com/optimizely/javascript-sdk/pull/123)
+
 ## 2.1.1
 June 19, 2018
 

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Give Node.js consumers the unbundled package ([#133](https://github.com/optimizely/javascript-sdk/pull/133))
 
 ### Deprecated
-- The UMD build of the SDK now assigns the SDK namespace object to `window.optimizelySdk` rather than to `window.optimizelyClient`. The old name still works, but on its first access a deprecation warning is logged to the console. The alias will be removed in the 3.0.0 release.
+- The UMD build of the SDK now assigns the SDK namespace object to `window.optimizelySdk` rather than to `window.optimizelyClient`. The old name still works, but on its first access a deprecation warning is logged to the console. The alias will be removed in the 3.0.0 release. ([#152](https://github.com/optimizely/javascript-sdk/pull/152))
 
 ## [2.1.2] - June 25, 2018
 

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -137,7 +137,7 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
-exports.NODE_CLIENT_VERSION = '2.1.2';
+exports.NODE_CLIENT_VERSION = '2.1.3';
 
 /*
  * Notification types for use with NotificationCenter

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -137,7 +137,7 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
-exports.NODE_CLIENT_VERSION = '2.1.1';
+exports.NODE_CLIENT_VERSION = '2.1.2';
 
 /*
  * Notification types for use with NotificationCenter

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
## Summary

- Bumps the version number to prepare for release.
- Bring back the previous changelog entry
