### PR TITLE
chore(changelog): Update the 3.0.0 changelog

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -54,7 +54,7 @@ The 3.0 release improves event tracking and supports additional audience targeti
 
 - Event tracking ([#207](https://github.com/optimizely/javascript-sdk/pull/207)):
   - The `track` method now dispatches its conversion event _unconditionally_, without first determining whether the user is targeted by a known experiment that uses the event. This may increase outbound network traffic.
-  - In Optimizely results, conversion events sent by 3.0 SDKs are automatically attributed to variations that the user has previously seen, as long as our backend has actually received the impression events for those variations.
+  - In Optimizely results, conversion events sent by 3.0 SDKs don't explicitly name the experiments and variations that are currently targeted to the user. Instead, conversions are automatically attributed to variations that the user has previously seen, as long as those variations were served via 3.0 SDKs or by other clients capable of automatic attribution, and as long as our backend actually received the impression events for those variations.
   - Altogether, this allows you to track conversion events and attribute them to variations even when you don't know all of a user's attribute values, and even if the user's attribute values or the experiment's configuration have changed such that the user is no longer affected by the experiment. As a result, **you may observe an increase in the conversion rate for previously-instrumented events.** If that is undesirable, you can reset the results of previously-running experiments after upgrading to the 3.0 SDK.
   - This will also allow you to attribute events to variations from other Optimizely projects in your account, even though those experiments don't appear in the same datafile.
   - Note that for results segmentation in Optimizely results, the user attribute values from one event are automatically applied to all other events in the same session, as long as the events in question were actually received by our backend. This behavior was already in place and is not affected by the 3.0 release.
@@ -75,6 +75,7 @@ The 3.0 release improves event tracking and supports additional audience targeti
 
 ### Breaking Changes:
 
+- Conversion events sent by 3.0 SDKs don't explicitly name the experiments and variations that are currently targeted to the user, so these events are unattributed in raw events data export. You must use the new _results_ export to determine the variations to which events have been attributed.
 - Previously, notification listeners were only given string-valued user attributes because only strings could be passed into various method calls. That is no longer the case. You may pass non-string attribute values, and if you do, you must update your notification listeners to be able to receive whatever values you pass in ([#174](https://github.com/optimizely/javascript-sdk/pull/174), [#204](https://github.com/optimizely/javascript-sdk/pull/204)).
 - Drops `window.optimizelyClient` from the bundled build. Now, `window.optimizelySdk` can be used instead. ([#189](https://github.com/optimizely/javascript-sdk/pull/189)).
 


### PR DESCRIPTION
We want to _further_ clarify the event tracking changes in the 3.0 release. I'm updating the `master` branch but I won't try to update the `v3.0.0` tag.

[Preview link](https://github.com/optimizely/javascript-sdk/blob/nikhil/update-3.0.0-changelog/packages/optimizely-sdk/CHANGELOG.MD)