### PR TITLE
Use event processor defaults only when config undefined

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -109,8 +109,8 @@ function Optimizely(config) {
 
   this.eventProcessor = new eventProcessor.LogTierV1EventProcessor({
     dispatcher: this.eventDispatcher,
-    flushInterval: config.eventFlushInterval || DEFAULT_EVENT_FLUSH_INTERVAL,
-    maxQueueSize: config.eventBatchSize || DEFAULT_EVENT_MAX_QUEUE_SIZE,
+    flushInterval: config.eventFlushInterval !== undefined ? config.eventFlushInterval : DEFAULT_EVENT_FLUSH_INTERVAL,
+    maxQueueSize: config.eventBatchSize !== undefined ? config.eventBatchSize : DEFAULT_EVENT_MAX_QUEUE_SIZE,
   });
   this.eventProcessor.start();
 

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -4771,6 +4771,71 @@ describe('lib/optimizely', function() {
     });
   });
 
+  describe('event processor defaults', function() {
+    var createdLogger = logger.createLogger({
+      logLevel: LOG_LEVEL.INFO,
+      logToConsole: false,
+    });
+
+    beforeEach(function() {
+      sinon.stub(eventDispatcher, 'dispatchEvent');
+      sinon.stub(errorHandler, 'handleError');
+      sinon.stub(createdLogger, 'log');
+      sinon.spy(eventProcessor, 'LogTierV1EventProcessor');
+    });
+
+    afterEach(function() {
+      eventDispatcher.dispatchEvent.restore();
+      errorHandler.handleError.restore();
+      createdLogger.log.restore();
+      eventProcessor.LogTierV1EventProcessor.restore();
+    });
+
+    var optlyInstance;
+
+    describe('when eventFlushInterval and maxQueueSize is not defined', function() {
+      it('should not instantiate the eventProcessor with the default event flush interval', function() {
+        optlyInstance = new Optimizely({
+          clientEngine: 'node-sdk',
+          errorHandler: errorHandler,
+          eventDispatcher: eventDispatcher,
+          jsonSchemaValidator: jsonSchemaValidator,
+          logger: createdLogger,
+          sdkKey: '12345',
+          isValidInstance: true,
+        });
+
+        sinon.assert.calledWithExactly(eventProcessor.LogTierV1EventProcessor, {
+          dispatcher: eventDispatcher,
+          flushInterval: 5000,
+          maxQueueSize: 1,
+        });
+      });
+    });
+
+    describe('when eventFlushInterval and maxQueueSize are both defined', function() {
+      it('should not instantiate the eventProcessor with the default event flush interval', function() {
+        optlyInstance = new Optimizely({
+          clientEngine: 'node-sdk',
+          errorHandler: errorHandler,
+          eventDispatcher: eventDispatcher,
+          jsonSchemaValidator: jsonSchemaValidator,
+          logger: createdLogger,
+          sdkKey: '12345',
+          isValidInstance: true,
+          eventFlushInterval: 50,
+          eventBatchSize: 100,
+        });
+
+        sinon.assert.calledWithExactly(eventProcessor.LogTierV1EventProcessor, {
+          dispatcher: eventDispatcher,
+          flushInterval: 50,
+          maxQueueSize: 100,
+        });
+      });
+    });
+  });
+
   describe('project config management', function() {
     var createdLogger = logger.createLogger({
       logLevel: LOG_LEVEL.INFO,

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -22,6 +22,7 @@ var projectConfigManager = require('../core/project_config/project_config_manage
 var enums = require('../utils/enums');
 var eventBuilder = require('../core/event_builder/index.js');
 var eventDispatcher = require('../plugins/event_dispatcher/index.node');
+var eventProcessor = require('@optimizely/js-sdk-event-processor');
 var errorHandler = require('../plugins/error_handler');
 var fns = require('../utils/fns');
 var jsonSchemaValidator = require('../utils/json_schema_validator');
@@ -4790,8 +4791,6 @@ describe('lib/optimizely', function() {
       createdLogger.log.restore();
       eventProcessor.LogTierV1EventProcessor.restore();
     });
-
-    var optlyInstance;
 
     describe('when eventFlushInterval and maxQueueSize is not defined', function() {
       it('should not instantiate the eventProcessor with the default event flush interval', function() {


### PR DESCRIPTION
## Summary
- Before the event processor used the default values if config value was falsy, thus not respecting `0`

## Test plan
- Added unit tests