### PR TITLE
fix (tests): Suppress console output in tests

### DIFF
--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -312,7 +312,10 @@ describe('lib/core/bucketer', function() {
     });
 
     describe('testBucketWithBucketingId', function() {
-      var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+      var createdLogger = logger.createLogger({
+        logLevel: LOG_LEVEL.INFO,
+        logToConsole: false,
+      });
 
       beforeEach(function() {
         configObj = projectConfig.createProjectConfig(testData);

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -333,7 +333,10 @@ describe('lib/core/decision_service', function() {
 
   describe('when a bucketingID is provided', function() {
     var configObj = projectConfig.createProjectConfig(testData);
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.DEBUG});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.DEBUG,
+      logToConsole: false,
+    });
     var optlyInstance;
     beforeEach(function () {
       optlyInstance = new Optimizely({
@@ -349,13 +352,11 @@ describe('lib/core/decision_service', function() {
 
       sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
-      sinon.stub(createdLogger, 'log');
     });
 
     afterEach(function () {
       eventDispatcher.dispatchEvent.restore();
       errorHandler.handleError.restore();
-      createdLogger.log.restore();
     });
 
     var testUserAttributes = {

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -565,13 +565,9 @@ describe('lib/core/project_config', function() {
   });
 
   describe('#getForcedVariation', function() {
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
-    beforeEach(function() {
-      sinon.stub(createdLogger, 'log');
-    });
-
-    afterEach(function() {
-      createdLogger.log.restore();
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
     });
 
     it('should return null for valid experimentKey, not set', function() {
@@ -592,13 +588,9 @@ describe('lib/core/project_config', function() {
   });
 
   describe('#setForcedVariation', function() {
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
-    beforeEach(function() {
-      sinon.stub(createdLogger, 'log');
-    });
-
-    afterEach(function() {
-      createdLogger.log.restore();
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
     });
 
     it('should return true for a valid forcedVariation in setForcedVariation', function() {

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -24,6 +24,7 @@ var testData = require('./tests/test_data');
 
 var chai = require('chai');
 var assert = chai.assert;
+var find = require('lodash/find');
 var sinon = require('sinon');
 
 describe('javascript-sdk', function() {
@@ -269,7 +270,7 @@ describe('javascript-sdk', function() {
             datafile: testData.getTestProjectConfig(),
             logLevel: enums.LOG_LEVEL.ERROR,
           });
-          var foundCall = logger.createLogger.getCalls().find(function(call) {
+          var foundCall = find(logger.createLogger.getCalls(), function(call) {
             return call.returned(sinon.match.same(optlyInstance.logger));
           });
           assert.strictEqual(foundCall.args[0].logLevel, enums.LOG_LEVEL.ERROR);
@@ -279,7 +280,7 @@ describe('javascript-sdk', function() {
           var optlyInstance = optimizelyFactory.createInstance({
             datafile: testData.getTestProjectConfig(),
           });
-          var foundCall = logger.createLogger.getCalls().find(function(call) {
+          var foundCall = find(logger.createLogger.getCalls(), function(call) {
             return call.returned(sinon.match.same(optlyInstance.logger));
           });
           assert.strictEqual(foundCall.args[0].logLevel, enums.LOG_LEVEL.INFO);

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -15,6 +15,7 @@
  */
 var configValidator = require('./utils/config_validator');
 var enums = require('./utils/enums');
+var logger = require('./plugins/logger');
 var Optimizely = require('./optimizely');
 var optimizelyFactory = require('./index.browser');
 var packageJSON = require('../package.json');
@@ -32,9 +33,13 @@ describe('javascript-sdk', function() {
     describe('createInstance', function() {
       var fakeErrorHandler = { handleError: function() {}};
       var fakeEventDispatcher = { dispatchEvent: function() {}};
-      var fakeLogger = { log: function() {}};
+      var silentLogger;
 
       beforeEach(function() {
+        silentLogger = logger.createLogger({
+          logLevel: enums.LOG_LEVEL.INFO,
+          logToConsole: false,
+        });
         sinon.spy(console, 'error');
         sinon.stub(configValidator, 'validate');
 
@@ -57,6 +62,7 @@ describe('javascript-sdk', function() {
         assert.doesNotThrow(function() {
           optimizelyFactory.createInstance({
             datafile: {},
+            logger: silentLogger,
           });
         });
       });
@@ -66,7 +72,7 @@ describe('javascript-sdk', function() {
           datafile: {},
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
@@ -77,27 +83,10 @@ describe('javascript-sdk', function() {
           datafile: {},
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
         assert.equal('javascript-sdk', optlyInstance.clientEngine);
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
-      });
-
-      it('should instantiate the logger with a custom logLevel when provided', function() {
-        var optlyInstance = optimizelyFactory.createInstance({
-          datafile: {},
-          logLevel: enums.LOG_LEVEL.ERROR,
-        });
-
-        assert.equal(optlyInstance.logger.logLevel, enums.LOG_LEVEL.ERROR);
-      });
-
-      it('should default to INFO when no logLevel is provided', function() {
-        var optlyInstance = optimizelyFactory.createInstance({
-          datafile: {},
-        });
-
-        assert.equal(optlyInstance.logger.logLevel, enums.LOG_LEVEL.INFO);
       });
 
       it('should activate with provided event dispatcher', function(done) {
@@ -105,7 +94,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
         var activate = optlyInstance.activate('testExperiment', 'testUser');
         assert.strictEqual(activate, 'control');
@@ -117,7 +106,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -133,7 +122,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -155,7 +144,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -178,7 +167,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -203,7 +192,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -228,7 +217,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperiment', 'testUser', 'control');
@@ -250,7 +239,7 @@ describe('javascript-sdk', function() {
           datafile: testData.getTestProjectConfig(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: eventDispatcher,
-          logger: fakeLogger,
+          logger: silentLogger,
         });
 
         var didSetVariation = optlyInstance.setForcedVariation('testExperimentNotRunning', 'testUser', 'controlNotRunning');
@@ -260,6 +249,41 @@ describe('javascript-sdk', function() {
         assert.strictEqual(variation, null);
 
         done();
+      });
+
+      describe('automatically created logger instances', function() {
+        beforeEach(function() {
+          sinon.stub(logger, 'createLogger').callsFake(function() {
+            return {
+              log: function() {},
+            };
+          });
+        });
+
+        afterEach(function() {
+          logger.createLogger.restore();
+        });
+
+        it('should instantiate the logger with a custom logLevel when provided', function() {
+          var optlyInstance = optimizelyFactory.createInstance({
+            datafile: testData.getTestProjectConfig(),
+            logLevel: enums.LOG_LEVEL.ERROR,
+          });
+          var foundCall = logger.createLogger.getCalls().find(function(call) {
+            return call.returned(sinon.match.same(optlyInstance.logger));
+          });
+          assert.strictEqual(foundCall.args[0].logLevel, enums.LOG_LEVEL.ERROR);
+        });
+
+        it('should default to INFO when no logLevel is provided', function() {
+          var optlyInstance = optimizelyFactory.createInstance({
+            datafile: testData.getTestProjectConfig(),
+          });
+          var foundCall = logger.createLogger.getCalls().find(function(call) {
+            return call.returned(sinon.match.same(optlyInstance.logger));
+          });
+          assert.strictEqual(foundCall.args[0].logLevel, enums.LOG_LEVEL.INFO);
+        });
       });
     });
   });

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -28,19 +28,20 @@ describe('optimizelyFactory', function() {
     describe('createInstance', function() {
       var fakeErrorHandler = { handleError: function() {}};
       var fakeEventDispatcher = { dispatchEvent: function() {}};
-      var fakeLogger = { log: function() {}};
+      var fakeLogger;
 
       beforeEach(function() {
-        sinon.spy(console, 'error');
+        fakeLogger = { log: sinon.spy() };
+        sinon.stub(logger, 'createLogger').returns(fakeLogger);
         sinon.stub(configValidator, 'validate');
       });
 
       afterEach(function() {
-        console.error.restore();
+        logger.createLogger.restore();
         configValidator.validate.restore();
       });
 
-      it('should not throw if the provided config is not valid and call console.error if logger is passed in', function() {
+      it('should not throw if the provided config is not valid and log an error if logger is passed in', function() {
         configValidator.validate.throws(new Error('Invalid config or something'));
         assert.doesNotThrow(function() {
           optimizelyFactory.createInstance({
@@ -48,17 +49,17 @@ describe('optimizelyFactory', function() {
             logger: logger.createLogger({ logLevel: enums.LOG_LEVEL.INFO }),
           });
         });
-        assert.isTrue(console.error.called);
+        sinon.assert.calledWith(fakeLogger.log, enums.LOG_LEVEL.ERROR);
       });
 
-      it('should not throw if the provided config is not valid and call console.error if no-op logger is used', function() {
+      it('should not throw if the provided config is not valid and log an error if no-op logger is used', function() {
         configValidator.validate.throws(new Error('Invalid config or something'));
         assert.doesNotThrow(function() {
           optimizelyFactory.createInstance({
             datafile: {},
           });
         });
-        assert.isTrue(console.error.called);
+        sinon.assert.calledWith(fakeLogger.log, enums.LOG_LEVEL.ERROR);
       });
 
       it('should create an instance of optimizely', function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -186,7 +186,7 @@ describe('lib/optimizely', function() {
             datafile: testData.getTestProjectConfig(),
             errorHandler: stubErrorHandler,
             eventDispatcher: stubEventDispatcher,
-            logger: logger.createLogger(),
+            logger: logger.createLogger({ logToConsole: false }),
             skipJSONValidation: true,
           });
 
@@ -357,7 +357,10 @@ describe('lib/optimizely', function() {
     var bucketStub;
     var clock;
 
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
     beforeEach(function() {
       optlyInstance = new Optimizely({
         clientEngine: 'node-sdk',
@@ -843,7 +846,10 @@ describe('lib/optimizely', function() {
           errorHandler: errorHandler,
           eventDispatcher: eventDispatcher,
           jsonSchemaValidator: jsonSchemaValidator,
-          logger: logger.createLogger({logLevel: 1}),
+          logger: logger.createLogger({
+            logLevel: enums.LOG_LEVEL.DEBUG,
+            logToConsole: false,
+          }),
           isValidInstance: true,
         });
 
@@ -1480,7 +1486,10 @@ describe('lib/optimizely', function() {
           errorHandler: errorHandler,
           eventDispatcher: eventDispatcher,
           jsonSchemaValidator: jsonSchemaValidator,
-          logger: logger.createLogger({logLevel: 1}),
+          logger: logger.createLogger({
+            logLevel: enums.LOG_LEVEL.DEBUG,
+            logToConsole: false,
+          }),
           isValidInstance: true,
         });
 
@@ -2459,7 +2468,10 @@ describe('lib/optimizely', function() {
   //tests separated out from APIs because of mock bucketing
   describe('getVariationBucketingIdAttribute', function() {
     var optlyInstance;
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
     beforeEach(function() {
       optlyInstance = new Optimizely({
         clientEngine: 'node-sdk',
@@ -2515,7 +2527,10 @@ describe('lib/optimizely', function() {
 
   describe('feature management', function() {
     var sandbox = sinon.sandbox.create();
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
     var optlyInstance;
     var clock;
     beforeEach(function() {
@@ -3305,7 +3320,10 @@ describe('lib/optimizely', function() {
 
   describe('audience match types', function() {
     var sandbox = sinon.sandbox.create();
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
     var optlyInstance;
     beforeEach(function() {
       optlyInstance = new Optimizely({
@@ -3422,7 +3440,10 @@ describe('lib/optimizely', function() {
 
   describe('audience combinations', function() {
     var sandbox = sinon.sandbox.create();
-    var createdLogger = logger.createLogger({logLevel: LOG_LEVEL.INFO});
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
     var optlyInstance;
     beforeEach(function() {
       optlyInstance = new Optimizely({


### PR DESCRIPTION
## Summary

Inspired by #147, this updates tests to prevent real console output that makes results hard to read.

- In general, we can create loggers with `logToConsole: false` to disable real output. For tests that don’t assert log calls, I used this.
- If a test was previously stubbing only to prevent real output, I removed the stub and used `logToConsole: false` instead.
- Some tests were stubbing both to assert log calls  _and_ to prevent real output. I mostly left these alone.
- As pointed out in #147, real output was sometimes still happening because `log` was called before `sinon.stub`. For these, I added `logToConsole: false`.
- The top-level entry points (index.node.js and index.browser.js) construct loggers internally. To prevent real output in these cases, I stubbed `createLogger`.

## Test plan

Run tests and verify that there is no unwanted real log output