### PR TITLE
Eliminate lodash functions that have browser-supported native alternatives

### DIFF
--- a/packages/optimizely-sdk/lib/core/event_builder/index.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.js
@@ -115,7 +115,7 @@ function getImpressionEventParams(configObj, experimentId, variationId) {
  * @param  {Object} logger                    Logger object
  * @return {Object}                           Conversion event params
  */
-function getVisitorSnapshot(configObj, eventKey, eventTags, experimentsToVariationMap, logger) {  
+function getVisitorSnapshot(configObj, eventKey, eventTags, experimentsToVariationMap, logger) {
   var snapshot = {
     decisions: [],
     events: []

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -215,7 +215,7 @@ module.exports = {
 
     var audienceIds = experiment.audienceIds;
     var audiencesInExperiment = [];
-    var audiencesInExperiment = fns.filter(projectConfig.audiences, function(audience) {
+    var audiencesInExperiment = (projectConfig.audiences || []).filter(function(audience) {
       return audienceIds.indexOf(audience.id) !== -1;
     });
     return audiencesInExperiment;

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -228,7 +228,7 @@ Optimizely.prototype._sendImpressionEvent = function(experimentKey, variationKey
  */
 Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
   try {
-    
+
     if (!this.isValidInstance) {
       this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'track'));
       return;
@@ -422,7 +422,7 @@ Optimizely.prototype.__getValidExperimentsForEvent = function(eventKey, userId, 
   }
 
   // determine which variations the user has been bucketed into
-  validExperimentsToVariationsMap = fns.reduce(experimentIdsForEvent, function(results, experimentId) {
+  validExperimentsToVariationsMap = experimentIdsForEvent.reduce(function(results, experimentId) {
     var experimentKey = this.configObj.experimentIdMap[experimentId].key;
 
     // user needs to be bucketed into experiment for us to track the event

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -22,14 +22,11 @@ module.exports = {
   currentTimestamp: function() {
     return Math.round(new Date().getTime());
   },
-  isArray: require('lodash/isArray'),
   isEmpty: require('lodash/isEmpty'),
   keyBy: require('lodash/keyBy'),
-  filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
   forOwn: require('lodash/forOwn'),
   map: require('lodash/map'),
-  reduce: require('lodash/reduce'),
   uuid: function() {
     return uuid.v4();
   },

--- a/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var fns = require('../fns');
 var validate = require('json-schema').validate;
 var sprintf = require('sprintf-js').sprintf;
 
@@ -40,7 +39,7 @@ module.exports = {
     if (result.valid) {
       return true;
     } else {
-      if (fns.isArray(result.errors)) {
+      if (Array.isArray(result.errors)) {
         throw new Error(sprintf(ERROR_MESSAGES.INVALID_DATAFILE, MODULE_NAME, result.errors[0].property, result.errors[0].message));
       }
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_JSON, MODULE_NAME));


### PR DESCRIPTION
- This PR is intended to slightly reduce the bundle size impact of the optimizely SDK when the client project does not already utilize lodash v4.x.
- Switch from `_.isArray` to `Array.isArray`
    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
- Switch from `_.filter` to `Array.prototype.filter`
    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
- Switch from `_.reduce` to `Array.prototype.reduce`
    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
- Fix existing lint warnings