### PR TITLE
Prepare for 3.0.1 release

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [3.0.1] - February 15, 2019
+
+### Changed
+- Expose default `loggers`, `errorHandlers`, `eventDispatcher` and `enums` on top level require.
+- `createLogger` and `createNoOpLogger` are available as methods on `optimizelySdk.logging`
+- Added `optimizelySdk.errorHandler`
+- Added `optimizelySdk.eventDispatcher`
+- Added `optimizelySdk.enums`
+
 ## [3.0.0] - February 13, 2019
 
 The 3.0 release improves event tracking and supports additional audience targeting functionality.

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -29,7 +29,7 @@ var MODULE_NAME = 'INDEX';
  * Entry point into the Optimizely Browser SDK
  */
 module.exports = {
-  logger: logger,
+  logging: logger,
   errorHandler: defaultErrorHandler,
   eventDispatcher: defaultEventDispatcher,
   enums: enums,

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -30,7 +30,9 @@ describe('javascript-sdk', function() {
     var requests;
 
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
-      assert.isDefined(optimizelyFactory.logger);
+      assert.isDefined(optimizelyFactory.logging);
+      assert.isDefined(optimizelyFactory.logging.createLogger);
+      assert.isDefined(optimizelyFactory.logging.createNoOpLogger);
       assert.isDefined(optimizelyFactory.errorHandler);
       assert.isDefined(optimizelyFactory.eventDispatcher);
       assert.isDefined(optimizelyFactory.enums);
@@ -42,7 +44,7 @@ describe('javascript-sdk', function() {
       var silentLogger;
 
       beforeEach(function() {
-        silentLogger = optimizelyFactory.logger.createLogger({
+        silentLogger = optimizelyFactory.logging.createLogger({
           logLevel: optimizelyFactory.enums.LOG_LEVEL.INFO,
           logToConsole: false,
         });
@@ -82,7 +84,7 @@ describe('javascript-sdk', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.0.0');
+        assert.equal(optlyInstance.clientVersion, '3.0.1');
       });
 
       it('should set the JavaScript client engine and version', function() {
@@ -251,7 +253,7 @@ describe('javascript-sdk', function() {
 
       describe('automatically created logger instances', function() {
         beforeEach(function() {
-          sinon.stub(optimizelyFactory.logger, 'createLogger').callsFake(function() {
+          sinon.stub(optimizelyFactory.logging, 'createLogger').callsFake(function() {
             return {
               log: function() {},
             };
@@ -259,7 +261,7 @@ describe('javascript-sdk', function() {
         });
 
         afterEach(function() {
-          optimizelyFactory.logger.createLogger.restore();
+          optimizelyFactory.logging.createLogger.restore();
         });
 
         it('should instantiate the logger with a custom logLevel when provided', function() {
@@ -267,7 +269,7 @@ describe('javascript-sdk', function() {
             datafile: testData.getTestProjectConfig(),
             logLevel: optimizelyFactory.enums.LOG_LEVEL.ERROR,
           });
-          var foundCall = find(optimizelyFactory.logger.createLogger.getCalls(), function(call) {
+          var foundCall = find(optimizelyFactory.logging.createLogger.getCalls(), function(call) {
             return call.returned(sinon.match.same(optlyInstance.logger));
           });
           assert.strictEqual(foundCall.args[0].logLevel, optimizelyFactory.enums.LOG_LEVEL.ERROR);
@@ -277,7 +279,7 @@ describe('javascript-sdk', function() {
           var optlyInstance = optimizelyFactory.createInstance({
             datafile: testData.getTestProjectConfig(),
           });
-          var foundCall = find(optimizelyFactory.logger.createLogger.getCalls(), function(call) {
+          var foundCall = find(optimizelyFactory.logging.createLogger.getCalls(), function(call) {
             return call.returned(sinon.match.same(optlyInstance.logger));
           });
           assert.strictEqual(foundCall.args[0].logLevel, optimizelyFactory.enums.LOG_LEVEL.INFO);

--- a/packages/optimizely-sdk/lib/index.node.js
+++ b/packages/optimizely-sdk/lib/index.node.js
@@ -31,7 +31,7 @@ var MODULE_NAME = 'INDEX';
  * Entry point into the Optimizely Node testing SDK
  */
 module.exports = {
-  logger: logger,
+  logging: logger,
   errorHandler: defaultErrorHandler,
   eventDispatcher: defaultEventDispatcher,
   enums: enums,

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -26,7 +26,9 @@ var sinon = require('sinon');
 describe('optimizelyFactory', function() {
   describe('APIs', function() {
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
-      assert.isDefined(optimizelyFactory.logger);
+      assert.isDefined(optimizelyFactory.logging);
+      assert.isDefined(optimizelyFactory.logging.createLogger);
+      assert.isDefined(optimizelyFactory.logging.createNoOpLogger);
       assert.isDefined(optimizelyFactory.errorHandler);
       assert.isDefined(optimizelyFactory.eventDispatcher);
       assert.isDefined(optimizelyFactory.enums);
@@ -78,7 +80,7 @@ describe('optimizelyFactory', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.0.0');
+        assert.equal(optlyInstance.clientVersion, '3.0.1');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -153,7 +153,7 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
-exports.NODE_CLIENT_VERSION = '3.0.0';
+exports.NODE_CLIENT_VERSION = '3.0.1';
 
 /*
  * Notification types for use with NotificationCenter

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
## Summary
- Expose all of the `enums` `plugins` via the top level object

```
const optimizelySdk = require('@optimizely/optimizely-sdk')
const logger = optimizelySdk.logging.createLogger({
  logLevel: optimizelySdk.enums.LOG_LEVEL.DEBUG,
});

const errorHandler = optimizelySdk.errorHandler
const eventDispatcher = optimizelySdk.eventDispatcher
```

We plan to deprecate direct requires of files (which is a really bad practice) in 4.0.  This gives customers time to change how they are requiring plugins / enums in the mean time.

## Test plan
- Unit tests

## Issues
- OASIS-4189
