### PR TITLE
fix (umd script test): Default logger calls console.info when logging at info level

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.umdtests.js
+++ b/packages/optimizely-sdk/lib/index.browser.umdtests.js
@@ -233,11 +233,15 @@ describe('javascript-sdk', function() {
 
       describe('automatically created logger instances', function() {
         beforeEach(function() {
-          sinon.spy(console, 'log')
+          sinon.spy(console, 'log');
+          sinon.spy(console, 'info');
+          sinon.spy(console, 'warn');
         });
 
         afterEach(function() {
           console.log.restore();
+          console.info.restore();
+          console.warn.restore();
         });
 
         it('should instantiate the logger with a custom logLevel when provided', function() {
@@ -264,10 +268,10 @@ describe('javascript-sdk', function() {
             datafile: testData.getTestProjectConfig(),
             skipJSONValidation: true
           });
-          assert.strictEqual(console.log.getCalls().length, 1)
-          call = console.log.getCalls()[0]
-          assert.strictEqual(call.args.length, 1)
-          assert(call.args[0].indexOf('OPTIMIZELY: Skipping JSON schema validation.') > -1)
+          assert.strictEqual(console.info.getCalls().length, 1);
+          call = console.info.getCalls()[0];
+          assert.strictEqual(call.args.length, 1);
+          assert(call.args[0].indexOf('OPTIMIZELY: Skipping JSON schema validation.') > -1);
         });
       });
     });


### PR DESCRIPTION
## Summary

Update UMD script test to reflect the latest expected behavior of the default logger (when the level is INFO, it calls `console.info`)

## Test plan

Run UMD script tests (`npm run test-umdbrowser`)
