### PR TITLE
fix: include package.json in files for those that install from Github.

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -67,6 +67,7 @@
     "lib/",
     "LICENSE",
     "CHANGELOG",
-    "README.md"
+    "README.md",
+    "package.json"
   ]
 }


### PR DESCRIPTION
## Summary
I uncovered this potential issue when trying to install the SDK into the testapp for E2E testing. I recently updated the testapp to use Node 10.6 as base image (up from Node 7) and that is what caused the installation from Github to fail (it doesn't include the `package.json` file inside the `optimizely-sdk` package
