### PR TITLE
fix (isFeatureEnabled): filter empty attribute values from impression event

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -66,7 +66,7 @@ function Optimizely(config) {
     if (typeof config.datafile === 'string' || config.datafile instanceof String) {
       config.datafile = JSON.parse(config.datafile);
     }
-    
+
     if (config.skipJSONValidation === true) {
       this.configObj = projectConfig.createProjectConfig(config.datafile);
       this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.SKIPPING_JSON_VALIDATION, MODULE_NAME));
@@ -137,9 +137,6 @@ Optimizely.prototype.activate = function (experimentKey, userId, attributes) {
         return variationKey;
       }
 
-      // remove null values from attributes
-      attributes = this.__filterEmptyValues(attributes);
-
       this._sendImpressionEvent(experimentKey, variationKey, userId, attributes);
 
       return variationKey;
@@ -169,6 +166,7 @@ Optimizely.prototype.activate = function (experimentKey, userId, attributes) {
 Optimizely.prototype._sendImpressionEvent = function(experimentKey, variationKey, userId, attributes) {
   var variationId = projectConfig.getVariationIdFromExperimentAndVariationKey(this.configObj, experimentKey, variationKey);
   var experimentId = projectConfig.getExperimentId(this.configObj, experimentKey);
+  this.__filterEmptyValues(attributes);
   var impressionEventOptions = {
     attributes: attributes,
     clientEngine: this.clientEngine,
@@ -217,7 +215,7 @@ Optimizely.prototype._sendImpressionEvent = function(experimentKey, variationKey
  */
 Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
   try {
-    
+
     if (!this.isValidInstance) {
       this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'track'));
       return;

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -2570,6 +2570,23 @@ describe('lib/optimizely', function() {
             sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature_for_experiment is enabled for user user1.');
           });
 
+          it('filters null attribute values from the impression event', function () {
+            var attrsWithNull = {test_attribute: null};
+            optlyInstance.isFeatureEnabled('test_feature_for_experiment', 'user1', attrsWithNull);
+            sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+            var impressionEvent = eventDispatcher.dispatchEvent.getCalls()[0].args[0];
+            var impressionEventAttrs = impressionEvent.params.visitors[0].attributes;
+            var expectedAttrs = [
+              {
+                'entity_id': '$opt_bot_filtering',
+                'key': '$opt_bot_filtering',
+                'type': 'custom',
+                'value': true,
+              },
+            ];
+            assert.deepEqual(impressionEventAttrs, expectedAttrs);
+          });
+
           it('returns false and does not dispatch an impression event when feature key is null', function() {
             var result = optlyInstance.isFeatureEnabled(null, 'user1', attributes);
             assert.strictEqual(result, false);


### PR DESCRIPTION
## Summary

With this change, attribute properties with null or undefined values are filtered out of impression events that are sent as a result of a feature being enabled via a feature test. This makes isFeatureEnabled behave the same way as activate with respect to null/undefined values in attributes in impression events.

## Test plan

Added new unit test