### PR TITLE
fix (audiences): Update project config - no longer expect conditions of audiences in typedAudiences to be strings

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -40,9 +40,10 @@ module.exports = {
     fns.forEach(projectConfig.audiences, function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
-    fns.forEach(projectConfig.typedAudiences, function(audience) {
-      audience.conditions = JSON.parse(audience.conditions);
-    });
+    /*
+     * Note: conditions of audiences in projectConfig.typedAudiences are not
+     * expected to be string-encoded as they are in projectConfig.audiences.
+     */
     projectConfig.audiencesById = fns.keyBy(projectConfig.audiences, 'id');
     fns.assign(projectConfig.audiencesById, fns.keyBy(projectConfig.typedAudiences, 'id'));
 

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -36,14 +36,13 @@ module.exports = {
   createProjectConfig: function(datafile) {
     var projectConfig = fns.cloneDeep(datafile);
 
-    // Manually parsed for audience targeting
+    /*
+     * Conditions of audiences in projectConfig.typedAudiences are not
+     * expected to be string-encoded as they are here in projectConfig.audiences.
+     */
     fns.forEach(projectConfig.audiences, function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
-    /*
-     * Note: conditions of audiences in projectConfig.typedAudiences are not
-     * expected to be string-encoded as they are in projectConfig.audiences.
-     */
     projectConfig.audiencesById = fns.keyBy(projectConfig.audiences, 'id');
     fns.assign(projectConfig.audiencesById, fns.keyBy(projectConfig.typedAudiences, 'id'));
 

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -529,7 +529,7 @@ describe('lib/core/project_config', function() {
       it('should retrieve audiences by checking first in typedAudiences, and then second in audiences', function() {
         assert.deepEqual(
           projectConfig.getAudiencesById(configObj),
-          testDatafile.parsedTypedAudiences
+          testDatafile.typedAudiencesById
         );
       });
     });

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -2085,32 +2085,32 @@ var typedAudiencesConfig = {
     {
       'id': '3988293898',
       'name': 'substringString',
-      'conditions': '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'house', 'type': 'custom_attribute', 'match':'substring', 'value':'Slytherin'}]]]
     },
     {
       'id': '3988293899',
       'name': 'exists',
-      'conditions': '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute", "match":"exists"}]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'favorite_ice_cream', 'type': 'custom_attribute', 'match':'exists'}]]]
     },
     {
       'id': '3468206646',
       'name': 'exactNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"exact", "value": 45.5}]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match':'exact', 'value': 45.5}]]]
     },
     {
       'id': '3468206647',
       'name': 'gtNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"gt", "value": 70 }]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match':'gt', 'value': 70 }]]]
     },
     {
       'id': '3468206644',
       'name': 'ltNumber',
-      'conditions': '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match":"lt", "value": 1.0 }]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'lasers', 'type': 'custom_attribute', 'match':'lt', 'value': 1.0 }]]]
     },
     {
       'id': '3468206643',
       'name': 'exactBoolean',
-      'conditions': '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]'
+      'conditions': ['and', ['or', ['or', {'name': 'should_do_it', 'type': 'custom_attribute', 'match':'exact', 'value': true}]]]
     }
   ],
   'groups': [],
@@ -2156,7 +2156,7 @@ var getTypedAudiencesConfig = function() {
   return cloneDeep(typedAudiencesConfig);
 };
 
-var parsedTypedAudiences = {
+var typedAudiencesById = {
   3468206642: {
     'id': '3468206642',
     'name': 'exactString',
@@ -2206,5 +2206,5 @@ module.exports = {
   datafileWithFeaturesExpectedData: datafileWithFeaturesExpectedData,
   getUnsupportedVersionConfig: getUnsupportedVersionConfig,
   getTypedAudiencesConfig: getTypedAudiencesConfig,
-  parsedTypedAudiences: parsedTypedAudiences,
+  typedAudiencesById: typedAudiencesById,
 };


### PR DESCRIPTION
## Summary

Update project config to handle the latest datafile format for 3.0 with typed audience evaluation. `conditions` properties of objects in `typedAudiences` will be `Array`s, and no longer JSON-`Strings`.

## Test Plan

Updated typed audiences datafile in test data to the latest format. Existing tests should pass - no change in behavior.