### PR TITLE
datafile is of type string or object

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -21,7 +21,7 @@ declare module '@optimizely/optimizely-sdk' {
   
     // The options object given to Optimizely.createInstance.
     export interface Config {
-        datafile: object;
+        datafile: string | object;
         errorHandler?: object;
         eventDispatcher?: object;
         logger?: object;


### PR DESCRIPTION
## Summary
This SDK accepts a string as the datafile type. This isn't represented in the typescript declaration file.

## Test plan
My typescript compiles

## Issues
would you like me to create one?