### PR TITLE
fix(bundling): Publish the unminified UMD bundle along with the minified one

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+Changes that have landed but are not yet released.
+- fix(bundling): Publish the unminified UMD bundle along with the minified one.
+
 ## [2.3.0] - November 14, 2018
 
 ### New Features

--- a/packages/optimizely-sdk/README.md
+++ b/packages/optimizely-sdk/README.md
@@ -36,6 +36,9 @@ The package's entry point is a CommonJS module, which can be used directly in en
 
 ```html
 <script src="https://unpkg.com/@optimizely/optimizely-sdk/dist/optimizely.browser.umd.js"></script>
+
+<!-- You can also use the minified version instead -->
+<script src="https://unpkg.com/@optimizely/optimizely-sdk/dist/optimizely.browser.umd.min.js"></script>
 ```
 
 When evaluated, that bundle assigns the SDK's exports to `window.optimizelySdk`. If you wish to use the asset locally (for example, if unpkg is down), you can find it in your local copy of the package at dist/optimizely.browser.umd.min.js.

--- a/packages/optimizely-sdk/scripts/build_browser_umd.sh
+++ b/packages/optimizely-sdk/scripts/build_browser_umd.sh
@@ -26,3 +26,28 @@ Object.defineProperty(window, 'optimizelyClient', {
 });
 EOF
 
+# Builds the unminified bundle
+npx webpack lib/index.browser.js dist/optimizely.browser.umd.js \
+  --define process.env.NODE_ENV="production" \
+  --output-library-target=umd \
+  --output-library="$BUNDLE_NAME"
+
+# Append some backwards-compatibility code to the bundle
+cat - >> dist/optimizely.browser.umd.min.js <<EOF
+
+
+window._optimizelyClientWarningGiven = false;
+
+Object.defineProperty(window, 'optimizelyClient', {
+  get: function () {
+    if (!window._optimizelyClientWarningGiven) {
+      console.warn('Accessing the SDK via window.optimizelyClient is deprecated; please use window.optimizelySdk instead. This alias will be dropped in 3.0.0.');
+      window._optimizelyClientWarningGiven = true;
+    }
+
+    return {
+      createInstance: window.optimizelySdk.createInstance
+    };
+  }
+});
+EOF

--- a/packages/optimizely-sdk/scripts/build_browser_umd.sh
+++ b/packages/optimizely-sdk/scripts/build_browser_umd.sh
@@ -33,7 +33,7 @@ npx webpack lib/index.browser.js dist/optimizely.browser.umd.js \
   --output-library="$BUNDLE_NAME"
 
 # Append some backwards-compatibility code to the bundle
-cat - >> dist/optimizely.browser.umd.min.js <<EOF
+cat - >> dist/optimizely.browser.umd.js <<EOF
 
 
 window._optimizelyClientWarningGiven = false;


### PR DESCRIPTION
## Summary
- We need to build and publish the unminified bundle to NPM as we publicly refer to it in our docs.

This is the output of cleaning the local `/dist` directory and building manually with `npm run build-browser-umd`:
```
Hash: 1e3850c525529035af49
Version: webpack 2.7.0
Time: 1222ms
                        Asset     Size  Chunks             Chunk Names
optimizely.browser.umd.min.js  82.8 kB       0  [emitted]  main
   [1] ./lib/utils/enums/index.js 11.8 kB {0} [built]
   [3] ./~/sprintf-js/src/sprintf.js 8.67 kB {0} [built]
   [4] ./lib/utils/fns/index.js 1.21 kB {0} [built]
  [44] ./lib/utils/config_validator/index.js 2.95 kB {0} [built]
  [74] ./lib/optimizely/index.js 28.7 kB {0} [built]
  [75] ./lib/plugins/error_handler/index.js 809 bytes {0} [built]
  [76] ./lib/plugins/event_dispatcher/index.browser.js 2.42 kB {0} [built]
  [77] ./lib/plugins/logger/index.js 4.09 kB {0} [built]
  [84] ./lib/index.browser.js 2.78 kB {0} [built]
  [85] ./lib/optimizely/project_config_schema.js 7.02 kB {0} [built]
  [87] ./lib/utils/event_tags_validator/index.js 1.29 kB {0} [built]
  [88] ./lib/utils/string_value_validator/index.js 864 bytes {0} [built]
  [89] ./lib/utils/user_profile_service_validator/index.js 2.14 kB {0} [built]
 [190] ./~/lodash/forEach.js 1.35 kB {0} [built]
 [193] ./~/lodash/isEmpty.js 2 kB {0} [built]
    + 194 hidden modules
Hash: 41332d833233093fb3ac
Version: webpack 2.7.0
Time: 458ms
                    Asset    Size  Chunks                    Chunk Names
optimizely.browser.umd.js  319 kB       0  [emitted]  [big]  main
   [1] ./lib/utils/enums/index.js 11.8 kB {0} [built]
   [3] ./~/sprintf-js/src/sprintf.js 8.67 kB {0} [built]
   [4] ./lib/utils/fns/index.js 1.21 kB {0} [built]
  [44] ./lib/utils/config_validator/index.js 2.95 kB {0} [built]
  [74] ./lib/optimizely/index.js 28.7 kB {0} [built]
  [75] ./lib/plugins/error_handler/index.js 809 bytes {0} [built]
  [76] ./lib/plugins/event_dispatcher/index.browser.js 2.42 kB {0} [built]
  [77] ./lib/plugins/logger/index.js 4.09 kB {0} [built]
  [84] ./lib/index.browser.js 2.78 kB {0} [built]
  [85] ./lib/optimizely/project_config_schema.js 7.02 kB {0} [built]
  [87] ./lib/utils/event_tags_validator/index.js 1.29 kB {0} [built]
  [88] ./lib/utils/string_value_validator/index.js 864 bytes {0} [built]
  [89] ./lib/utils/user_profile_service_validator/index.js 2.14 kB {0} [built]
 [190] ./~/lodash/forEach.js 1.35 kB {0} [built]
 [193] ./~/lodash/isEmpty.js 2 kB {0} [built]
    + 194 hidden modules
total 792
-rw-r--r--  1 mng  staff  319465 Nov 14 13:49 optimizely.browser.umd.js
-rw-r--r--  1 mng  staff   83743 Nov 14 13:49 optimizely.browser.umd.min.js
```

## Testing
- Manually loaded both min and unminified files in the browser and verified that `window.optimizelySdk` and `window.optimizelyClient` are accessible.