### PR TITLE
Prepare 3.1.0-beta1 release

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [3.1.0-beta1] - March 5th, 2019
+
+### Changed
+
+- New APIs for setting `logger` and `logLevel` on the optimizelySDK singleton
+- `logger` and `logLevel` are now set globally for all instances of Optimizely.  If you were passing
+different loggers to individual instances of Optimizely, logging behavior may now be different.
+
+#### Setting a ConsoleLogger
+
+```js
+var optimizelySDK = require('@optimizely/optimizely-sdk')
+
+// logger and logLevel are now set on the optimizelySDK singleton
+optimizelySDK.setLogger(optimizelySDK.logging.createLogger())
+
+// valid levels: 'DEBUG', 'INFO', 'WARN', 'ERROR'
+optimizelySDK.setLogLevel('WARN')
+// enums can also be used
+optimizelySDK.setLogLevel(optimizely.enums.LOG_LEVEL.ERROR)
+```
+
+#### Disable logging
+
+```js
+var optimizelySDK = require('@optimizely/optimizely-sdk')
+
+optimizelySDK.setLogger(null)
+```
+
 ## [3.0.1] - February 21, 2019
 
 ### Changed

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -11,7 +11,7 @@ Changes that have landed but are not yet released.
 
 ### Changed
 
-- New APIs for setting `logger` and `logLevel` on the optimizelySDK singleton
+- New APIs for setting `logger` and `logLevel` on the optimizelySDK singleton ([#232](https://github.com/optimizely/javascript-sdk/pull/232))
 - `logger` and `logLevel` are now set globally for all instances of Optimizely.  If you were passing
 different loggers to individual instances of Optimizely, logging behavior may now be different.
 

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -85,7 +85,7 @@ describe('javascript-sdk', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.0.1');
+        assert.equal(optlyInstance.clientVersion, '3.1.0-beta1');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -84,7 +84,7 @@ describe('optimizelyFactory', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.0.1');
+        assert.equal(optlyInstance.clientVersion, '3.1.0-beta1');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -150,7 +150,7 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
-exports.NODE_CLIENT_VERSION = '3.0.1';
+exports.NODE_CLIENT_VERSION = '3.1.0-beta1';
 
 /*
  * Notification types for use with NotificationCenter

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.0.1",
+  "version": "3.1.0-beta1",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
## Summary
- New APIs for setting `logger` and `logLevel` on the optimizelySDK singleton
- `logger` and `logLevel` are now set globally for all instances of Optimizely.  If you were passing
different loggers to individual instances of Optimizely, logging behavior may now be different.

## Test plan
- Existing unit + compat tests

## Issues
- OASIS-4297
