### PR TITLE
fix (datafile management): Update polling behavior

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -9,6 +9,9 @@ Changes that have landed but are not yet released.
 
 ### Changed
 - Changed value for node in engines in package.json from >=4.0.0 to >=6.0.0
+- Updated polling behavior:
+  - Start update interval timer immediately after request
+  - When update interval timer fires during request, wait until request completes, then immediately start next request
 
 ## [0.2.0] - April 9, 2019
 


### PR DESCRIPTION
## Summary
- When `autoUpdate` is `true`, start the timer for the following request immediately, instead of waiting for the response to start the timer
- When the timeout fires before the response is received, wait for the response to complete and then start the next request immediately. This ensures there is at most 1 request in flight at any time.

## Test plan

Added new unit tests. Manually tested.

## Issues
https://optimizely.atlassian.net/browse/OASIS-4628
