### PR TITLE
fix(set-forced-variation): Treats empty variation key as invalid and does not reset variation.

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -406,7 +406,8 @@ module.exports = {
    */
   setForcedVariation: function(projectConfig, experimentKey, userId, variationKey, logger) {
     if (variationKey != null && !stringValidator.validate(variationKey)) {
-      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.INVALID_VARIATION_KEY, MODULE_NAME))
+      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.INVALID_VARIATION_KEY, MODULE_NAME));
+      return false;
     }
 
     var experimentId;

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -16,6 +16,7 @@
 var fns = require('../../utils/fns');
 var enums = require('../../utils/enums');
 var sprintf = require('sprintf-js').sprintf;
+var stringValidator = require('../../utils/string_value_validator');
 
 var EXPERIMENT_LAUNCHED_STATUS = 'Launched';
 var EXPERIMENT_RUNNING_STATUS = 'Running';
@@ -404,6 +405,10 @@ module.exports = {
    * @return {boolean} A boolean value that indicates if the set completed successfully.
    */
   setForcedVariation: function(projectConfig, experimentKey, userId, variationKey, logger) {
+    if (variationKey != null && !stringValidator.validate(variationKey)) {
+      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.INVALID_VARIATION_KEY, MODULE_NAME))
+    }
+
     var experimentId;
     try {
       var experiment = this.getExperimentFromKey(projectConfig, experimentKey);
@@ -420,7 +425,7 @@ module.exports = {
       return false;
     }
 
-    if (!variationKey) {
+    if (variationKey == null) {
       try {
         this.removeForcedVariation(projectConfig, userId, experimentId, experimentKey, logger);
         return true;

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -741,5 +741,13 @@ describe('lib/core/project_config', function() {
       var didSetVariation = projectConfig.setForcedVariation(configObj, 'testExperiment', undefined, 'control', createdLogger);
       assert.strictEqual(didSetVariation, false);
     });
+
+    it('should return false for an empty variation key', function() {
+      var testData = testDatafile.getTestProjectConfig();
+      var configObj = projectConfig.createProjectConfig(testData);
+
+      var didSetVariation = projectConfig.setForcedVariation(configObj, 'testExperiment', 'user1', '', createdLogger);
+      assert.strictEqual(didSetVariation, false);
+    });
   });
 });

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -60,6 +60,7 @@ exports.ERROR_MESSAGES = {
   VARIATION_ID_NOT_IN_DATAFILE_NO_EXPERIMENT: '%s: Variation ID %s is not in the datafile.',
   INVALID_INPUT_FORMAT: '%s: Provided %s is in an invalid format.',
   INVALID_DATAFILE_VERSION: '%s: This version of the JavaScript SDK does not support the given datafile version: %s',
+  INVALID_VARIATION_KEY: '%s: Provided variation key is in an invalid format.',
 };
 
 exports.LOG_MESSAGES = {


### PR DESCRIPTION
## Summary
- Forced variation key passed as an empty String will be considered as invalid.
- Added unit test for empty string variation key.