### PR TITLE
refac(ci): improve build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ stages:
 jobs:
   include:
     - stage: 'Integration tests'
+      merge_mode: replace
       env: SDK=javascript
+      cache: false
       language: python
       before_install: skip
       install:
@@ -43,4 +45,4 @@ jobs:
         - "aws s3 cp s3://optimizely-travisci-artifacts/ci/trigger_fullstack-sdk-compat.sh ci/ && chmod u+x ci/trigger_fullstack-sdk-compat.sh"
       script:
         - "ci/trigger_fullstack-sdk-compat.sh"
-      after_success: skip
+      after_success: travis_terminate 0


### PR DESCRIPTION
## Summary
Optimizations to the 'Integration tests' triggering build:
- added merge_mode: replace, trigger job only needs to run shell script, so just do that and nothing else.
- added cache: false, caching is used for some *-sdk, this disables it for the 'Integration tests' triggering build since it is not needed.
- replaced after_success: skip with after_success: travis_terminate 0, this avoids running srcclr which saves 18-30s from build time.