### PR TITLE
feat (audience match types): Update audience evaluator and project config for new audience match types

### DIFF
--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2018 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -20,8 +20,9 @@ module.exports = {
    * Determine if the given user attributes satisfy the given audience conditions
    * @param  {Object[]} audiences            Audiences to match the user attributes against
    * @param  {Object[]} audiences.conditions Audience conditions to match the user attributes against
-   * @param  {Object}   userAttributes       Hash representing user attributes which will be used in determining if
-   *                                         the audience conditions are met
+   * @param  {Object}   [userAttributes]     Hash representing user attributes which will be used in
+   *                                         determining if the audience conditions are met. If not
+   *                                         provided, defaults to an empty object.
    * @return {Boolean}  True if the user attributes match the given audience conditions
    */
   evaluate: function(audiences, userAttributes) {
@@ -30,9 +31,8 @@ module.exports = {
       return true;
     }
 
-    // if no user attributes specified, return false
     if (!userAttributes) {
-      return false;
+      userAttributes = {};
     }
 
     for (var i = 0; i < audiences.length; i++) {

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2018 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -18,10 +18,18 @@ var chai = require('chai');
 var assert = chai.assert;
 
 var chromeUserAudience = {
-  conditions: ['and', {'name': 'browser_type', 'value': 'chrome'}],
+  conditions: ['and', {
+    name: 'browser_type',
+    value: 'chrome',
+    type: 'custom_attribute',
+  }],
 };
 var iphoneUserAudience = {
-  conditions: ['and', {'name': 'device_model', 'value': 'iphone'}],
+  conditions: ['and', {
+    name: 'device_model',
+    value: 'iphone',
+    type: 'custom_attribute',
+  }],
 };
 
 describe('lib/core/audience_evaluator', function() {
@@ -71,6 +79,18 @@ describe('lib/core/audience_evaluator', function() {
         assert.isFalse(audienceEvaluator.evaluate([chromeUserAudience, iphoneUserAudience], nexusUsers));
         assert.isFalse(audienceEvaluator.evaluate([chromeUserAudience, iphoneUserAudience], safariUsers));
         assert.isFalse(audienceEvaluator.evaluate([chromeUserAudience, iphoneUserAudience], nexusSafariUsers));
+      });
+
+      it('should return true if no attributes are passed and the audience conditions evaluate to true in the absence of attributes', function() {
+        var conditionsPassingWithNoAttrs = ['not', {
+          match: 'exists',
+          name: 'input_value',
+          type: 'custom_attribute',
+        }];
+        var audience = {
+          conditions: conditionsPassingWithNoAttrs,
+        };
+        assert.isTrue(audienceEvaluator.evaluate([audience]));
       });
     });
   });

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +40,11 @@ module.exports = {
     fns.forEach(projectConfig.audiences, function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
-    projectConfig.audienceIdMap = fns.keyBy(projectConfig.audiences, 'id');
     fns.forEach(projectConfig.typedAudiences, function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
-    projectConfig.typedAudienceIdMap = fns.keyBy(projectConfig.typedAudiences, 'id');
+    projectConfig.audiencesById = fns.keyBy(projectConfig.audiences, 'id');
+    fns.assign(projectConfig.audiencesById, fns.keyBy(projectConfig.typedAudiences, 'id'));
 
     projectConfig.attributeKeyMap = fns.keyBy(projectConfig.attributes, 'key');
     projectConfig.eventKeyMap = fns.keyBy(projectConfig.events, 'key');
@@ -221,12 +221,7 @@ module.exports = {
     var audienceIds = experiment.audienceIds;
     var audiencesInExperiment = [];
     fns.forEach(audienceIds, function(audienceId) {
-      var typedAudience = projectConfig.typedAudienceIdMap[audienceId];
-      if (typedAudience) {
-        audiencesInExperiment.push(typedAudience);
-        return;
-      }
-      var audience = projectConfig.audienceIdMap[audienceId];
+      var audience = projectConfig.audiencesById[audienceId];
       if (audience) {
         audiencesInExperiment.push(audience);
       }

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -40,6 +40,11 @@ module.exports = {
     fns.forEach(projectConfig.audiences, function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
+    projectConfig.audienceIdMap = fns.keyBy(projectConfig.audiences, 'id');
+    fns.forEach(projectConfig.typedAudiences, function(audience) {
+      audience.conditions = JSON.parse(audience.conditions);
+    });
+    projectConfig.typedAudienceIdMap = fns.keyBy(projectConfig.typedAudiences, 'id');
 
     projectConfig.attributeKeyMap = fns.keyBy(projectConfig.attributes, 'key');
     projectConfig.eventKeyMap = fns.keyBy(projectConfig.events, 'key');
@@ -215,8 +220,16 @@ module.exports = {
 
     var audienceIds = experiment.audienceIds;
     var audiencesInExperiment = [];
-    var audiencesInExperiment = fns.filter(projectConfig.audiences, function(audience) {
-      return audienceIds.indexOf(audience.id) !== -1;
+    fns.forEach(audienceIds, function(audienceId) {
+      var typedAudience = projectConfig.typedAudienceIdMap[audienceId];
+      if (typedAudience) {
+        audiencesInExperiment.push(typedAudience);
+        return;
+      }
+      var audience = projectConfig.audienceIdMap[audienceId];
+      if (audience) {
+        audiencesInExperiment.push(audience);
+      }
     });
     return audiencesInExperiment;
   },

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -534,12 +534,12 @@ describe('lib/core/project_config', function() {
 
     describe('audience match types', function() {
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
+        configObj = projectConfig.createProjectConfig(testDatafile.getTypedAudiencesConfig());
       });
 
       it('should retrieve audiences in getAudiencesForExperiment by checking first in typedAudiences, and then second in audiences', function() {
         assert.deepEqual(
-          projectConfig.getAudiencesForExperiment(configObj, 'typed_audience_experiment'),
+          projectConfig.getAudiencesForExperiment(configObj, 'feat_with_var_test'),
           testDatafile.parsedTypedAudiences
         );
       });

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -531,6 +531,19 @@ describe('lib/core/project_config', function() {
         });
       });
     });
+
+    describe('audience match types', function() {
+      beforeEach(function() {
+        configObj = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
+      });
+
+      it('should retrieve audiences in getAudiencesForExperiment by checking first in typedAudiences, and then second in audiences', function() {
+        assert.deepEqual(
+          projectConfig.getAudiencesForExperiment(configObj, 'typed_audience_experiment'),
+          testDatafile.parsedTypedAudiences
+        );
+      });
+    });
   });
 
   describe('#getForcedVariation', function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -3321,7 +3321,6 @@ describe('lib/optimizely', function() {
       sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
-      sandbox.stub(fns, 'currentTimestamp').returns(1509489766569);
     });
 
     afterEach(function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -2512,23 +2512,12 @@ describe('lib/optimizely', function() {
     });
   });
 
-  describe('feature management', function() {
+  describe('APIs, using a v4 project config', function() {
     var sandbox = sinon.sandbox.create();
     var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
     var optlyInstance;
     var clock;
     beforeEach(function() {
-      optlyInstance = new Optimizely({
-        clientEngine: 'node-sdk',
-        datafile: testData.getTestProjectConfigWithFeatures(),
-        eventBuilder: eventBuilder,
-        errorHandler: errorHandler,
-        eventDispatcher: eventDispatcher,
-        jsonSchemaValidator: jsonSchemaValidator,
-        logger: createdLogger,
-        isValidInstance: true,
-      });
-
       sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
@@ -2542,35 +2531,459 @@ describe('lib/optimizely', function() {
       clock.restore();
     });
 
-    describe('#isFeatureEnabled', function() {
-      it('returns false, and does not dispatch an impression event, for an invalid feature key', function() {
-        var result = optlyInstance.isFeatureEnabled('thisIsDefinitelyNotAFeatureKey', 'user1');
-        assert.strictEqual(result, false);
-        sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-      });
-
-      it('returns false if the instance is invalid', function() {
+    describe('using configWithFeatures', function() {
+      beforeEach(function() {
         optlyInstance = new Optimizely({
           clientEngine: 'node-sdk',
-          datafile: {
-            lasers: 300,
-            message: 'this is not a valid datafile'
-          },
+          datafile: testData.getTestProjectConfigWithFeatures(),
           eventBuilder: eventBuilder,
           errorHandler: errorHandler,
           eventDispatcher: eventDispatcher,
           jsonSchemaValidator: jsonSchemaValidator,
           logger: createdLogger,
+          isValidInstance: true,
         });
-        var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 'user1');
-        assert.strictEqual(result, false);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Optimizely object is not valid. Failing isFeatureEnabled.');
       });
 
-      describe('when the user bucketed into a variation of an experiment with the feature', function() {
-        var attributes = { test_attribute: 'test_value' };
+      describe('#isFeatureEnabled', function() {
+        it('returns false, and does not dispatch an impression event, for an invalid feature key', function() {
+          var result = optlyInstance.isFeatureEnabled('thisIsDefinitelyNotAFeatureKey', 'user1');
+          assert.strictEqual(result, false);
+          sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+        });
 
-        describe('when the variation is toggled ON', function() {
+        it('returns false if the instance is invalid', function() {
+          optlyInstance = new Optimizely({
+            clientEngine: 'node-sdk',
+            datafile: {
+              lasers: 300,
+              message: 'this is not a valid datafile'
+            },
+            eventBuilder: eventBuilder,
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            jsonSchemaValidator: jsonSchemaValidator,
+            logger: createdLogger,
+          });
+          var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 'user1');
+          assert.strictEqual(result, false);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Optimizely object is not valid. Failing isFeatureEnabled.');
+        });
+
+        describe('when the user bucketed into a variation of an experiment with the feature', function() {
+          var attributes = { test_attribute: 'test_value' };
+
+          describe('when the variation is toggled ON', function() {
+            beforeEach(function() {
+              var experiment = optlyInstance.configObj.experimentKeyMap.testing_my_feature;
+              var variation = experiment.variations[0];
+              sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+                experiment: experiment,
+                variation: variation,
+                decisionSource: DECISION_SOURCES.EXPERIMENT,
+              });
+            });
+
+            it('returns true and dispatches an impression event', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 'user1', attributes);
+              assert.strictEqual(result, true);
+              sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
+              var feature = optlyInstance.configObj.featureKeyMap.test_feature_for_experiment;
+              sinon.assert.calledWithExactly(
+                optlyInstance.decisionService.getVariationForFeature,
+                feature,
+                'user1',
+                attributes
+              );
+              sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+              var expectedImpressionEvent = {
+                'httpVerb': 'POST',
+                'url': 'https://logx.optimizely.com/v1/events',
+                'params': {
+                  'account_id': '572018',
+                  'project_id': '594001',
+                  'visitors': [
+                    {
+                      'snapshots': [
+                        {
+                          'decisions': [
+                            {
+                              'campaign_id': '594093',
+                              'experiment_id': '594098',
+                              'variation_id': '594096'
+                            }
+                          ],
+                          'events': [
+                            {
+                              'entity_id': '594093',
+                              'timestamp': 1509489766569,
+                              'key': 'campaign_activated',
+                              'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c'
+                            }
+                          ]
+                        }
+                      ],
+                      'visitor_id': 'user1',
+                      'attributes': [
+                        {
+                          'entity_id': '594014',
+                          'key': 'test_attribute',
+                          'type': 'custom',
+                          'value': 'test_value',
+                        }, {
+                          'entity_id': '$opt_bot_filtering',
+                          'key': '$opt_bot_filtering',
+                          'type': 'custom',
+                          'value': true,
+                        },
+                      ],
+                    }
+                  ],
+                  'revision': '35',
+                  'client_name': 'node-sdk',
+                  'client_version': enums.NODE_CLIENT_VERSION,
+                  'anonymize_ip': true
+                }
+              };
+              var callArgs = eventDispatcher.dispatchEvent.getCalls()[0].args;
+              assert.deepEqual(callArgs[0], expectedImpressionEvent);
+              assert.isFunction(callArgs[1]);
+              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature_for_experiment is enabled for user user1.');
+            });
+
+            it('returns false and does not dispatch an impression event when feature key is null', function() {
+              var result = optlyInstance.isFeatureEnabled(null, 'user1', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+            });
+
+            it('returns false when user id is null', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', null, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+            });
+
+            it('returns false when feature key and user id are null', function() {
+              var result = optlyInstance.isFeatureEnabled(null, null, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+            });
+
+            it('returns false when feature key is undefined', function() {
+              var result = optlyInstance.isFeatureEnabled(undefined, 'user1', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+            });
+
+            it('returns false when user id is undefined', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', undefined, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+            });
+
+            it('returns false when feature key and user id are undefined', function() {
+              var result = optlyInstance.isFeatureEnabled(undefined, undefined, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+            });
+
+            it('returns false when no arguments are provided', function() {
+              var result = optlyInstance.isFeatureEnabled();
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+            });
+
+            it('returns false when user id is an object', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', {}, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+            });
+
+            it('returns false when user id is a number', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 72, attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+            });
+
+            it('returns false when feature key is an array', function() {
+              var result = optlyInstance.isFeatureEnabled(['a', 'feature'], 'user1', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+            });
+
+            it('returns false when user id is an empty string', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', '', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+            });
+
+            it('returns false when feature key is an empty string', function() {
+              var result = optlyInstance.isFeatureEnabled('', 'user1', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+            });
+
+            it('returns false when a feature key is provided, but a user id is not', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment');
+              assert.strictEqual(result, false);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+            });
+          });
+
+          describe('when the variation is toggled OFF', function() {
+            var result;
+            beforeEach(function() {
+              var experiment = optlyInstance.configObj.experimentKeyMap.test_shared_feature;
+              var variation = experiment.variations[1];
+              sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+                experiment: experiment,
+                variation: variation,
+                decisionSource: DECISION_SOURCES.EXPERIMENT,
+              });
+              result = optlyInstance.isFeatureEnabled('shared_feature', 'user1', attributes);
+            });
+
+            it('should return false', function() {
+              assert.strictEqual(result, false);
+              sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
+              var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
+              sinon.assert.calledWithExactly(
+                optlyInstance.decisionService.getVariationForFeature,
+                feature,
+                'user1',
+                attributes
+              );
+            });
+
+            it('should dispatch an impression event', function() {
+              sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+              var expectedImpressionEvent = {
+                'httpVerb': 'POST',
+                'url': 'https://logx.optimizely.com/v1/events',
+                'params': {
+                  'account_id': '572018',
+                  'project_id': '594001',
+                  'visitors': [
+                    {
+                      'snapshots': [
+                        {
+                          'decisions': [
+                            {
+                              'campaign_id': '599023',
+                              'experiment_id': '599028',
+                              'variation_id': '599027'
+                            }
+                          ],
+                          'events': [
+                            {
+                              'entity_id': '599023',
+                              'timestamp': 1509489766569,
+                              'key': 'campaign_activated',
+                              'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c'
+                            }
+                          ]
+                        }
+                      ],
+                      'visitor_id': 'user1',
+                      'attributes': [
+                        {
+                          'entity_id': '594014',
+                          'key': 'test_attribute',
+                          'type': 'custom',
+                          'value': 'test_value',
+                        }, {
+                          'entity_id': '$opt_bot_filtering',
+                          'key': '$opt_bot_filtering',
+                          'type': 'custom',
+                          'value': true,
+                        },
+                      ],
+                    }
+                  ],
+                  'revision': '35',
+                  'client_name': 'node-sdk',
+                  'client_version': enums.NODE_CLIENT_VERSION,
+                  'anonymize_ip': true
+                }
+              };
+              var callArgs = eventDispatcher.dispatchEvent.getCalls()[0].args;
+              assert.deepEqual(callArgs[0], expectedImpressionEvent);
+              assert.isFunction(callArgs[1]);
+            });
+          });
+
+          describe('when the variation is missing the toggle', function() {
+            beforeEach(function() {
+              var experiment = optlyInstance.configObj.experimentKeyMap.test_shared_feature;
+              var variation = fns.cloneDeep(experiment.variations[0]);
+              delete variation['featureEnabled'];
+              sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+                experiment: experiment,
+                variation: variation,
+                decisionSource: DECISION_SOURCES.EXPERIMENT,
+              });
+            });
+
+            it('should return false', function() {
+              var result = optlyInstance.isFeatureEnabled('shared_feature', 'user1', attributes);
+              assert.strictEqual(result, false);
+              sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
+              var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
+              sinon.assert.calledWithExactly(
+                optlyInstance.decisionService.getVariationForFeature,
+                feature,
+                'user1',
+                attributes
+              );
+            });
+          });
+        });
+
+        describe('user bucketed into a variation of a rollout of the feature', function() {
+          describe('when the variation is toggled ON', function() {
+            beforeEach(function() {
+              // This experiment is the first audience targeting rule in the rollout of feature 'test_feature'
+              var experiment = optlyInstance.configObj.experimentKeyMap['594031'];
+              var variation = experiment.variations[0];
+              sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+                experiment: experiment,
+                variation: variation,
+                decisionSource: DECISION_SOURCES.ROLLOUT,
+              });
+            });
+
+            it('returns true and does not dispatch an event', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature', 'user1', {
+                test_attribute: 'test_value',
+              });
+              assert.strictEqual(result, true);
+              sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is enabled for user user1.');
+            });
+          });
+
+          describe('when the variation is toggled OFF', function() {
+            beforeEach(function() {
+              // This experiment is the second audience targeting rule in the rollout of feature 'test_feature'
+              var experiment = optlyInstance.configObj.experimentKeyMap['594037'];
+              var variation = experiment.variations[0];
+              sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+                experiment: experiment,
+                variation: variation,
+                decisionSource: DECISION_SOURCES.ROLLOUT,
+              });
+            });
+
+            it('returns false ', function() {
+              var result = optlyInstance.isFeatureEnabled('test_feature', 'user1', {
+                test_attribute: 'test_value',
+              });
+              assert.strictEqual(result, false);
+              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is not enabled for user user1.');
+            });
+          });
+        });
+
+        describe('user not bucketed into an experiment or a rollout', function() {
+          beforeEach(function() {
+            sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
+              experiment: null,
+              variation: null,
+              decisionSource: null,
+            });
+          });
+
+          it('returns false and does not dispatch an event', function() {
+            var result = optlyInstance.isFeatureEnabled('test_feature', 'user1');
+            assert.strictEqual(result, false);
+            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is not enabled for user user1.');
+          });
+        });
+      });
+
+      describe('#getEnabledFeatures', function() {
+        beforeEach(function() {
+          sandbox.stub(optlyInstance, 'isFeatureEnabled', function(featureKey) {
+            return featureKey === 'test_feature' || featureKey === 'test_feature_for_experiment';
+          });
+        });
+
+        it('returns an empty array if the instance is invalid', function() {
+          optlyInstance = new Optimizely({
+            clientEngine: 'node-sdk',
+            datafile: {
+              lasers: 300,
+              message: 'this is not a valid datafile'
+            },
+            eventBuilder: eventBuilder,
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            jsonSchemaValidator: jsonSchemaValidator,
+            logger: createdLogger,
+          });
+          var result = optlyInstance.getEnabledFeatures('user1', { test_attribute: 'test_value' });
+          assert.deepEqual(result, []);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Optimizely object is not valid. Failing getEnabledFeatures.');
+        });
+
+        it('returns only enabled features for the specified user and attributes', function() {
+          var attributes = { test_attribute: 'test_value', };
+          var result = optlyInstance.getEnabledFeatures('user1', attributes);
+          assert.strictEqual(result.length, 2);
+          assert.isAbove(result.indexOf('test_feature'), -1);
+          assert.isAbove(result.indexOf('test_feature_for_experiment'), -1);
+          sinon.assert.callCount(optlyInstance.isFeatureEnabled, 6);
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'test_feature',
+            'user1',
+            attributes
+          );
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'test_feature_2',
+            'user1',
+            attributes
+          );
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'test_feature_for_experiment',
+            'user1',
+            attributes
+          );
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'feature_with_group',
+            'user1',
+            attributes
+          );
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'shared_feature',
+            'user1',
+            attributes
+          );
+          sinon.assert.calledWithExactly(
+            optlyInstance.isFeatureEnabled,
+            'unused_flag',
+            'user1',
+            attributes
+          );
+        });
+      });
+
+      describe('feature variable APIs', function() {
+        describe('bucketed into variation in an experiment with variable values', function() {
           beforeEach(function() {
             var experiment = optlyInstance.configObj.experimentKeyMap.testing_my_feature;
             var variation = experiment.variations[0];
@@ -2581,723 +2994,618 @@ describe('lib/optimizely', function() {
             });
           });
 
-          it('returns true and dispatches an impression event', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 'user1', attributes);
+          it('returns the right value from getFeatureVariableBoolean', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1', { test_attribute: 'test_value' });
             assert.strictEqual(result, true);
-            sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
-            var feature = optlyInstance.configObj.featureKeyMap.test_feature_for_experiment;
-            sinon.assert.calledWithExactly(
-              optlyInstance.decisionService.getVariationForFeature,
-              feature,
-              'user1',
-              attributes
-            );
-            sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
-            var expectedImpressionEvent = {
-              'httpVerb': 'POST',
-              'url': 'https://logx.optimizely.com/v1/events',
-              'params': {
-                'account_id': '572018',
-                'project_id': '594001',
-                'visitors': [
-                  {
-                    'snapshots': [
-                      {
-                        'decisions': [
-                          {
-                            'campaign_id': '594093',
-                            'experiment_id': '594098',
-                            'variation_id': '594096'
-                          }
-                        ],
-                        'events': [
-                          {
-                            'entity_id': '594093',
-                            'timestamp': 1509489766569,
-                            'key': 'campaign_activated',
-                            'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c'
-                          }
-                        ]
-                      }
-                    ],
-                    'visitor_id': 'user1',
-                    'attributes': [
-                      {
-                        'entity_id': '594014',
-                        'key': 'test_attribute',
-                        'type': 'custom',
-                        'value': 'test_value',
-                      }, {
-                        'entity_id': '$opt_bot_filtering',
-                        'key': '$opt_bot_filtering',
-                        'type': 'custom',
-                        'value': true,
-                      },
-                    ],
-                  }
-                ],
-                'revision': '35',
-                'client_name': 'node-sdk',
-                'client_version': enums.NODE_CLIENT_VERSION,
-                'anonymize_ip': true
-              }
-            };
-            var callArgs = eventDispatcher.dispatchEvent.getCalls()[0].args;
-            assert.deepEqual(callArgs[0], expectedImpressionEvent);
-            assert.isFunction(callArgs[1]);
-            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature_for_experiment is enabled for user user1.');
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "is_button_animated" of feature flag "test_feature_for_experiment" is true for user "user1"');
           });
 
-          it('returns false and does not dispatch an impression event when feature key is null', function() {
-            var result = optlyInstance.isFeatureEnabled(null, 'user1', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+          it('returns the right value from getFeatureVariableDouble', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 20.25);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "button_width" of feature flag "test_feature_for_experiment" is 20.25 for user "user1"');
           });
 
-          it('returns false when user id is null', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', null, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          it('returns the right value from getFeatureVariableInteger', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 2);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "num_buttons" of feature flag "test_feature_for_experiment" is 2 for user "user1"');
           });
 
-          it('returns false when feature key and user id are null', function() {
-            var result = optlyInstance.isFeatureEnabled(null, null, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+          it('returns the right value from getFeatureVariableString', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 'Buy me NOW');
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "button_txt" of feature flag "test_feature_for_experiment" is Buy me NOW for user "user1"');
           });
 
-          it('returns false when feature key is undefined', function() {
-            var result = optlyInstance.isFeatureEnabled(undefined, 'user1', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+          it('returns null from getFeatureVariableBoolean when called with a non-boolean variable', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'button_width', 'user1');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "boolean", but variable is of type "double". Use correct API to retrieve value. Returning None.');
           });
 
-          it('returns false when user id is undefined', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', undefined, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          it('returns null from getFeatureVariableDouble when called with a non-double variable', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'is_button_animated', 'user1');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "double", but variable is of type "boolean". Use correct API to retrieve value. Returning None.');
           });
 
-          it('returns false when feature key and user id are undefined', function() {
-            var result = optlyInstance.isFeatureEnabled(undefined, undefined, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+          it('returns null from getFeatureVariableInteger when called with a non-integer variable', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'button_width', 'user1');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "integer", but variable is of type "double". Use correct API to retrieve value. Returning None.');
           });
 
-          it('returns false when no arguments are provided', function() {
-            var result = optlyInstance.isFeatureEnabled();
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+          it('returns null from getFeatureVariableString when called with a non-string variable', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'num_buttons', 'user1');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "string", but variable is of type "integer". Use correct API to retrieve value. Returning None.');
           });
 
-          it('returns false when user id is an object', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', {}, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          it('returns null from getFeatureVariableBoolean if user id is null', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', null, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
           });
 
-          it('returns false when user id is a number', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', 72, attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          it('returns null from getFeatureVariableBoolean if user id is undefined', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', undefined, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
           });
 
-          it('returns false when feature key is an array', function() {
-            var result = optlyInstance.isFeatureEnabled(['a', 'feature'], 'user1', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWithExactly(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided feature_key is in an invalid format.');
+          it('returns null from getFeatureVariableBoolean if user id is not provided', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
           });
 
-          it('returns false when user id is an empty string', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment', '', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+          it('returns null from getFeatureVariableDouble if user id is null', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', null, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
           });
 
-          it('returns false when feature key is an empty string', function() {
-            var result = optlyInstance.isFeatureEnabled('', 'user1', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+          it('returns null from getFeatureVariableDouble if user id is undefined', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', undefined, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
           });
 
-          it('returns false when a feature key is provided, but a user id is not', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature_for_experiment');
-            assert.strictEqual(result, false);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
+          it('returns null from getFeatureVariableDouble if user id is not provided', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableInteger if user id is null', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', null, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableInteger if user id is undefined', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', undefined, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableInteger if user id is not provided', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableString if user id is null', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', null, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableString if user id is undefined', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', undefined, { test_attribute: 'test_value' });
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          it('returns null from getFeatureVariableString if user id is not provided', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt');
+            assert.strictEqual(result, null);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
+          });
+
+          describe('type casting failures', function() {
+            describe('invalid boolean', function() {
+              beforeEach(function() {
+                sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('falsezzz');
+              });
+
+              it('should return null and log an error', function() {
+                var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1');
+                assert.strictEqual(result, null);
+                sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value falsezzz to type boolean, returning null.');
+              });
+            });
+
+            describe('invalid integer', function() {
+              beforeEach(function() {
+                sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('zzz123');
+              });
+
+              it('should return null and log an error', function() {
+                var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1');
+                assert.strictEqual(result, null);
+                sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value zzz123 to type integer, returning null.');
+              });
+            });
+
+            describe('invalid double', function() {
+              beforeEach(function() {
+                sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('zzz44.55');
+              });
+
+              it('should return null and log an error', function() {
+                var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1');
+                assert.strictEqual(result, null);
+                sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value zzz44.55 to type double, returning null.');
+              });
+            });
           });
         });
 
-        describe('when the variation is toggled OFF', function() {
-          var result;
+        describe('not bucketed into a variation', function() {
           beforeEach(function() {
-            var experiment = optlyInstance.configObj.experimentKeyMap.test_shared_feature;
-            var variation = experiment.variations[1];
             sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-              experiment: experiment,
-              variation: variation,
-              decisionSource: DECISION_SOURCES.EXPERIMENT,
+              experiment: null,
+              variation: null,
+              decisionSource: null,
             });
-            result = optlyInstance.isFeatureEnabled('shared_feature', 'user1', attributes);
           });
 
-          it('should return false', function() {
+          it('returns the variable default value from getFeatureVariableBoolean', function() {
+            var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1', { test_attribute: 'test_value' });
             assert.strictEqual(result, false);
-            sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
-            var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
-            sinon.assert.calledWithExactly(
-              optlyInstance.decisionService.getVariationForFeature,
-              feature,
-              'user1',
-              attributes
-            );
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "is_button_animated" of feature flag "test_feature_for_experiment".');
           });
 
-          it('should dispatch an impression event', function() {
-            sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
-            var expectedImpressionEvent = {
-              'httpVerb': 'POST',
-              'url': 'https://logx.optimizely.com/v1/events',
-              'params': {
-                'account_id': '572018',
-                'project_id': '594001',
-                'visitors': [
-                  {
-                    'snapshots': [
-                      {
-                        'decisions': [
-                          {
-                            'campaign_id': '599023',
-                            'experiment_id': '599028',
-                            'variation_id': '599027'
-                          }
-                        ],
-                        'events': [
-                          {
-                            'entity_id': '599023',
-                            'timestamp': 1509489766569,
-                            'key': 'campaign_activated',
-                            'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c'
-                          }
-                        ]
-                      }
-                    ],
-                    'visitor_id': 'user1',
-                    'attributes': [
-                      {
-                        'entity_id': '594014',
-                        'key': 'test_attribute',
-                        'type': 'custom',
-                        'value': 'test_value',
-                      }, {
-                        'entity_id': '$opt_bot_filtering',
-                        'key': '$opt_bot_filtering',
-                        'type': 'custom',
-                        'value': true,
-                      },
-                    ],
-                  }
-                ],
-                'revision': '35',
-                'client_name': 'node-sdk',
-                'client_version': enums.NODE_CLIENT_VERSION,
-                'anonymize_ip': true
-              }
-            };
-            var callArgs = eventDispatcher.dispatchEvent.getCalls()[0].args;
-            assert.deepEqual(callArgs[0], expectedImpressionEvent);
-            assert.isFunction(callArgs[1]);
+          it('returns the variable default value from getFeatureVariableDouble', function() {
+            var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 50.55);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "button_width" of feature flag "test_feature_for_experiment".');
+          });
+
+          it('returns the variable default value from getFeatureVariableInteger', function() {
+            var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 10);
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "num_buttons" of feature flag "test_feature_for_experiment".');
+          });
+
+          it('returns the variable default value from getFeatureVariableString', function() {
+            var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', 'user1', { test_attribute: 'test_value' });
+            assert.strictEqual(result, 'Buy me');
+            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "button_txt" of feature flag "test_feature_for_experiment".');
           });
         });
 
-        describe('when the variation is missing the toggle', function() {
-          beforeEach(function() {
-            var experiment = optlyInstance.configObj.experimentKeyMap.test_shared_feature;
-            var variation = fns.cloneDeep(experiment.variations[0]);
-            delete variation['featureEnabled'];
-            sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-              experiment: experiment,
-              variation: variation,
-              decisionSource: DECISION_SOURCES.EXPERIMENT,
-            });
+        it('returns null from getFeatureVariableBoolean if the argument feature key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableBoolean('thisIsNotAValidKey<><><>', 'is_button_animated', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableDouble if the argument feature key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableDouble('thisIsNotAValidKey<><><>', 'button_width', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableInteger if the argument feature key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableInteger('thisIsNotAValidKey<><><>', 'num_buttons', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableString if the argument feature key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableString('thisIsNotAValidKey<><><>', 'button_txt', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableBoolean if the argument variable key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableDouble if the argument variable key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableInteger if the argument variable key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableString if the argument variable key is invalid', function() {
+          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+          assert.strictEqual(result, null);
+          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
+        });
+
+        it('returns null from getFeatureVariableBoolean when optimizely object is not a valid instance', function() {
+          var instance = new Optimizely({
+            datafile: {},
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            logger: createdLogger,
           });
 
-          it('should return false', function() {
-            var result = optlyInstance.isFeatureEnabled('shared_feature', 'user1', attributes);
-            assert.strictEqual(result, false);
-            sinon.assert.calledOnce(optlyInstance.decisionService.getVariationForFeature);
-            var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
-            sinon.assert.calledWithExactly(
-              optlyInstance.decisionService.getVariationForFeature,
-              feature,
-              'user1',
-              attributes
-            );
+          createdLogger.log.reset();
+
+          instance.getFeatureVariableBoolean('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+
+          sinon.assert.calledOnce(createdLogger.log);
+          var logMessage = createdLogger.log.args[0][1];
+          assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableBoolean'));
+        });
+
+        it('returns null from getFeatureVariableDouble when optimizely object is not a valid instance', function() {
+          var instance = new Optimizely({
+            datafile: {},
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            logger: createdLogger,
           });
+
+          createdLogger.log.reset();
+
+          instance.getFeatureVariableDouble('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+
+          sinon.assert.calledOnce(createdLogger.log);
+          var logMessage = createdLogger.log.args[0][1];
+          assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableDouble'));
+        });
+
+        it('returns null from getFeatureVariableInteger when optimizely object is not a valid instance', function() {
+          var instance = new Optimizely({
+            datafile: {},
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            logger: createdLogger,
+          });
+
+          createdLogger.log.reset();
+
+          instance.getFeatureVariableInteger('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+
+          sinon.assert.calledOnce(createdLogger.log);
+          var logMessage = createdLogger.log.args[0][1];
+          assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableInteger'));
+        });
+
+        it('returns null from getFeatureVariableString when optimizely object is not a valid instance', function() {
+          var instance = new Optimizely({
+            datafile: {},
+            errorHandler: errorHandler,
+            eventDispatcher: eventDispatcher,
+            logger: createdLogger,
+          });
+
+          createdLogger.log.reset();
+
+          instance.getFeatureVariableString('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+
+          sinon.assert.calledOnce(createdLogger.log);
+          var logMessage = createdLogger.log.args[0][1];
+          assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableString'));
         });
       });
 
-      describe('user bucketed into a variation of a rollout of the feature', function() {
-        describe('when the variation is toggled ON', function() {
-          beforeEach(function() {
-            // This experiment is the first audience targeting rule in the rollout of feature 'test_feature'
-            var experiment = optlyInstance.configObj.experimentKeyMap['594031'];
-            var variation = experiment.variations[0];
-            sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-              experiment: experiment,
-              variation: variation,
-              decisionSource: DECISION_SOURCES.ROLLOUT,
-            });
+      describe('audience match types', function() {
+        it('can activate and track an experiment with an exact match string audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            house: 'Gryffindor',
           });
-
-          it('returns true and does not dispatch an event', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature', 'user1', {
-              test_attribute: 'test_value',
-            });
-            assert.strictEqual(result, true);
-            sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is enabled for user user1.');
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Gryffindor' }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            house: 'Gryffindor',
           });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Gryffindor' }]
+          );
         });
 
-        describe('when the variation is toggled OFF', function() {
-          beforeEach(function() {
-            // This experiment is the second audience targeting rule in the rollout of feature 'test_feature'
-            var experiment = optlyInstance.configObj.experimentKeyMap['594037'];
-            var variation = experiment.variations[0];
-            sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-              experiment: experiment,
-              variation: variation,
-              decisionSource: DECISION_SOURCES.ROLLOUT,
-            });
+        it('can activate and track an experiment with a substring match string audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            house: 'Welcome to House Slytherin, yall!',
           });
-
-          it('returns false ', function() {
-            var result = optlyInstance.isFeatureEnabled('test_feature', 'user1', {
-              test_attribute: 'test_value',
-            });
-            assert.strictEqual(result, false);
-            sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is not enabled for user user1.');
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Welcome to House Slytherin, yall!' }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            house: 'Welcome to House Slytherin, yall!',
           });
-        });
-      });
-
-      describe('user not bucketed into an experiment or a rollout', function() {
-        beforeEach(function() {
-          sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-            experiment: null,
-            variation: null,
-            decisionSource: null,
-          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Welcome to House Slytherin, yall!' }]
+          );
         });
 
-        it('returns false and does not dispatch an event', function() {
-          var result = optlyInstance.isFeatureEnabled('test_feature', 'user1');
-          assert.strictEqual(result, false);
-          sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Feature test_feature is not enabled for user user1.');
+        it('can activate and track an experiment with an exists audience', function() {
+          var variationKey = optlyInstance.activate('string_exists_audience_experiment', 'user1', {
+            house: 'Ravenclaw',
+          });
+          assert.strictEqual(variationKey, 'B');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Ravenclaw' }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            house: 'Ravenclaw',
+          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594015', key: 'house', type: 'custom', value: 'Ravenclaw' }]
+          );
+        });
+
+        it('can activate and track an experiment with an exact number audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            lasers: 45.5,
+          });
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: 45.5 }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            lasers: 45.5,
+          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: 45.5 }]
+          );
+        });
+
+        it('can activate and track an experiment with a greater than number audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            lasers: 71,
+          });
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: 71 }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            lasers: 71,
+          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: 71 }]
+          );
+        });
+
+        it('can activate and track an experiment with a less than number audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            lasers: -3.45,
+          });
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: -3.45 }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            lasers: -3.45,
+          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594016', key: 'lasers', type: 'custom', value: -3.45 }]
+          );
+        });
+
+        it('can activate and track an experiment with an exact boolean audience', function() {
+          var variationKey = optlyInstance.activate('typed_audience_experiment', 'user1', {
+            should_do_it: true,
+          });
+          assert.strictEqual(variationKey, 'A');
+          sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(0).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594017', key: 'should_do_it', type: 'custom', value: true }]
+          );
+          optlyInstance.track('item_bought', 'user1', {
+            should_do_it: true,
+          });
+          sinon.assert.calledTwice(eventDispatcher.dispatchEvent);
+          assert.includeDeepMembers(
+            eventDispatcher.dispatchEvent.getCall(1).args[0].params.visitors[0].attributes,
+            [{ entity_id: '594017', key: 'should_do_it', type: 'custom', value: true }]
+          );
         });
       });
     });
 
-    describe('#getEnabledFeatures', function() {
+    describe('using featuresWithTypedAudiencesConfig', function() {
       beforeEach(function() {
-        sandbox.stub(optlyInstance, 'isFeatureEnabled', function(featureKey) {
-          return featureKey === 'test_feature' || featureKey === 'test_feature_for_experiment';
-        });
-      });
-
-      it('returns an empty array if the instance is invalid', function() {
         optlyInstance = new Optimizely({
           clientEngine: 'node-sdk',
-          datafile: {
-            lasers: 300,
-            message: 'this is not a valid datafile'
-          },
+          datafile: testData.getFeaturesWithTypedAudiencesConfig(),
           eventBuilder: eventBuilder,
           errorHandler: errorHandler,
           eventDispatcher: eventDispatcher,
           jsonSchemaValidator: jsonSchemaValidator,
           logger: createdLogger,
-        });
-        var result = optlyInstance.getEnabledFeatures('user1', { test_attribute: 'test_value' });
-        assert.deepEqual(result, []);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Optimizely object is not valid. Failing getEnabledFeatures.');
-      });
-
-      it('returns only enabled features for the specified user and attributes', function() {
-        var attributes = { test_attribute: 'test_value', };
-        var result = optlyInstance.getEnabledFeatures('user1', attributes);
-        assert.strictEqual(result.length, 2);
-        assert.isAbove(result.indexOf('test_feature'), -1);
-        assert.isAbove(result.indexOf('test_feature_for_experiment'), -1);
-        sinon.assert.callCount(optlyInstance.isFeatureEnabled, 6);
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'test_feature',
-          'user1',
-          attributes
-        );
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'test_feature_2',
-          'user1',
-          attributes
-        );
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'test_feature_for_experiment',
-          'user1',
-          attributes
-        );
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'feature_with_group',
-          'user1',
-          attributes
-        );
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'shared_feature',
-          'user1',
-          attributes
-        );
-        sinon.assert.calledWithExactly(
-          optlyInstance.isFeatureEnabled,
-          'unused_flag',
-          'user1',
-          attributes
-        );
-      });
-    });
-
-    describe('feature variable APIs', function() {
-      describe('bucketed into variation in an experiment with variable values', function() {
-        beforeEach(function() {
-          var experiment = optlyInstance.configObj.experimentKeyMap.testing_my_feature;
-          var variation = experiment.variations[0];
-          sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-            experiment: experiment,
-            variation: variation,
-            decisionSource: DECISION_SOURCES.EXPERIMENT,
-          });
-        });
-
-        it('returns the right value from getFeatureVariableBoolean', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, true);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "is_button_animated" of feature flag "test_feature_for_experiment" is true for user "user1"');
-        });
-
-        it('returns the right value from getFeatureVariableDouble', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 20.25);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "button_width" of feature flag "test_feature_for_experiment" is 20.25 for user "user1"');
-        });
-
-        it('returns the right value from getFeatureVariableInteger', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 2);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "num_buttons" of feature flag "test_feature_for_experiment" is 2 for user "user1"');
-        });
-
-        it('returns the right value from getFeatureVariableString', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 'Buy me NOW');
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: Value for variable "button_txt" of feature flag "test_feature_for_experiment" is Buy me NOW for user "user1"');
-        });
-
-        it('returns null from getFeatureVariableBoolean when called with a non-boolean variable', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'button_width', 'user1');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "boolean", but variable is of type "double". Use correct API to retrieve value. Returning None.');
-        });
-
-        it('returns null from getFeatureVariableDouble when called with a non-double variable', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'is_button_animated', 'user1');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "double", but variable is of type "boolean". Use correct API to retrieve value. Returning None.');
-        });
-
-        it('returns null from getFeatureVariableInteger when called with a non-integer variable', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'button_width', 'user1');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "integer", but variable is of type "double". Use correct API to retrieve value. Returning None.');
-        });
-
-        it('returns null from getFeatureVariableString when called with a non-string variable', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'num_buttons', 'user1');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.WARNING, 'OPTIMIZELY: Requested variable type "string", but variable is of type "integer". Use correct API to retrieve value. Returning None.');
-        });
-
-        it('returns null from getFeatureVariableBoolean if user id is null', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', null, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableBoolean if user id is undefined', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', undefined, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableBoolean if user id is not provided', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableDouble if user id is null', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', null, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableDouble if user id is undefined', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', undefined, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableDouble if user id is not provided', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableInteger if user id is null', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', null, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableInteger if user id is undefined', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', undefined, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableInteger if user id is not provided', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableString if user id is null', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', null, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableString if user id is undefined', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', undefined, { test_attribute: 'test_value' });
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        it('returns null from getFeatureVariableString if user id is not provided', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt');
-          assert.strictEqual(result, null);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'OPTIMIZELY: Provided user_id is in an invalid format.');
-        });
-
-        describe('type casting failures', function() {
-          describe('invalid boolean', function() {
-            beforeEach(function() {
-              sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('falsezzz');
-            });
-
-            it('should return null and log an error', function() {
-              var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1');
-              assert.strictEqual(result, null);
-              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value falsezzz to type boolean, returning null.');
-            });
-          });
-
-          describe('invalid integer', function() {
-            beforeEach(function() {
-              sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('zzz123');
-            });
-
-            it('should return null and log an error', function() {
-              var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1');
-              assert.strictEqual(result, null);
-              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value zzz123 to type integer, returning null.');
-            });
-          });
-
-          describe('invalid double', function() {
-            beforeEach(function() {
-              sandbox.stub(projectConfig, 'getVariableValueForVariation').returns('zzz44.55');
-            });
-
-            it('should return null and log an error', function() {
-              var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1');
-              assert.strictEqual(result, null);
-              sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Unable to cast value zzz44.55 to type double, returning null.');
-            });
-          });
+          isValidInstance: true,
         });
       });
 
-      describe('not bucketed into a variation', function() {
-        beforeEach(function() {
-          sandbox.stub(optlyInstance.decisionService, 'getVariationForFeature').returns({
-            experiment: null,
-            variation: null,
-            decisionSource: null,
-          });
+      it('can enable a feature through a rollout with an exact match string audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          house: 'Gryffindor',
         });
+        assert.strictEqual(featureEnabled, true);
+      });
 
-        it('returns the variable default value from getFeatureVariableBoolean', function() {
-          var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'is_button_animated', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, false);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "is_button_animated" of feature flag "test_feature_for_experiment".');
+      it('can enable a feature through a feature test with an exact match string audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          house: 'Gryffindor',
         });
+        assert.strictEqual(featureEnabled, true);
+      });
 
-        it('returns the variable default value from getFeatureVariableDouble', function() {
-          var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'button_width', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 50.55);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "button_width" of feature flag "test_feature_for_experiment".');
+      it('can access a feature variable through a feature test with an exact match string audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          house: 'Gryffindor',
         });
+        assert.strictEqual(variableValue, 'xyz');
+      });
 
-        it('returns the variable default value from getFeatureVariableInteger', function() {
-          var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'num_buttons', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 10);
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "num_buttons" of feature flag "test_feature_for_experiment".');
+      it('can enable a feature through a rollout with a substring match string audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          house: 'Welcome to House Slytherin, yall!',
         });
+        assert.strictEqual(featureEnabled, true);
+      });
 
-        it('returns the variable default value from getFeatureVariableString', function() {
-          var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'button_txt', 'user1', { test_attribute: 'test_value' });
-          assert.strictEqual(result, 'Buy me');
-          sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, 'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "button_txt" of feature flag "test_feature_for_experiment".');
+      it('can enable a feature through a feature test with a substring match string audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          house: 'Welcome to House Slytherin, yall!',
         });
+        assert.strictEqual(featureEnabled, true);
       });
 
-      it('returns null from getFeatureVariableBoolean if the argument feature key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableBoolean('thisIsNotAValidKey<><><>', 'is_button_animated', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableDouble if the argument feature key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableDouble('thisIsNotAValidKey<><><>', 'button_width', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableInteger if the argument feature key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableInteger('thisIsNotAValidKey<><><>', 'num_buttons', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableString if the argument feature key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableString('thisIsNotAValidKey<><><>', 'button_txt', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Feature key thisIsNotAValidKey<><><> is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableBoolean if the argument variable key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableBoolean('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableDouble if the argument variable key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableDouble('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableInteger if the argument variable key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableInteger('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableString if the argument variable key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableString('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-        assert.strictEqual(result, null);
-        sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.ERROR, 'PROJECT_CONFIG: Variable with key "thisIsNotAVariableKey****" associated with feature with key "test_feature_for_experiment" is not in datafile.');
-      });
-
-      it('returns null from getFeatureVariableBoolean when optimizely object is not a valid instance', function() {
-        var instance = new Optimizely({
-          datafile: {},
-          errorHandler: errorHandler,
-          eventDispatcher: eventDispatcher,
-          logger: createdLogger,
+      it('can access a feature variable through a feature test with a substring match string audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          house: 'Welcome to House Slytherin, yall!',
         });
-
-        createdLogger.log.reset();
-
-        instance.getFeatureVariableBoolean('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-
-        sinon.assert.calledOnce(createdLogger.log);
-        var logMessage = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableBoolean'));
+        assert.strictEqual(variableValue, 'xyz');
       });
 
-      it('returns null from getFeatureVariableDouble when optimizely object is not a valid instance', function() {
-        var instance = new Optimizely({
-          datafile: {},
-          errorHandler: errorHandler,
-          eventDispatcher: eventDispatcher,
-          logger: createdLogger,
+      it('can enable a feature through a rollout with an exists audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          favorite_ice_cream: 'chocolate',
         });
-
-        createdLogger.log.reset();
-
-        instance.getFeatureVariableDouble('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-
-        sinon.assert.calledOnce(createdLogger.log);
-        var logMessage = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableDouble'));
+        assert.strictEqual(featureEnabled, true);
       });
 
-      it('returns null from getFeatureVariableInteger when optimizely object is not a valid instance', function() {
-        var instance = new Optimizely({
-          datafile: {},
-          errorHandler: errorHandler,
-          eventDispatcher: eventDispatcher,
-          logger: createdLogger,
+      it('can enable a feature through a feature test with an exists audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          favorite_ice_cream: 'chocolate',
         });
-
-        createdLogger.log.reset();
-
-        instance.getFeatureVariableInteger('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
-
-        sinon.assert.calledOnce(createdLogger.log);
-        var logMessage = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableInteger'));
+        assert.strictEqual(featureEnabled, true);
       });
 
-      it('returns null from getFeatureVariableString when optimizely object is not a valid instance', function() {
-        var instance = new Optimizely({
-          datafile: {},
-          errorHandler: errorHandler,
-          eventDispatcher: eventDispatcher,
-          logger: createdLogger,
+      it('can access a feature variable through a feature test with an exists audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          favorite_ice_cream: 'chocolate',
         });
+        assert.strictEqual(variableValue, 'xyz');
+      });
 
-        createdLogger.log.reset();
+      it('can enable a feature through a rollout with an exact number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          lasers: 45.5,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
 
-        instance.getFeatureVariableString('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+      it('can enable a feature through a feature test with an exact number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          lasers: 45.5,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
 
-        sinon.assert.calledOnce(createdLogger.log);
-        var logMessage = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableString'));
+      it('can access a feature variable through a feature test with an exact number audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          lasers: 45.5,
+        });
+        assert.strictEqual(variableValue, 'xyz');
+      });
+
+      it('can enable a feature through a rollout with a greater than number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          lasers: 71,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can enable a feature through a feature test with a greater than number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          lasers: 71,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can access a feature variable through a feature test with a greater than number audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          lasers: 71,
+        });
+        assert.strictEqual(variableValue, 'xyz');
+      });
+
+      it('can enable a feature through a rollout with a less than number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          lasers: -3.45,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can enable a feature through a feature test with a less than number audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          lasers: -3.45,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can access a feature variable through a feature test with a less than number audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          lasers: -3.45,
+        });
+        assert.strictEqual(variableValue, 'xyz');
+      });
+
+      it('can enable a feature through a rollout with an exact boolean audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat', 'user1', {
+          should_do_it: true,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can enable a feature through a feature test with an exact boolean audience', function() {
+        var featureEnabled = optlyInstance.isFeatureEnabled('feat_with_var', 'user1', {
+          should_do_it: true,
+        });
+        assert.strictEqual(featureEnabled, true);
+      });
+
+      it('can access a feature variable through a feature test with a less than number audience', function() {
+        var variableValue = optlyInstance.getFeatureVariableString('feat_with_var', 'x', 'user1', {
+          should_do_it: true,
+        });
+        assert.strictEqual(variableValue, 'xyz');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -277,7 +277,8 @@ var configWithFeatures = {
         '594098',
         '595010',
         '599028',
-        '599082'
+        '599082',
+        '1323241597'
       ]
     }
   ],
@@ -537,6 +538,57 @@ var configWithFeatures = {
       'status': 'Running',
       'key': 'test_shared_feature',
       'id': '599028'
+    },
+    {
+      'id': '1323241597',
+      'key': 'typed_audience_experiment',
+      'layerId': '1630555627',
+      'status': 'Running',
+      'variations': [
+        {
+          'id': '1423767503',
+          'key': 'A',
+          'variables': []
+        }
+      ],
+      'trafficAllocation': [
+        {
+          'entityId': '1423767503',
+          'endOfRange': 10000
+        }
+      ],
+      'audienceIds': ['3468206642', '3988293898', '3468206646', '3468206647', '3468206644', '3468206643'],
+      'forcedVariations': {}
+    },
+    {
+      'id': '1323241598',
+      'key': 'string_exists_audience_experiment',
+      'layerId': '1630555628',
+      'status': 'Running',
+      'variations': [
+        {
+          'id': '1023767503',
+          'key': 'A',
+          'variables': []
+        },
+        {
+          'id': '3033458315',
+          'key': 'B',
+          'variables': []
+        }
+      ],
+      'trafficAllocation': [
+        {
+          'entityId': '1023767503',
+          'endOfRange': 5000
+        },
+        {
+          'entityId': '3033458315',
+          'endOfRange': 10000
+        }
+      ],
+      'audienceIds': ['3988293899', '3468206646'],
+      'forcedVariations': {}
     }
   ],
   'anonymizeIP': true,
@@ -546,6 +598,73 @@ var configWithFeatures = {
       'id': '594017',
       'name': 'test_audience',
       'conditions': '["and", ["or", ["or", {"type": "custom_attribute", "name": "test_attribute", "value": "test_value"}]]]'
+    },
+    {
+      'id': '3468206642',
+      'name': 'exactString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
+    },
+    {
+      'id': '3988293898',
+      'name': '$$dummySubstringString',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3988293899',
+      'name': '$$dummyExists',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206646',
+      'name': '$$dummyExactNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206647',
+      'name': '$$dummyGtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206644',
+      'name': '$$dummyLtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206643',
+      'name': '$$dummyExactBoolean',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    }
+  ],
+  'typedAudiences': [
+    {
+      'id': '3988293898',
+      'name': 'substringString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+    },
+    {
+      'id': '3988293899',
+      'name': 'exists',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"exists"}]]]'
+    },
+    {
+      'id': '3468206646',
+      'name': 'exactNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
+    },
+    {
+      'id': '3468206647',
+      'name': 'gtNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
+    },
+    {
+      'id': '3468206644',
+      'name': 'ltNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
+    },
+    {
+      'id': '3468206643',
+      'name': 'exactBoolean',
+      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
     }
   ],
   'revision': '35',
@@ -631,6 +750,18 @@ var configWithFeatures = {
     {
       'key': 'test_attribute',
       'id': '594014'
+    },
+    {
+      'key': 'house',
+      'id': '594015'
+    },
+    {
+      'key': 'lasers',
+      'id': '594016'
+    },
+    {
+      'key': 'should_do_it',
+      'id': '594017'
     }
   ],
   'rollouts': [
@@ -846,6 +977,40 @@ var configWithFeatures = {
   'version': '4',
   'variables': []
 };
+
+var parsedTypedAudiences = [
+  {
+    'id': '3468206642',
+    'name': 'exactString',
+    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'value': 'Gryffindor'}]]]
+  },
+  {
+    'id': '3988293898',
+    'name': 'substringString',
+    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'match': 'substring', 'value': 'Slytherin'}]]]
+  },
+  {
+    'id': '3468206646',
+    'name': 'exactNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'exact', 'value': 45.5}]]]
+  },
+  {
+    'id': '3468206647',
+    'name': 'gtNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'gt', 'value': 70 }]]]
+  },
+  {
+    'id': '3468206644',
+    'name': 'ltNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'lt', 'value': 1.0 }]]]
+  },
+  {
+    'id': '3468206643',
+    'name': 'exactBoolean',
+    'conditions': ['and', ['or', ['or', {'name': 'should_do_it', 'type': 'custom_attribute', 'match': 'exact', 'value': true}]]]
+  }
+];
+
 
 var getTestProjectConfigWithFeatures = function() {
   return cloneDeep(configWithFeatures);
@@ -1321,6 +1486,9 @@ var datafileWithFeaturesExpectedData = {
     },
     599080: {},
     599081: {},
+    1423767503: {},
+    1023767503: {},
+    3033458315: {},
   },
 
   featureKeyMap: {
@@ -1776,10 +1944,226 @@ var getUnsupportedVersionConfig = function() {
   return cloneDeep(unsupportedVersionConfig);
 };
 
+var featuresWithTypedAudiencesConfig = {
+  'version': '4',
+  'rollouts': [
+    {
+      'experiments': [
+        {
+          'status': 'Running',
+          'key': '11488548027',
+          'layerId': '11551226731',
+          'trafficAllocation': [
+            {
+              'entityId': '11557362669',
+              'endOfRange': 10000
+            }
+          ],
+          'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
+          'variations': [
+            {
+              'variables': [],
+              'id': '11557362669',
+              'key': '11557362669',
+              'featureEnabled': true
+            }
+          ],
+          'forcedVariations': {},
+          'id': '11488548027'
+        }
+      ],
+      'id': '11551226731'
+    },
+    {
+      'experiments': [
+        {
+          'status': 'Paused',
+          'key': '11630490911',
+          'layerId': '11638870867',
+          'trafficAllocation': [
+            {
+              'entityId': '11475708558',
+              'endOfRange': 0
+            }
+          ],
+          'audienceIds': [],
+          'variations': [
+            {
+              'variables': [],
+              'id': '11475708558',
+              'key': '11475708558',
+              'featureEnabled': false
+            }
+          ],
+          'forcedVariations': {},
+          'id': '11630490911'
+        }
+      ],
+      'id': '11638870867'
+    }
+  ],
+  'anonymizeIP': false,
+  'projectId': '11624721371',
+  'variables': [],
+  'featureFlags': [
+    {
+      'experimentIds': [],
+      'rolloutId': '11551226731',
+      'variables': [],
+      'id': '11477755619',
+      'key': 'feat'
+    },
+    {
+      'experimentIds': [
+        '11564051718'
+      ],
+      'rolloutId': '11638870867',
+      'variables': [
+        {
+          'defaultValue': 'x',
+          'type': 'string',
+          'id': '11535264366',
+          'key': 'x'
+        }
+      ],
+      'id': '11567102051',
+      'key': 'feat_with_var'
+    }
+  ],
+  'experiments': [
+    {
+      'status': 'Running',
+      'key': 'feat_with_var_test',
+      'layerId': '11504144555',
+      'trafficAllocation': [
+        {
+          'entityId': '11617170975',
+          'endOfRange': 10000
+        }
+      ],
+      'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
+      'variations': [
+        {
+          'variables': [
+            {
+              'id': '11535264366',
+              'value': 'xyz'
+            }
+          ],
+          'id': '11617170975',
+          'key': 'variation_2',
+          'featureEnabled': true
+        }
+      ],
+      'forcedVariations': {},
+      'id': '11564051718'
+    }
+  ],
+  'audiences': [
+    {
+      'id': '3468206642',
+      'name': 'exactString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
+    },
+    {
+      'id': '3988293898',
+      'name': '$$dummySubstringString',
+      'conditions': '["and", ["or"]]',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3988293899',
+      'name': '$$dummyExists',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206646',
+      'name': '$$dummyExactNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206647',
+      'name': '$$dummyGtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206644',
+      'name': '$$dummyLtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206643',
+      'name': '$$dummyExactBoolean',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    }
+  ],
+  'typedAudiences': [
+    {
+      'id': '3988293898',
+      'name': 'substringString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+    },
+    {
+      'id': '3988293899',
+      'name': 'exists',
+      'conditions': '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute", "match":"exists"}]]]'
+    },
+    {
+      'id': '3468206646',
+      'name': 'exactNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
+    },
+    {
+      'id': '3468206647',
+      'name': 'gtNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
+    },
+    {
+      'id': '3468206644',
+      'name': 'ltNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
+    },
+    {
+      'id': '3468206643',
+      'name': 'exactBoolean',
+      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
+    }
+  ],
+  'groups': [],
+  'attributes': [
+    {
+      'key': 'house',
+      'id': '594015'
+    },
+    {
+      'key': 'lasers',
+      'id': '594016'
+    },
+    {
+      'key': 'should_do_it',
+      'id': '594017'
+    },
+    {
+      'key': 'favorite_ice_cream',
+      'id': '594018'
+    }
+  ],
+  'botFiltering': false,
+  'accountId': '4879520872',
+  'events': [],
+  'revision': '3'
+};
+
+var getFeaturesWithTypedAudiencesConfig = function() {
+  return featuresWithTypedAudiencesConfig;
+};
+
 module.exports = {
   getTestProjectConfig: getTestProjectConfig,
   getParsedAudiences: getParsedAudiences,
   getTestProjectConfigWithFeatures: getTestProjectConfigWithFeatures,
   datafileWithFeaturesExpectedData: datafileWithFeaturesExpectedData,
   getUnsupportedVersionConfig: getUnsupportedVersionConfig,
+  parsedTypedAudiences: parsedTypedAudiences,
+  getFeaturesWithTypedAudiencesConfig: getFeaturesWithTypedAudiencesConfig,
 };

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -1776,10 +1776,264 @@ var getUnsupportedVersionConfig = function() {
   return cloneDeep(unsupportedVersionConfig);
 };
 
+var typedAudiencesConfig = {
+  'version': '4',
+  'rollouts': [
+    {
+      'experiments': [
+        {
+          'status': 'Running',
+          'key': '11488548027',
+          'layerId': '11551226731',
+          'trafficAllocation': [
+            {
+              'entityId': '11557362669',
+              'endOfRange': 10000
+            }
+          ],
+          'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
+          'variations': [
+            {
+              'variables': [],
+              'id': '11557362669',
+              'key': '11557362669',
+              'featureEnabled': true
+            }
+          ],
+          'forcedVariations': {},
+          'id': '11488548027'
+        }
+      ],
+      'id': '11551226731'
+    },
+    {
+      'experiments': [
+        {
+          'status': 'Paused',
+          'key': '11630490911',
+          'layerId': '11638870867',
+          'trafficAllocation': [
+            {
+              'entityId': '11475708558',
+              'endOfRange': 0
+            }
+          ],
+          'audienceIds': [],
+          'variations': [
+            {
+              'variables': [],
+              'id': '11475708558',
+              'key': '11475708558',
+              'featureEnabled': false
+            }
+          ],
+          'forcedVariations': {},
+          'id': '11630490911'
+        }
+      ],
+      'id': '11638870867'
+    }
+  ],
+  'anonymizeIP': false,
+  'projectId': '11624721371',
+  'variables': [],
+  'featureFlags': [
+    {
+      'experimentIds': [],
+      'rolloutId': '11551226731',
+      'variables': [],
+      'id': '11477755619',
+      'key': 'feat'
+    },
+    {
+      'experimentIds': [
+        '11564051718'
+      ],
+      'rolloutId': '11638870867',
+      'variables': [
+        {
+          'defaultValue': 'x',
+          'type': 'string',
+          'id': '11535264366',
+          'key': 'x'
+        }
+      ],
+      'id': '11567102051',
+      'key': 'feat_with_var'
+    }
+  ],
+  'experiments': [
+    {
+      'status': 'Running',
+      'key': 'feat_with_var_test',
+      'layerId': '11504144555',
+      'trafficAllocation': [
+        {
+          'entityId': '11617170975',
+          'endOfRange': 10000
+        }
+      ],
+      'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
+      'variations': [
+        {
+          'variables': [
+            {
+              'id': '11535264366',
+              'value': 'xyz'
+            }
+          ],
+          'id': '11617170975',
+          'key': 'variation_2',
+          'featureEnabled': true
+        }
+      ],
+      'forcedVariations': {},
+      'id': '11564051718'
+    }
+  ],
+  'audiences': [
+    {
+      'id': '3468206642',
+      'name': 'exactString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
+    },
+    {
+      'id': '3988293898',
+      'name': '$$dummySubstringString',
+      'conditions': '["and", ["or"]]',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3988293899',
+      'name': '$$dummyExists',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206646',
+      'name': '$$dummyExactNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206647',
+      'name': '$$dummyGtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206644',
+      'name': '$$dummyLtNumber',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    },
+    {
+      'id': '3468206643',
+      'name': '$$dummyExactBoolean',
+      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+    }
+  ],
+  'typedAudiences': [
+    {
+      'id': '3988293898',
+      'name': 'substringString',
+      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+    },
+    {
+      'id': '3988293899',
+      'name': 'exists',
+      'conditions': '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute", "match":"exists"}]]]'
+    },
+    {
+      'id': '3468206646',
+      'name': 'exactNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
+    },
+    {
+      'id': '3468206647',
+      'name': 'gtNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
+    },
+    {
+      'id': '3468206644',
+      'name': 'ltNumber',
+      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
+    },
+    {
+      'id': '3468206643',
+      'name': 'exactBoolean',
+      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
+    }
+  ],
+  'groups': [],
+  'attributes': [
+    {
+      'key': 'house',
+      'id': '594015'
+    },
+    {
+      'key': 'lasers',
+      'id': '594016'
+    },
+    {
+      'key': 'should_do_it',
+      'id': '594017'
+    },
+    {
+      'key': 'favorite_ice_cream',
+      'id': '594018'
+    }
+  ],
+  'botFiltering': false,
+  'accountId': '4879520872',
+  'events': [],
+  'revision': '3'
+};
+
+var getTypedAudiencesConfig = function() {
+  return cloneDeep(typedAudiencesConfig);
+};
+
+var parsedTypedAudiences = [
+  {
+    'id': '3468206642',
+    'name': 'exactString',
+    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'value': 'Gryffindor'}]]]
+  },
+  {
+    'id': '3988293898',
+    'name': 'substringString',
+    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'match': 'substring', 'value': 'Slytherin'}]]],
+  },
+  {
+    'id': '3988293899',
+    'name': 'exists',
+    'conditions': ['and', ['or', ['or', {'name': 'favorite_ice_cream', 'type': 'custom_attribute', 'match': 'exists'}]]],
+  },
+  {
+    'id': '3468206646',
+    'name': 'exactNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'exact', 'value': 45.5}]]]
+  },
+  {
+    'id': '3468206647',
+    'name': 'gtNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'gt', 'value': 70}]]]
+  },
+  {
+    'id': '3468206644',
+    'name': 'ltNumber',
+    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'lt', 'value': 1.0}]]]
+  },
+  {
+    'id': '3468206643',
+    'name': 'exactBoolean',
+    'conditions': ['and', ['or', ['or', {'name': 'should_do_it', 'type': 'custom_attribute', 'match': 'exact', 'value': true}]]]
+  },
+];
+
 module.exports = {
   getTestProjectConfig: getTestProjectConfig,
   getParsedAudiences: getParsedAudiences,
   getTestProjectConfigWithFeatures: getTestProjectConfigWithFeatures,
   datafileWithFeaturesExpectedData: datafileWithFeaturesExpectedData,
   getUnsupportedVersionConfig: getUnsupportedVersionConfig,
+  getTypedAudiencesConfig: getTypedAudiencesConfig,
+  parsedTypedAudiences: parsedTypedAudiences,
 };

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -277,8 +277,7 @@ var configWithFeatures = {
         '594098',
         '595010',
         '599028',
-        '599082',
-        '1323241597'
+        '599082'
       ]
     }
   ],
@@ -538,57 +537,6 @@ var configWithFeatures = {
       'status': 'Running',
       'key': 'test_shared_feature',
       'id': '599028'
-    },
-    {
-      'id': '1323241597',
-      'key': 'typed_audience_experiment',
-      'layerId': '1630555627',
-      'status': 'Running',
-      'variations': [
-        {
-          'id': '1423767503',
-          'key': 'A',
-          'variables': []
-        }
-      ],
-      'trafficAllocation': [
-        {
-          'entityId': '1423767503',
-          'endOfRange': 10000
-        }
-      ],
-      'audienceIds': ['3468206642', '3988293898', '3468206646', '3468206647', '3468206644', '3468206643'],
-      'forcedVariations': {}
-    },
-    {
-      'id': '1323241598',
-      'key': 'string_exists_audience_experiment',
-      'layerId': '1630555628',
-      'status': 'Running',
-      'variations': [
-        {
-          'id': '1023767503',
-          'key': 'A',
-          'variables': []
-        },
-        {
-          'id': '3033458315',
-          'key': 'B',
-          'variables': []
-        }
-      ],
-      'trafficAllocation': [
-        {
-          'entityId': '1023767503',
-          'endOfRange': 5000
-        },
-        {
-          'entityId': '3033458315',
-          'endOfRange': 10000
-        }
-      ],
-      'audienceIds': ['3988293899', '3468206646'],
-      'forcedVariations': {}
     }
   ],
   'anonymizeIP': true,
@@ -598,73 +546,6 @@ var configWithFeatures = {
       'id': '594017',
       'name': 'test_audience',
       'conditions': '["and", ["or", ["or", {"type": "custom_attribute", "name": "test_attribute", "value": "test_value"}]]]'
-    },
-    {
-      'id': '3468206642',
-      'name': 'exactString',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
-    },
-    {
-      'id': '3988293898',
-      'name': '$$dummySubstringString',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3988293899',
-      'name': '$$dummyExists',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206646',
-      'name': '$$dummyExactNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206647',
-      'name': '$$dummyGtNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206644',
-      'name': '$$dummyLtNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206643',
-      'name': '$$dummyExactBoolean',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    }
-  ],
-  'typedAudiences': [
-    {
-      'id': '3988293898',
-      'name': 'substringString',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
-    },
-    {
-      'id': '3988293899',
-      'name': 'exists',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"exists"}]]]'
-    },
-    {
-      'id': '3468206646',
-      'name': 'exactNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
-    },
-    {
-      'id': '3468206647',
-      'name': 'gtNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
-    },
-    {
-      'id': '3468206644',
-      'name': 'ltNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
-    },
-    {
-      'id': '3468206643',
-      'name': 'exactBoolean',
-      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
     }
   ],
   'revision': '35',
@@ -750,18 +631,6 @@ var configWithFeatures = {
     {
       'key': 'test_attribute',
       'id': '594014'
-    },
-    {
-      'key': 'house',
-      'id': '594015'
-    },
-    {
-      'key': 'lasers',
-      'id': '594016'
-    },
-    {
-      'key': 'should_do_it',
-      'id': '594017'
     }
   ],
   'rollouts': [
@@ -977,40 +846,6 @@ var configWithFeatures = {
   'version': '4',
   'variables': []
 };
-
-var parsedTypedAudiences = [
-  {
-    'id': '3468206642',
-    'name': 'exactString',
-    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'value': 'Gryffindor'}]]]
-  },
-  {
-    'id': '3988293898',
-    'name': 'substringString',
-    'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'match': 'substring', 'value': 'Slytherin'}]]]
-  },
-  {
-    'id': '3468206646',
-    'name': 'exactNumber',
-    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'exact', 'value': 45.5}]]]
-  },
-  {
-    'id': '3468206647',
-    'name': 'gtNumber',
-    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'gt', 'value': 70 }]]]
-  },
-  {
-    'id': '3468206644',
-    'name': 'ltNumber',
-    'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match': 'lt', 'value': 1.0 }]]]
-  },
-  {
-    'id': '3468206643',
-    'name': 'exactBoolean',
-    'conditions': ['and', ['or', ['or', {'name': 'should_do_it', 'type': 'custom_attribute', 'match': 'exact', 'value': true}]]]
-  }
-];
-
 
 var getTestProjectConfigWithFeatures = function() {
   return cloneDeep(configWithFeatures);
@@ -1486,9 +1321,6 @@ var datafileWithFeaturesExpectedData = {
     },
     599080: {},
     599081: {},
-    1423767503: {},
-    1023767503: {},
-    3033458315: {},
   },
 
   featureKeyMap: {
@@ -1944,226 +1776,10 @@ var getUnsupportedVersionConfig = function() {
   return cloneDeep(unsupportedVersionConfig);
 };
 
-var featuresWithTypedAudiencesConfig = {
-  'version': '4',
-  'rollouts': [
-    {
-      'experiments': [
-        {
-          'status': 'Running',
-          'key': '11488548027',
-          'layerId': '11551226731',
-          'trafficAllocation': [
-            {
-              'entityId': '11557362669',
-              'endOfRange': 10000
-            }
-          ],
-          'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
-          'variations': [
-            {
-              'variables': [],
-              'id': '11557362669',
-              'key': '11557362669',
-              'featureEnabled': true
-            }
-          ],
-          'forcedVariations': {},
-          'id': '11488548027'
-        }
-      ],
-      'id': '11551226731'
-    },
-    {
-      'experiments': [
-        {
-          'status': 'Paused',
-          'key': '11630490911',
-          'layerId': '11638870867',
-          'trafficAllocation': [
-            {
-              'entityId': '11475708558',
-              'endOfRange': 0
-            }
-          ],
-          'audienceIds': [],
-          'variations': [
-            {
-              'variables': [],
-              'id': '11475708558',
-              'key': '11475708558',
-              'featureEnabled': false
-            }
-          ],
-          'forcedVariations': {},
-          'id': '11630490911'
-        }
-      ],
-      'id': '11638870867'
-    }
-  ],
-  'anonymizeIP': false,
-  'projectId': '11624721371',
-  'variables': [],
-  'featureFlags': [
-    {
-      'experimentIds': [],
-      'rolloutId': '11551226731',
-      'variables': [],
-      'id': '11477755619',
-      'key': 'feat'
-    },
-    {
-      'experimentIds': [
-        '11564051718'
-      ],
-      'rolloutId': '11638870867',
-      'variables': [
-        {
-          'defaultValue': 'x',
-          'type': 'string',
-          'id': '11535264366',
-          'key': 'x'
-        }
-      ],
-      'id': '11567102051',
-      'key': 'feat_with_var'
-    }
-  ],
-  'experiments': [
-    {
-      'status': 'Running',
-      'key': 'feat_with_var_test',
-      'layerId': '11504144555',
-      'trafficAllocation': [
-        {
-          'entityId': '11617170975',
-          'endOfRange': 10000
-        }
-      ],
-      'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
-      'variations': [
-        {
-          'variables': [
-            {
-              'id': '11535264366',
-              'value': 'xyz'
-            }
-          ],
-          'id': '11617170975',
-          'key': 'variation_2',
-          'featureEnabled': true
-        }
-      ],
-      'forcedVariations': {},
-      'id': '11564051718'
-    }
-  ],
-  'audiences': [
-    {
-      'id': '3468206642',
-      'name': 'exactString',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
-    },
-    {
-      'id': '3988293898',
-      'name': '$$dummySubstringString',
-      'conditions': '["and", ["or"]]',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3988293899',
-      'name': '$$dummyExists',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206646',
-      'name': '$$dummyExactNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206647',
-      'name': '$$dummyGtNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206644',
-      'name': '$$dummyLtNumber',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    },
-    {
-      'id': '3468206643',
-      'name': '$$dummyExactBoolean',
-      'conditions': '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
-    }
-  ],
-  'typedAudiences': [
-    {
-      'id': '3988293898',
-      'name': 'substringString',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
-    },
-    {
-      'id': '3988293899',
-      'name': 'exists',
-      'conditions': '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute", "match":"exists"}]]]'
-    },
-    {
-      'id': '3468206646',
-      'name': 'exactNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
-    },
-    {
-      'id': '3468206647',
-      'name': 'gtNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
-    },
-    {
-      'id': '3468206644',
-      'name': 'ltNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
-    },
-    {
-      'id': '3468206643',
-      'name': 'exactBoolean',
-      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
-    }
-  ],
-  'groups': [],
-  'attributes': [
-    {
-      'key': 'house',
-      'id': '594015'
-    },
-    {
-      'key': 'lasers',
-      'id': '594016'
-    },
-    {
-      'key': 'should_do_it',
-      'id': '594017'
-    },
-    {
-      'key': 'favorite_ice_cream',
-      'id': '594018'
-    }
-  ],
-  'botFiltering': false,
-  'accountId': '4879520872',
-  'events': [],
-  'revision': '3'
-};
-
-var getFeaturesWithTypedAudiencesConfig = function() {
-  return featuresWithTypedAudiencesConfig;
-};
-
 module.exports = {
   getTestProjectConfig: getTestProjectConfig,
   getParsedAudiences: getParsedAudiences,
   getTestProjectConfigWithFeatures: getTestProjectConfigWithFeatures,
   datafileWithFeaturesExpectedData: datafileWithFeaturesExpectedData,
   getUnsupportedVersionConfig: getUnsupportedVersionConfig,
-  parsedTypedAudiences: parsedTypedAudiences,
-  getFeaturesWithTypedAudiencesConfig: getFeaturesWithTypedAudiencesConfig,
 };

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -1889,6 +1889,27 @@ var typedAudiencesConfig = {
       ],
       'forcedVariations': {},
       'id': '11564051718'
+    },
+    {
+      'id': '1323241597',
+      'key': 'typed_audience_experiment',
+      'layerId': '1630555627',
+      'status': 'Running',
+      'variations': [
+        {
+          'id': '1423767503',
+          'key': 'A',
+          'variables': []
+        }
+      ],
+      'trafficAllocation': [
+        {
+          'entityId': '1423767503',
+          'endOfRange': 10000
+        }
+      ],
+      'audienceIds': ['3468206642', '3988293898', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643'],
+      'forcedVariations': {}
     }
   ],
   'audiences': [
@@ -1982,7 +2003,16 @@ var typedAudiencesConfig = {
   ],
   'botFiltering': false,
   'accountId': '4879520872',
-  'events': [],
+  'events': [
+    {
+      'key': 'item_bought',
+      'id': '594089',
+      'experimentIds': [
+        '11564051718',
+        '1323241597'
+      ]
+    }
+  ],
   'revision': '3'
 };
 


### PR DESCRIPTION
### Summary

This updates project config and the audience evaluator to finish the implementation of typed audience evaluation:

- In audience_evaluator, allow evaluation to continue when no user attributes are passed (previously we were immediately returning `false` when no attributes were passed)
- Update project_config: in `createProjectConfig`, set up a by-id object for accessing audiences from both `audiences` and `typedAudiences`. Also, update `getAudiencesForExperiment` to first look in `projectConfig.typedAudiences`, and only look in `projectConfig.audiences` as a fallback.
- Added unit tests checking that all top-level methods that accept user attributes can bucket users into experiments or rollouts that use typed audiences.


### Test Plan

- New & existing unit tests
- Ran compatibility suite tests