### PR TITLE
fix(logs): Change invalid experiment key to debug level.

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -312,7 +312,8 @@ Optimizely.prototype.getVariation = function(experimentKey, userId, attributes) 
 
       var experiment = this.configObj.experimentKeyMap[experimentKey];
       if (fns.isEmpty(experiment)) {
-        throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+        this.logger.log(LOG_LEVEL.DEBUG, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+        return null;
       }
 
       return this.decisionService.getVariation(experimentKey, userId, attributes);

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -730,14 +730,10 @@ describe('lib/optimizely', function() {
         assert.strictEqual(logMessage2, sprintf(LOG_MESSAGES.NOT_ACTIVATING_USER, 'OPTIMIZELY', 'null', 'testExperiment'));
       });
 
-      it('should throw an error for invalid experiment key', function() {
+      it('should log an error for invalid experiment key', function() {
         assert.isNull(optlyInstance.activate('invalidExperimentKey', 'testUser'));
 
         sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-
-        sinon.assert.calledOnce(errorHandler.handleError);
-        var errorMessage = errorHandler.handleError.lastCall.args[0].message;
-        assert.strictEqual(errorMessage, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, 'OPTIMIZELY', 'invalidExperimentKey'));
 
         sinon.assert.calledTwice(createdLogger.log);
         var logMessage1 = createdLogger.log.args[0][1];
@@ -1554,14 +1550,9 @@ describe('lib/optimizely', function() {
         assert.strictEqual(logMessage, sprintf(ERROR_MESSAGES.INVALID_INPUT_FORMAT, 'OPTIMIZELY', 'user_id'));
       });
 
-      it('should throw an error for invalid experiment key', function() {
+      it('should log an error for invalid experiment key', function() {
         var getVariationWithError = optlyInstance.getVariation('invalidExperimentKey', 'testUser');
-
         assert.isNull(getVariationWithError);
-
-        sinon.assert.calledOnce(errorHandler.handleError);
-        var errorMessage = errorHandler.handleError.lastCall.args[0].message;
-        assert.strictEqual(errorMessage, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, 'OPTIMIZELY', 'invalidExperimentKey'));
 
         sinon.assert.calledOnce(createdLogger.log);
         var logMessage = createdLogger.log.args[0][1];

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -38,7 +38,7 @@ exports.ERROR_MESSAGES = {
   INVALID_EVENT_DISPATCHER: '%s: Provided "eventDispatcher" is in an invalid format.',
   INVALID_EVENT_KEY: '%s: Event key %s is not in datafile.',
   INVALID_EVENT_TAGS: '%s: Provided event tags are in an invalid format.',
-  INVALID_EXPERIMENT_KEY: '%s: Experiment key %s is not in datafile.',
+  INVALID_EXPERIMENT_KEY: '%s: Experiment key %s is not in datafile. It is either invalid, paused, or archived.',
   INVALID_EXPERIMENT_ID: '%s: Experiment ID %s is not in datafile.',
   INVALID_GROUP_ID: '%s: Group ID %s is not in datafile.',
   INVALID_LOGGER: '%s: Provided "logger" is in an invalid format.',


### PR DESCRIPTION
## Summary
Change the log level from ERROR to DEBUG when we are not able to find the experiment with the given key in the datafile. The reason is because we stopped including non-active experiments in the datafile so if you reference an inexistent experiment, it could mean that the experiment is paused/archived as opposed to existing at all in your project.