### PR TITLE
fix(event-tags): do not exclude falsy revenue and event values in the event payload

### DIFF
--- a/packages/optimizely-sdk/lib/core/event_builder/index.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.js
@@ -133,12 +133,12 @@ function getVisitorSnapshot(configObj, eventKey, eventTags, logger) {
 
   if (eventTags) {
     var revenue = eventTagUtils.getRevenueValue(eventTags, logger);
-    if (revenue) {
+    if (revenue !== null) {
       eventDict[enums.RESERVED_EVENT_KEYWORDS.REVENUE] = revenue;
     }
 
     var eventValue = eventTagUtils.getEventValue(eventTags, logger);
-    if (eventValue) {
+    if (eventValue !== null) {
       eventDict[enums.RESERVED_EVENT_KEYWORDS.VALUE] = eventValue;
     }
 

--- a/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
@@ -1097,6 +1097,54 @@ describe('lib/core/event_builder', function() {
             assert.deepEqual(actualParams, expectedParams);
           });
 
+          it('should include falsy revenue values in the event object', function() {
+            var expectedParams = {
+              url: 'https://logx.optimizely.com/v1/events',
+              httpVerb: 'POST',
+              params: {
+                'client_version': packageJSON.version,
+                'project_id': '111001',
+                'visitors': [{
+                  'attributes': [],
+                  'visitor_id': 'testUser',
+                  'snapshots': [{
+                    'events': [{
+                      'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c',
+                      'tags': {
+                        'revenue': 0
+                      },
+                      'timestamp': Math.round(new Date().getTime()),
+                      'revenue': 0,
+                      'key': 'testEvent',
+                      'entity_id': '111095'
+                    }]
+                  }]
+                }],
+                'account_id': '12001',
+                'client_name': 'node-sdk',
+                'revision': '42',
+                'anonymize_ip': false,
+                'enrich_decisions': true,
+              },
+            };
+
+            var eventOptions = {
+              clientEngine: 'node-sdk',
+              clientVersion: packageJSON.version,
+              configObj: configObj,
+              eventKey: 'testEvent',
+              eventTags: {
+                'revenue': 0,
+              },
+              logger: mockLogger,
+              userId: 'testUser',
+            };
+
+            var actualParams = eventBuilder.getConversionEvent(eventOptions);
+
+            assert.deepEqual(actualParams, expectedParams);
+          });
+
           describe('and the revenue value is invalid', function() {
             it('should not include the revenue value in the event object', function() {
               var expectedParams = {
@@ -1190,6 +1238,54 @@ describe('lib/core/event_builder', function() {
               eventTags: {
                 'value': '13.37',
                 'non-revenue': 'cool',
+              },
+              logger: mockLogger,
+              userId: 'testUser',
+            };
+
+            var actualParams = eventBuilder.getConversionEvent(eventOptions);
+
+            assert.deepEqual(actualParams, expectedParams);
+          });
+
+          it('should include the falsy event values in the event object', function() {
+            var expectedParams = {
+              url: 'https://logx.optimizely.com/v1/events',
+              httpVerb: 'POST',
+              params: {
+                'client_version': packageJSON.version,
+                'project_id': '111001',
+                'visitors': [{
+                  'attributes': [],
+                  'visitor_id': 'testUser',
+                  'snapshots': [{
+                    'events': [{
+                      'uuid': 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c',
+                      'tags': {
+                        'value': '0.0'
+                      },
+                      'timestamp': Math.round(new Date().getTime()),
+                      'value': 0.0,
+                      'key': 'testEvent',
+                      'entity_id': '111095'
+                    }]
+                  }]
+                }],
+                'account_id': '12001',
+                'client_name': 'node-sdk',
+                'revision': '42',
+                'anonymize_ip': false,
+                'enrich_decisions': true,
+              },
+            };
+
+            var eventOptions = {
+              clientEngine: 'node-sdk',
+              clientVersion: packageJSON.version,
+              configObj: configObj,
+              eventKey: 'testEvent',
+              eventTags: {
+                'value': '0.0',
               },
               logger: mockLogger,
               userId: 'testUser',

--- a/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
@@ -1097,7 +1097,7 @@ describe('lib/core/event_builder', function() {
             assert.deepEqual(actualParams, expectedParams);
           });
 
-          it('should include falsy revenue values in the event object', function() {
+          it('should include revenue value of 0 in the event object', function() {
             var expectedParams = {
               url: 'https://logx.optimizely.com/v1/events',
               httpVerb: 'POST',

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -231,7 +231,6 @@ Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
 
       // remove null values from eventTags
       eventTags = this.__filterEmptyValues(eventTags);
-
       var conversionEventOptions = {
         attributes: attributes,
         clientEngine: this.clientEngine,


### PR DESCRIPTION
## Summary
- The revenue and event values were excluded from the event object if they evaluated as falsy.
- The fix is to check against `null` instead of performing a truthy check because the utility method will return `null` if the revenue or event values cannot be parsed from the tags.

## Test plan
- Unit tests and integration tests
