### PR TITLE
refactor (datafile management): Remove direct reference to project config object from decision service

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -48,7 +48,6 @@ describe('lib/core/decision_service', function() {
       bucketerStub = sinon.stub(bucketer, 'bucket');
       sinon.stub(mockLogger, 'log');
       decisionServiceInstance = DecisionService.createDecisionService({
-        configObj: configObj,
         logger: mockLogger,
       });
     });
@@ -61,12 +60,12 @@ describe('lib/core/decision_service', function() {
     describe('#getVariation', function () {
       it('should return the correct variation for the given experiment key and user ID for a running experiment', function () {
         bucketerStub.returns('111128'); // ID of the 'control' variation from `test_data`
-        assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+        assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
         sinon.assert.calledOnce(bucketerStub);
       });
 
       it('should return the whitelisted variation if the user is whitelisted', function () {
-        assert.strictEqual('variationWithAudience', decisionServiceInstance.getVariation('testExperimentWithAudiences', 'user2'));
+        assert.strictEqual('variationWithAudience', decisionServiceInstance.getVariation(configObj, 'testExperimentWithAudiences', 'user2'));
         sinon.assert.notCalled(bucketerStub);
         assert.strictEqual(2, mockLogger.log.callCount);
         assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User user2 is not in the forced variation map.');
@@ -74,7 +73,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return null if the user does not meet audience conditions', function () {
-        assert.isNull(decisionServiceInstance.getVariation('testExperimentWithAudiences', 'user3', {foo: 'bar'}));
+        assert.isNull(decisionServiceInstance.getVariation(configObj, 'testExperimentWithAudiences', 'user3', {foo: 'bar'}));
         assert.strictEqual(7, mockLogger.log.callCount);
         assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User user3 is not in the forced variation map.');
         assert.strictEqual(mockLogger.log.args[1][1], 'DECISION_SERVICE: Evaluating audiences for experiment "testExperimentWithAudiences": ["11154"].');
@@ -83,7 +82,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return null if the experiment is not running', function () {
-        assert.isNull(decisionServiceInstance.getVariation('testExperimentNotRunning', 'user1'));
+        assert.isNull(decisionServiceInstance.getVariation(configObj, 'testExperimentNotRunning', 'user1'));
         sinon.assert.notCalled(bucketerStub);
         assert.strictEqual(1, mockLogger.log.callCount);
         assert.strictEqual(mockLogger.log.args[0][1], 'DECISION_SERVICE: Experiment testExperimentNotRunning is not running.');
@@ -100,7 +99,7 @@ describe('lib/core/decision_service', function() {
             },
           };
 
-          assert.strictEqual('variation', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user', attributes));
+          assert.strictEqual('variation', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user', attributes));
           sinon.assert.notCalled(bucketerStub);
         });
       });
@@ -118,7 +117,6 @@ describe('lib/core/decision_service', function() {
           };
 
           decisionServiceInstance = DecisionService.createDecisionService({
-            configObj: configObj,
             logger: mockLogger,
             userProfileService: userProfileServiceInstance,
           });
@@ -143,7 +141,7 @@ describe('lib/core/decision_service', function() {
             },
           });
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.notCalled(bucketerStub);
           assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -157,7 +155,7 @@ describe('lib/core/decision_service', function() {
             experiment_bucket_map: {},
           });
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub);
           // make sure we save the decision
@@ -175,7 +173,7 @@ describe('lib/core/decision_service', function() {
           bucketerStub.returns('111128'); // ID of the 'control' variation
           userProfileLookupStub.returns(null);
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub);
           // make sure we save the decision
@@ -200,7 +198,7 @@ describe('lib/core/decision_service', function() {
             },
           });
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub);
           assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -223,7 +221,7 @@ describe('lib/core/decision_service', function() {
             experiment_bucket_map: {}, // no decisions for user
           });
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub);
           assert.strictEqual(4, mockLogger.log.callCount);
@@ -243,7 +241,7 @@ describe('lib/core/decision_service', function() {
           bucketerStub.returns('111128'); // ID of the 'control' variation
           userProfileLookupStub.throws(new Error('I am an error'));
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub); // should still go through with bucketing
           assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -255,7 +253,7 @@ describe('lib/core/decision_service', function() {
           userProfileLookupStub.returns(null);
           userProfileSaveStub.throws(new Error('I am an error'));
 
-          assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user'));
+          assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user'));
           sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
           sinon.assert.calledOnce(bucketerStub); // should still go through with bucketing
 
@@ -294,7 +292,7 @@ describe('lib/core/decision_service', function() {
             };
 
 
-            assert.strictEqual('variation', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user', attributes));
+            assert.strictEqual('variation', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user', attributes));
             sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
             sinon.assert.notCalled(bucketerStub);
             assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -319,7 +317,7 @@ describe('lib/core/decision_service', function() {
               },
             };
 
-            assert.strictEqual('control', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user', attributes));
+            assert.strictEqual('control', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user', attributes));
             sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
             sinon.assert.notCalled(bucketerStub);
             assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -344,7 +342,7 @@ describe('lib/core/decision_service', function() {
               },
             };
 
-            assert.strictEqual('variation', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user', attributes));
+            assert.strictEqual('variation', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user', attributes));
             sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
             sinon.assert.notCalled(bucketerStub);
             assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -362,7 +360,7 @@ describe('lib/core/decision_service', function() {
               },
             };
 
-            assert.strictEqual('variation', decisionServiceInstance.getVariation('testExperiment', 'decision_service_user', attributes));
+            assert.strictEqual('variation', decisionServiceInstance.getVariation(configObj, 'testExperiment', 'decision_service_user', attributes));
             sinon.assert.calledWith(userProfileLookupStub, 'decision_service_user');
             sinon.assert.notCalled(bucketerStub);
             assert.strictEqual(mockLogger.log.args[0][1], 'PROJECT_CONFIG: User decision_service_user is not in the forced variation map.');
@@ -374,7 +372,7 @@ describe('lib/core/decision_service', function() {
 
     describe('__buildBucketerParams', function () {
       it('should return params object with correct properties', function () {
-        var bucketerParams = decisionServiceInstance.__buildBucketerParams('testExperiment', 'testUser', 'testUser');
+        var bucketerParams = decisionServiceInstance.__buildBucketerParams(configObj, 'testExperiment', 'testUser', 'testUser');
 
         var expectedParams = {
           bucketingId: 'testUser',
@@ -405,12 +403,12 @@ describe('lib/core/decision_service', function() {
 
     describe('__checkIfExperimentIsActive', function () {
       it('should return true if experiment is running', function () {
-        assert.isTrue(decisionServiceInstance.__checkIfExperimentIsActive('testExperiment', 'testUser'));
+        assert.isTrue(decisionServiceInstance.__checkIfExperimentIsActive(configObj, 'testExperiment', 'testUser'));
         sinon.assert.notCalled(mockLogger.log);
       });
 
       it('should return false when experiment is not running', function () {
-        assert.isFalse(decisionServiceInstance.__checkIfExperimentIsActive('testExperimentNotRunning', 'testUser'));
+        assert.isFalse(decisionServiceInstance.__checkIfExperimentIsActive(configObj, 'testExperimentNotRunning', 'testUser'));
         sinon.assert.calledOnce(mockLogger.log);
         var logMessage = mockLogger.log.args[0][1];
         assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.EXPERIMENT_NOT_RUNNING, 'DECISION_SERVICE', 'testExperimentNotRunning'));
@@ -429,14 +427,14 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return true when audience conditions are met', function () {
-        assert.isTrue(decisionServiceInstance.__checkIfUserIsInAudience('testExperimentWithAudiences', 'testUser', {browser_type: 'firefox'}));
+        assert.isTrue(decisionServiceInstance.__checkIfUserIsInAudience(configObj, 'testExperimentWithAudiences', 'testUser', {browser_type: 'firefox'}));
         assert.strictEqual(4, mockLogger.log.callCount);
         assert.strictEqual(mockLogger.log.args[0][1], 'DECISION_SERVICE: Evaluating audiences for experiment "testExperimentWithAudiences": ["11154"].');
         assert.strictEqual(mockLogger.log.args[3][1], 'DECISION_SERVICE: Audiences for experiment testExperimentWithAudiences collectively evaluated to TRUE.');
       });
 
       it('should return true when experiment has no audience', function () {
-        assert.isTrue(decisionServiceInstance.__checkIfUserIsInAudience('testExperiment', 'testUser'));
+        assert.isTrue(decisionServiceInstance.__checkIfUserIsInAudience(configObj, 'testExperiment', 'testUser'));
         assert.isTrue(__audienceEvaluateSpy.alwaysReturned(true));
 
         assert.strictEqual(2, mockLogger.log.callCount);
@@ -445,7 +443,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return false when audience conditions can not be evaluated', function() {
-        assert.isFalse(decisionServiceInstance.__checkIfUserIsInAudience('testExperimentWithAudiences', 'testUser'));
+        assert.isFalse(decisionServiceInstance.__checkIfUserIsInAudience(configObj, 'testExperimentWithAudiences', 'testUser'));
         assert.isTrue(__audienceEvaluateSpy.alwaysReturned(false));
 
         assert.strictEqual(6, mockLogger.log.callCount);
@@ -455,7 +453,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return false when audience conditions are not met', function () {
-        assert.isFalse(decisionServiceInstance.__checkIfUserIsInAudience('testExperimentWithAudiences', 'testUser', {browser_type: 'chrome'}));
+        assert.isFalse(decisionServiceInstance.__checkIfUserIsInAudience(configObj, 'testExperimentWithAudiences', 'testUser', {browser_type: 'chrome'}));
         assert.isTrue(__audienceEvaluateSpy.alwaysReturned(false));
 
         assert.strictEqual(5, mockLogger.log.callCount);
@@ -479,6 +477,7 @@ describe('lib/core/decision_service', function() {
     });
   });
 
+  // TODO: Move tests that test methods of Optimizely to lib/optimizely/index.tests.js
   describe('when a bucketingID is provided', function() {
     var configObj = projectConfig.createProjectConfig(testData);
     var createdLogger = logger.createLogger({
@@ -597,12 +596,12 @@ describe('lib/core/decision_service', function() {
       });
 
       var decisionServiceInstance = DecisionService.createDecisionService({
-        configObj: configObj,
         logger: createdLogger,
         userProfileService: userProfileServiceInstance,
       });
 
       assert.strictEqual('control', decisionServiceInstance.getVariation(
+          configObj,
           'testExperiment',
           'test_user',
           userAttributesWithBucketingId
@@ -629,7 +628,6 @@ describe('lib/core/decision_service', function() {
       sinon.stub(mockLogger, 'log');
       configObj = projectConfig.createProjectConfig(testData);
       decisionService = DecisionService.createDecisionService({
-        configObj: configObj,
         logger: mockLogger,
       });
     });
@@ -667,7 +665,6 @@ describe('lib/core/decision_service', function() {
         sandbox = sinon.sandbox.create();
         sandbox.stub(mockLogger, 'log');
         decisionServiceInstance = DecisionService.createDecisionService({
-          configObj: configObj,
           logger: mockLogger,
         });
       });
@@ -687,11 +684,11 @@ describe('lib/core/decision_service', function() {
           beforeEach(function() {
             getVariationStub = sandbox.stub(decisionServiceInstance, 'getVariation');
             getVariationStub.returns(null);
-            getVariationStub.withArgs('testing_my_feature', 'user1').returns('variation');
+            getVariationStub.withArgs(configObj, 'testing_my_feature', 'user1').returns('variation');
           });
 
           it('returns a decision with a variation in the experiment the feature is attached to', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1', {
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1', {
               test_attribute: 'test_value',
             });
             var expectedDecision = {
@@ -830,7 +827,7 @@ describe('lib/core/decision_service', function() {
             };
             assert.deepEqual(decision, expectedDecision);
             sinon.assert.calledWithExactly(mockLogger.log, LOG_LEVEL.DEBUG, 'DECISION_SERVICE: User user1 is in variation variation of experiment testing_my_feature on the feature test_feature_for_experiment.');
-            sinon.assert.calledWithExactly(getVariationStub, 'testing_my_feature', 'user1', {
+            sinon.assert.calledWithExactly(getVariationStub, configObj, 'testing_my_feature', 'user1', {
               test_attribute: 'test_value',
             });
           });
@@ -844,7 +841,7 @@ describe('lib/core/decision_service', function() {
           });
 
           it('returns a decision with no variation and source rollout', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
             var expectedDecision = {
               experiment: null,
               variation: null,
@@ -867,11 +864,11 @@ describe('lib/core/decision_service', function() {
           beforeEach(function() {
             getVariationStub = sandbox.stub(decisionServiceInstance, 'getVariation');
             getVariationStub.returns(null);
-            getVariationStub.withArgs('exp_with_group', 'user1').returns('var');
+            getVariationStub.withArgs(configObj, 'exp_with_group', 'user1').returns('var');
           });
 
           it('returns a decision with a variation in an experiment in a group', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
             var expectedDecision = {
               experiment: {
                 'forcedVariations': {},
@@ -916,7 +913,7 @@ describe('lib/core/decision_service', function() {
           });
 
           it('returns a decision with no experiment, no variation and source rollout', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
             var expectedDecision = {
               experiment: null,
               variation: null,
@@ -928,7 +925,7 @@ describe('lib/core/decision_service', function() {
 
           it('returns null decision for group experiment not referenced by the feature', function() {
             var noTrafficExpFeature = configObj.featureKeyMap.feature_exp_no_traffic;
-            var decision = decisionServiceInstance.getVariationForFeature(noTrafficExpFeature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, noTrafficExpFeature, 'user1');
             var expectedDecision = {
               experiment: null,
               variation: null,
@@ -947,7 +944,7 @@ describe('lib/core/decision_service', function() {
           });
 
           it('returns a decision with no experiment, no variation and source rollout', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
             var expectedDecision = {
               experiment: null,
               variation: null,
@@ -974,7 +971,7 @@ describe('lib/core/decision_service', function() {
 
           it('returns a decision with a variation and experiment from the audience targeting rule', function() {
             var attributes = { test_attribute: 'test_value' };
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1', attributes);
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1', attributes);
             var expectedDecision = {
               experiment: {
                 'forcedVariations': {},
@@ -1072,7 +1069,7 @@ describe('lib/core/decision_service', function() {
 
           it('returns a decision with a variation and experiment from the everyone else targeting rule', function() {
             var attributes = {};
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1', attributes);
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1', attributes);
             var expectedDecision = {
               experiment: {
                 'forcedVariations': {},
@@ -1169,7 +1166,7 @@ describe('lib/core/decision_service', function() {
           });
 
           it('returns a decision with no variation, no experiment and source rollout', function() {
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
             var expectedDecision = {
               experiment: null,
               variation: null,
@@ -1191,7 +1188,7 @@ describe('lib/core/decision_service', function() {
 
           it('returns a decision with a variation and experiment from the everyone else targeting rule', function() {
             var attributes = { test_attribute: 'test_value' };
-            var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1', attributes);
+            var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1', attributes);
             var expectedDecision = {
               experiment: {
                 'forcedVariations': {},
@@ -1298,7 +1295,7 @@ describe('lib/core/decision_service', function() {
         it('can bucket a user into the rollout when the user is not bucketed into the experiment', function() {
           // No attributes passed, so user is not in the audience for the experiment
           // It should fall through to the rollout
-          var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+          var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
           var expectedDecision = {
             experiment: {
               'trafficAllocation': [
@@ -1379,7 +1376,7 @@ describe('lib/core/decision_service', function() {
         });
 
         it('returns a decision with no variation, no experiment and source rollout', function() {
-          var decision = decisionServiceInstance.getVariationForFeature(feature, 'user1');
+          var decision = decisionServiceInstance.getVariationForFeature(configObj, feature, 'user1');
           var expectedDecision = {
             experiment: null,
             variation: null,
@@ -1403,7 +1400,6 @@ describe('lib/core/decision_service', function() {
         configObj = projectConfig.createProjectConfig(testDataWithFeatures);
         feature = configObj.featureKeyMap.test_feature;
         decisionService = DecisionService.createDecisionService({
-          configObj: configObj,
           logger: logger.createLogger({logLevel: LOG_LEVEL.INFO}),
         });
         __buildBucketerParamsSpy = sinon.spy(decisionService, '__buildBucketerParams');
@@ -1415,11 +1411,11 @@ describe('lib/core/decision_service', function() {
 
       it('should call __buildBucketerParams with user Id when bucketing Id is not provided in the attributes', function () {
         var attributes = { test_attribute: 'test_value' };
-        decisionService._getVariationForRollout(feature, 'testUser', attributes);
+        decisionService._getVariationForRollout(configObj, feature, 'testUser', attributes);
 
         sinon.assert.callCount(__buildBucketerParamsSpy, 2);
-        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, '594031', 'testUser', 'testUser');
-        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, '594037', 'testUser', 'testUser');
+        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, configObj, '594031', 'testUser', 'testUser');
+        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, configObj, '594037', 'testUser', 'testUser');
       });
 
       it('should call __buildBucketerParams with bucketing Id when bucketing Id is provided in the attributes', function () {
@@ -1427,11 +1423,11 @@ describe('lib/core/decision_service', function() {
           test_attribute: 'test_value',
           $opt_bucketing_id: 'abcdefg'
         };
-        decisionService._getVariationForRollout(feature, 'testUser', attributes);
+        decisionService._getVariationForRollout(configObj, feature, 'testUser', attributes);
 
         sinon.assert.callCount(__buildBucketerParamsSpy, 2);
-        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, '594031', 'abcdefg', 'testUser');
-        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, '594037', 'abcdefg', 'testUser');
+        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, configObj, '594031', 'abcdefg', 'testUser');
+        sinon.assert.calledWithExactly(__buildBucketerParamsSpy, configObj, '594037', 'abcdefg', 'testUser');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -105,7 +105,6 @@ function Optimizely(config) {
   }
 
   this.decisionService = decisionService.createDecisionService({
-    configObj: this.configObj,
     userProfileService: userProfileService,
     logger: this.logger,
   });
@@ -344,7 +343,7 @@ Optimizely.prototype.getVariation = function(experimentKey, userId, attributes) 
         return null;
       }
 
-      var variationKey = this.decisionService.getVariation(experimentKey, userId, attributes);
+      var variationKey = this.decisionService.getVariation(this.configObj, experimentKey, userId, attributes);
       this.notificationCenter.sendNotifications(
         NOTIFICATION_TYPES.DECISION,
         {
@@ -505,7 +504,7 @@ Optimizely.prototype.isFeatureEnabled = function(featureKey, userId, attributes)
     var featureEnabled = false;
     var experimentKey = null;
     var variationKey = null;
-    var decision = this.decisionService.getVariationForFeature(feature, userId, attributes);
+    var decision = this.decisionService.getVariationForFeature(this.configObj, feature, userId, attributes);
     var variation = decision.variation;
     
     if (!!variation) {
@@ -634,7 +633,7 @@ Optimizely.prototype._getFeatureVariableForType = function(featureKey, variableK
     return null;
   }
 
-  var decision = this.decisionService.getVariationForFeature(featureFlag, userId, attributes);
+  var decision = this.decisionService.getVariationForFeature(this.configObj, featureFlag, userId, attributes);
   var variableValue;
   if (decision.variation !== null) {
     variableValue = projectConfig.getVariableValueForVariation(

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -236,7 +236,6 @@ describe('lib/optimizely', function() {
           });
 
           sinon.assert.calledWith(decisionService.createDecisionService, {
-            configObj: optlyInstance.configObj,
             userProfileService: userProfileServiceInstance,
             logger: createdLogger,
           });
@@ -260,7 +259,6 @@ describe('lib/optimizely', function() {
           });
 
           sinon.assert.calledWith(decisionService.createDecisionService, {
-            configObj: optlyInstance.configObj,
             userProfileService: null,
             logger: createdLogger,
           });
@@ -2425,7 +2423,7 @@ describe('lib/optimizely', function() {
               }
             });
           });
-  
+
           it('should send notification with null variation key when getVariation returns null', function() {
             var variation = optlyInstance.getVariation('testExperimentWithAudiences', 'testUser', {});
             assert.isNull(variation);
@@ -2770,6 +2768,7 @@ describe('lib/optimizely', function() {
             var feature = optlyInstance.configObj.featureKeyMap.test_feature_for_experiment;
             sinon.assert.calledWithExactly(
               optlyInstance.decisionService.getVariationForFeature,
+              optlyInstance.configObj,
               feature,
               'user1',
               attributes
@@ -2939,6 +2938,7 @@ describe('lib/optimizely', function() {
             var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
             sinon.assert.calledWithExactly(
               optlyInstance.decisionService.getVariationForFeature,
+              optlyInstance.configObj,
               feature,
               'user1',
               attributes
@@ -3022,6 +3022,7 @@ describe('lib/optimizely', function() {
             var feature = optlyInstance.configObj.featureKeyMap.shared_feature;
             sinon.assert.calledWithExactly(
               optlyInstance.decisionService.getVariationForFeature,
+              optlyInstance.configObj,
               feature,
               'user1',
               attributes


### PR DESCRIPTION
## Summary

In preparation for datafile management, change decision service so that the `configObj` is not passed into the constructor. Instead, every method that needs `configObj` accepts it as an argument.

## Test plan

Updated unit tests and compatibility suite.

## Issues
https://optimizely.atlassian.net/browse/OASIS-4383
