### PR TITLE
fix (datafile management): Clear timeout created in onReady method when it's no longer needed

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Bug Fixes:
+- Clear timeout created in onReady call for timeout promise as soon as project config manager's ready promise fulfills
+
 ### New Features
 - Added 60 second timeout for all datafile requests
 

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -936,6 +936,11 @@ Optimizely.prototype.onReady = function(options) {
     onClose: onClose,
   };
 
+  this.__readyPromise.then(function() {
+    clearTimeout(readyTimeout);
+    delete this.__readyTimeouts[timeoutId];
+  }.bind(this));
+
   return Promise.race([this.__readyPromise, timeoutPromise]);
 };
 

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -939,6 +939,9 @@ Optimizely.prototype.onReady = function(options) {
   this.__readyPromise.then(function() {
     clearTimeout(readyTimeout);
     delete this.__readyTimeouts[timeoutId];
+    resolveTimeoutPromise({
+      success: true,
+    });
   }.bind(this));
 
   return Promise.race([this.__readyPromise, timeoutPromise]);


### PR DESCRIPTION
## Summary
`onReady` sets a timeout that fulfills a timeout promise. The timeout promise is only used to race against the ready promise provided by `ProjectConfigManager`. So, as soon as `ProjectConfigManager`'s ready promise is fulfilled, the timeout can be cleared. Before this change, the timeout would only be cleared in the `close` method.

## Test plan

Manual & added unit test