### PR TITLE
chore(ci): Ensure Travis unit tests also run on release branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ node_js:
 branches:
   only:
   - master
-  - 2.0.x
-  - 2.1.x
+  - /^\d+\.\d+\.(\d|[x])
 env:
   global:
   # BROWSER_STACK_USERNAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ node_js:
 branches:
   only:
   - master
+  - 2.0.x
+  - 2.1.x
 env:
   global:
   # BROWSER_STACK_USERNAME


### PR DESCRIPTION
## Summary

Release branches need to have unit tests run on them given that we will soon be in a state (3.x release) where we can't always fast-forward these branches to the latest master.