### PR TITLE
Remove pointer to invalid enums.CLIENT_VERSION

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -71,7 +71,6 @@ module.exports = {
 
       config = fns.assignIn({
         clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
-        clientVersion: enums.CLIENT_VERSION,
         errorHandler: defaultErrorHandler,
         eventDispatcher: defaultEventDispatcher,
         logger: logger.createLogger({logLevel: logLevel})

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -82,6 +82,7 @@ describe('javascript-sdk', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
+        assert.equal(optlyInstance.clientVersion, '3.0.0');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.node.js
+++ b/packages/optimizely-sdk/lib/index.node.js
@@ -66,7 +66,6 @@ module.exports = {
 
     config = fns.assign({
       clientEngine: enums.NODE_CLIENT_ENGINE,
-      clientVersion: enums.CLIENT_VERSION,
       errorHandler: defaultErrorHandler,
       eventDispatcher: defaultEventDispatcher,
       jsonSchemaValidator: jsonSchemaValidator,

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -78,6 +78,7 @@ describe('optimizelyFactory', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
+        assert.equal(optlyInstance.clientVersion, '3.0.0');
       });
     });
   });


### PR DESCRIPTION
## Summary
- The `index.browser.js` and `index.node.js` entry points where using an invalid enum `enums.CLIENT_VERSION`.  

This wasn't causing an issue becasue the `Optimizely` constructor defaults to the correct enum.  The fix is to not let this be passed into `Optimizely` and just hard code the value.

## Test plan
- Added unit test to ensure clientVersion after `createInstance`
