### PR TITLE
Update existing eventDispatchers to properly respect the callback suc…

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/event_dispatcher_bridge.js
+++ b/packages/optimizely-sdk/lib/optimizely/event_dispatcher_bridge.js
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 /**
- * Bridges the existing event dispatcher interface with the one in the eventProcessor
+ * Bridges the existing event dispatcher interface with the HttpClient defined
+ * in the eventProcessor package
  *
  * new EventDispatcher interface
-interface EventDispatcher {
-  dispatch(event: object, callback: (success: boolean) => void): void
+export interface HttpClient {
+  dispatch(event: EventV1Request, callback: (success: boolean) => void): void
 }
 
-interface HttpRequest {
+export interface EventV1Request {
   url: string
   method: 'POST' | 'PUT' | 'GET' | 'PATCH'
   headers: {
     [key: string]: string[]
   }
-  body: string
-}
-
-interface HttpEventDispatcher extends EventDispatcher {
-  dispatch(request: HttpRequest, callback: (success: boolean) => void): void
+  event: EventV1,
 }
  */
 
@@ -46,9 +43,9 @@ EventDispatcherBridge.prototype.dispatch = function(request, callback) {
       url: request.url,
       params: request.event,
     },
-    function(response) {
+    function(success) {
       // right now callbacks only happen if statusCode >= 200 && < 400
-      callback(true);
+      callback(success);
     }
   );
 

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -36,7 +36,8 @@ module.exports = {
       req.onreadystatechange = function() {
         if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
           try {
-            callback(params);
+            var success = req.status >= 200 && req.status < 400;
+            callback(success);
           } catch (e) {
             // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
           }
@@ -55,7 +56,8 @@ module.exports = {
       req.onreadystatechange = function() {
         if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
           try {
-            callback();
+            var success = req.status >= 200 && req.status < 400;
+            callback(success);
           } catch (e) {
             // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
           }

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -27,8 +27,8 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         xhr = sinon.useFakeXMLHttpRequest();
         global.XMLHttpRequest = xhr;
         requests = [];
-        xhr.onCreate = function (req) {
-            requests.push(req);
+        xhr.onCreate = function(req) {
+          requests.push(req);
         };
       });
 
@@ -36,15 +36,15 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         xhr.restore();
       });
 
-      it('should send a POST request with the specified params', function(done) {
-        var eventParams = {'testParam': 'testParamValue'};
+      it('should send a POST request with the specified params', function() {
+        var eventParams = { testParam: 'testParamValue' };
         var eventObj = {
           url: 'https://cdn.com/event',
           body: {
             id: 123,
           },
           httpVerb: 'POST',
-          params: eventParams
+          params: eventParams,
         };
 
         var callback = sinon.spy();
@@ -52,40 +52,112 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         assert.strictEqual(1, requests.length);
         assert.strictEqual(requests[0].method, 'POST');
         assert.strictEqual(requests[0].requestBody, JSON.stringify(eventParams));
-        done();
       });
 
-      it('should execute the callback passed to event dispatcher with a post', function(done) {
-        var eventParams = {'testParam': 'testParamValue'};
-        var eventObj = {
-          url: 'https://cdn.com/event',
-          body: {
-            id: 123,
-          },
-          httpVerb: 'POST',
-          params: eventParams
-        };
+      describe('when response code = 200', function() {
+        it('should execute the callback passed to event dispatcher with a post', function() {
+          var eventParams = { testParam: 'testParamValue' };
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            body: {
+              id: 123,
+            },
+            httpVerb: 'POST',
+            params: eventParams,
+          };
 
-        var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
-        requests[ 0 ].respond([ 200, {}, '{"url":"https://cdn.com/event","body":{"id":123},"httpVerb":"POST","params":{"testParam":"testParamValue"}}' ]);
-        sinon.assert.calledOnce(callback);
-        done();
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          assert.strictEqual(1, requests.length);
+          requests[0].respond(200, {});
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, true);
+        });
+
+        it('should execute the callback passed to event dispatcher with a get', function() {
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            httpVerb: 'GET',
+          };
+
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          assert.strictEqual(1, requests.length);
+          requests[0].respond(200, {});
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, true);
+        });
       });
 
-      it('should execute the callback passed to event dispatcher with a get', function(done) {
-        var eventObj = {
-          url: 'https://cdn.com/event',
-          httpVerb: 'GET'
-        };
+      describe('when response code = 204', function() {
+        it('should execute the callback passed to event dispatcher with a post', function() {
+          var eventParams = { testParam: 'testParamValue' };
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            body: {
+              id: 123,
+            },
+            httpVerb: 'POST',
+            params: eventParams,
+          };
 
-        var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
-        requests[ 0 ].respond([ 200, {}, '{"url":"https://cdn.com/event","httpVerb":"GET"' ]);
-        sinon.assert.calledOnce(callback);
-        done();
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          assert.strictEqual(1, requests.length);
+          requests[0].respond(204, {});
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, true);
+        });
+
+        it('should execute the callback passed to event dispatcher with a get', function() {
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            httpVerb: 'GET',
+          };
+
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          assert.strictEqual(1, requests.length);
+          requests[0].respond(204, {});
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, true);
+        });
       });
 
+      describe('when response code = 400', function() {
+        it('should execute the callback passed to event dispatcher with a post', function() {
+          var eventParams = { testParam: 'testParamValue' };
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            body: {
+              id: 123,
+            },
+            httpVerb: 'POST',
+            params: eventParams,
+          };
+
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          requests[0].respond(400, {});
+          assert.strictEqual(1, requests.length);
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, false);
+        });
+
+        it('should execute the callback passed to event dispatcher with a get', function() {
+          var eventObj = {
+            url: 'https://cdn.com/event',
+            httpVerb: 'GET',
+          };
+
+          var callback = sinon.spy();
+          eventDispatcher.dispatchEvent(eventObj, callback);
+          assert.strictEqual(1, requests.length);
+          requests[0].respond(400, {});
+          sinon.assert.calledOnce(callback);
+          sinon.assert.calledWithExactly(callback, false);
+        });
+      });
     });
   });
 });

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -53,13 +53,17 @@ module.exports = {
 
     var requestCallback = function(response) {
       if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400) {
-        callback(response);
+        callback(true);
+      } else {
+        callback(false);
       }
     };
 
     var req = (parsedUrl.protocol === 'http:' ? http : https).request(requestOptions, requestCallback);
     // Add no-op error listener to prevent this from throwing
-    req.on('error', function() {});
+    req.on('error', function() {
+      callback(false);
+    });
     req.write(dataString);
     req.end();
     return req;


### PR DESCRIPTION
## Summary
- Change existing eventDispatcher implementations to use `callback(success)` instead of (inconsistently) passing back the response object. 

This is needed to be able to properly track if a request has completed or errored for the retry mechanism in an upcoming PR

## Test plan
- Unit tests