### PR TITLE
fix(audiences): return null variation when audience is specified and user attributes are empty.

### DIFF
--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -31,7 +31,7 @@ module.exports = {
     }
 
     // if no user attributes specified, return false
-    if (!userAttributes) {
+    if (!userAttributes || Object.keys(userAttributes).length === 0) {
       return false;
     }
 

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -31,8 +31,12 @@ describe('lib/core/audience_evaluator', function() {
         assert.isTrue(audienceEvaluator.evaluate([], {}));
       });
 
-      it('should return false if there are audiences but no attributes', function() {
+      it('should return false if there are audiences but the user has emtpy attributes', function() {
         assert.isFalse(audienceEvaluator.evaluate([chromeUserAudience], {}));
+      });
+
+      it('should return false if there are audiences but but the user has null attributes', function() {
+        assert.isFalse(audienceEvaluator.evaluate([chromeUserAudience], null));
       });
 
       it('should return true if any of the audience conditions are met', function() {


### PR DESCRIPTION
## Summary

This fixes a bug where passing in empty attribute maps are causing the `not` audience match to evaluate to true.

```
// Given audience condition is 
// [\"not\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"customattr\", \"value\": \"exact_match\"}]]

let attributes = {}
let variation = optimizelyClient.activate('experiment_with_audience', 'user_1', attributes)

// variation should be `null`. But this bug causes audience evaluation to return true, and thus the client returns a valid variation.
```