### PR TITLE
Marking activate listener as deprecated and preparing for 3.1.0 release

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
-## [3.1.0] - April 19th, 2019
+## [3.1.0] - April 22nd, 2019
 
 ### New Features:
 

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [3.1.0] - April 19th, 2019
+
+### New Features:
+
+- Introduced Decision notification listener to be able to record:
+    - Variation assignments for users activated in an experiment.
+    - Feature access for users.
+    - Feature variable value for users.
+
+### Changed
+
+* New APIs for setting `logger` and `logLevel` on the optimizelySDK singleton ([#232](https://github.com/optimizely/javascript-sdk/pull/232))
+* `logger` and `logLevel` are now set globally for all instances of Optimizely.  If you were passing
+different loggers to individual instances of Optimizely, logging behavior may now be different.
+
+#### Setting a ConsoleLogger
+
+```js
+var optimizelySDK = require('@optimizely/optimizely-sdk')
+
+// logger and logLevel are now set on the optimizelySDK singleton
+optimizelySDK.setLogger(optimizelySDK.logging.createLogger())
+
+// valid levels: 'DEBUG', 'INFO', 'WARN', 'ERROR'
+optimizelySDK.setLogLevel('WARN')
+// enums can also be used
+optimizelySDK.setLogLevel(optimizely.enums.LOG_LEVEL.ERROR)
+```
+
+#### Disable logging
+
+```js
+var optimizelySDK = require('@optimizely/optimizely-sdk')
+
+optimizelySDK.setLogger(null)
+```
+
+### Bug Fixes
+
+* Feature variable APIs now return default variable value when featureEnabled property is false. ([#249](https://github.com/optimizely/javascript-sdk/pull/249))
+
+### Deprecated
+
+* Activate notification listener is deprecated as of this release. Recommendation is to use the new Decision notification listener. Activate notification listener will be removed in the next major release.
+
+
 ## [3.1.0-beta1] - March 5th, 2019
 
 ### Changed

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -33,7 +33,7 @@ optimizelySDK.setLogger(optimizelySDK.logging.createLogger())
 // valid levels: 'DEBUG', 'INFO', 'WARN', 'ERROR'
 optimizelySDK.setLogLevel('WARN')
 // enums can also be used
-optimizelySDK.setLogLevel(optimizely.enums.LOG_LEVEL.ERROR)
+optimizelySDK.setLogLevel(optimizelySDK.enums.LOG_LEVEL.ERROR)
 ```
 
 #### Disable logging

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -112,7 +112,7 @@ describe('javascript-sdk', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.1.0-beta1');
+        assert.equal(optlyInstance.clientVersion, '3.1.0');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -84,7 +84,7 @@ describe('optimizelyFactory', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.1.0-beta1');
+        assert.equal(optlyInstance.clientVersion, '3.1.0');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -152,7 +152,7 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
-exports.NODE_CLIENT_VERSION = '3.1.0-beta1';
+exports.NODE_CLIENT_VERSION = '3.1.0';
 
 /*
  * Notification types for use with NotificationCenter
@@ -160,6 +160,7 @@ exports.NODE_CLIENT_VERSION = '3.1.0-beta1';
  *
  * SDK consumers can use these to register callbacks with the notification center.
  *
+ *  @deprecated since 3.1.0
  *  ACTIVATE: An impression event will be sent to Optimizely
  *  Callbacks will receive an object argument with the following properties:
  *    - experiment {Object}
@@ -168,6 +169,14 @@ exports.NODE_CLIENT_VERSION = '3.1.0-beta1';
  *    - variation {Object}
  *    - logEvent {Object}
  *
+ *  DECISION: A decision is made in the system. i.e. user activation,
+ *  feature access or feature-variable value retrieval
+ *  Callbacks will receive an object argument with the following properties:
+ *    - type {string}
+ *    - userId {string}
+ *    - attributes {Object|undefined}
+ *    - decisionInfo {Object|undefined}
+ *
  *  TRACK: A conversion event will be sent to Optimizely
  *  Callbacks will receive the an object argument with the following properties:
  *    - eventKey {string}
@@ -175,18 +184,11 @@ exports.NODE_CLIENT_VERSION = '3.1.0-beta1';
  *    - attributes {Object|undefined}
  *    - eventTags {Object|undefined}
  *    - logEvent {Object}
- *  DECISION: A decision is made in the system. i.e. user activation, 
- *  feature access or feature-variable value retrieval
- *  Callbacks will receive an object argument with the following properties:
- *    - type {string}
- *    - userId {string}
- *    - attributes {Object|undefined}
- *    - decisionInfo {Object|undefined}
  */
 exports.NOTIFICATION_TYPES = {
   ACTIVATE: 'ACTIVATE:experiment, user_id,attributes, variation, event',
-  TRACK: 'TRACK:event_key, user_id, attributes, event_tags, event',
   DECISION: 'DECISION:type, userId, attributes, decisionInfo',
+  TRACK: 'TRACK:event_key, user_id, attributes, event_tags, event',
 };
 
 exports.DECISION_NOTIFICATION_TYPES = {

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.1.0-beta1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.1.0-beta1",
+  "version": "3.1.0",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
- Marking activate listener as deprecated in favor of decision listener.
- Updating CHANGELOG for 3.1.0 release.