### PR TITLE
[OASIS-3799]  Adding test-ci to prepublish hoook

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint lib/**",
     "cover": "istanbul cover _mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js",
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
-    "prepublishOnly": "npm run build-browser-umd && npm test && npm run test-xbrowser"
+    "prepublishOnly": "npm run build-browser-umd && npm test && npm run test-ci"
   },
   "repository": {
     "type": "git",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint lib/**",
     "cover": "istanbul cover _mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js",
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
-    "prepublishOnly": "npm run build-browser-umd && npm test && npm run test-ci"
+    "prepublishOnly": "npm run build-browser-umd && npm test && npm run test-xbrowser && npm run test-umdbrowser"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- @mjc1283 suggested adding test-ci into the prepublish hook, so I've swapped it out for test-xbrowser there

## Test plan

## Issues
- OASIS-3799
