### PR TITLE
Allow react-sdk to be passed in as clientEngine

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -93,9 +93,10 @@ module.exports = {
         hasRetriedEvents = true;
       }
 
-      config = fns.assignIn({}, config, {
-        eventDispatcher: wrappedEventDispatcher,
+      config = fns.assignIn({
         clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
+      }, config, {
+        eventDispatcher: wrappedEventDispatcher,
         // always get the OptimizelyLogger facade from logging
         logger: logger,
         errorHandler: logging.getErrorHandler(),

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -135,6 +135,32 @@ describe('javascript-sdk', function() {
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
       });
 
+      it('should allow passing of "react-sdk" as the clientEngine', function() {
+        var optlyInstance = optimizelyFactory.createInstance({
+          clientEngine: 'react-sdk',
+          datafile: {},
+          errorHandler: fakeErrorHandler,
+          eventDispatcher: fakeEventDispatcher,
+          logger: silentLogger,
+        });
+        // Invalid datafile causes onReady Promise rejection - catch this error
+        optlyInstance.onReady().catch(function() {});
+        assert.equal('react-sdk', optlyInstance.clientEngine);
+      });
+
+      it('should allow passing of "react-sdk" as the clientEngine', function() {
+        var optlyInstance = optimizelyFactory.createInstance({
+          clientEngine: 'react-sdk',
+          datafile: {},
+          errorHandler: fakeErrorHandler,
+          eventDispatcher: fakeEventDispatcher,
+          logger: silentLogger,
+        });
+        // Invalid datafile causes onReady Promise rejection - catch this error
+        optlyInstance.onReady().catch(function() {});
+        assert.equal('react-sdk', optlyInstance.clientEngine);
+      });
+
       it('should activate with provided event dispatcher', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           datafile: testData.getTestProjectConfig(),

--- a/packages/optimizely-sdk/lib/index.node.js
+++ b/packages/optimizely-sdk/lib/index.node.js
@@ -86,13 +86,13 @@ module.exports = {
 
       config = fns.assign(
         {
+          clientEngine: enums.NODE_CLIENT_ENGINE,
           eventDispatcher: defaultEventDispatcher,
           jsonSchemaValidator: jsonSchemaValidator,
           skipJSONValidation: false,
         },
         config,
         {
-          clientEngine: enums.NODE_CLIENT_ENGINE,
           // always get the OptimizelyLogger facade from logging
           logger: logger,
           errorHandler: logging.getErrorHandler(),

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -58,7 +58,7 @@ var DEFAULT_ONREADY_TIMEOUT = 30000;
  */
 function Optimizely(config) {
   var clientEngine = config.clientEngine;
-  if (clientEngine !== enums.NODE_CLIENT_ENGINE && clientEngine !== enums.JAVASCRIPT_CLIENT_ENGINE) {
+  if (enums.VALID_CLIENT_ENGINES.indexOf(clientEngine) === -1) {
     config.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.INVALID_CLIENT_ENGINE, MODULE_NAME, clientEngine));
     clientEngine = enums.NODE_CLIENT_ENGINE;
   }

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -128,6 +128,18 @@ describe('lib/optimizely', function() {
         assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_CLIENT_ENGINE, 'OPTIMIZELY', 'undefined'));
       });
 
+      it('should allow passing `react-sdk` as the clientEngine', function() {
+        var instance = new Optimizely({
+          clientEngine: 'react-sdk',
+          datafile: testData.getTestProjectConfig(),
+          errorHandler: stubErrorHandler,
+          eventDispatcher: stubEventDispatcher,
+          logger: createdLogger,
+        });
+
+        assert.strictEqual(instance.clientEngine, 'react-sdk');
+      });
+
       describe('when a user profile service is provided', function() {
         beforeEach(function() {
           sinon.stub(decisionService, 'createDecisionService');

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -154,7 +154,14 @@ exports.CONTROL_ATTRIBUTES = {
 
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
+exports.REACT_CLIENT_ENGINE = 'react-sdk';
 exports.NODE_CLIENT_VERSION = '3.2.0-beta';
+
+exports.VALID_CLIENT_ENGINES = [
+  exports.NODE_CLIENT_ENGINE,
+  exports.REACT_CLIENT_ENGINE,
+  exports.JAVASCRIPT_CLIENT_ENGINE,
+];
 
 /*
  * Notification types for use with NotificationCenter


### PR DESCRIPTION
## Summary
- Prepare for ReactSDK `0.3.0` release which will happen after javascript-sdk `3.2.0` is released.

## Test plan
- Unit tests

## Issues
- OASIS-4762
