### PR TITLE
try/catch when parsing the eventDispatcher callback response

### DIFF
--- a/packages/event-processor/src/eventDispatcher.ts
+++ b/packages/event-processor/src/eventDispatcher.ts
@@ -17,6 +17,8 @@ import { EventV1 } from "./v1/buildEventV1";
 
 export type EventDispatcherResponse = {
   statusCode: number
+} | {
+  status: number
 }
 
 export type EventDispatcherCallback = (response: EventDispatcherResponse) => void

--- a/packages/event-processor/src/eventProcessor.ts
+++ b/packages/event-processor/src/eventProcessor.ts
@@ -169,8 +169,18 @@ export abstract class AbstractEventProcessor implements EventProcessor {
 }
 
 function isResponseSuccess(response: EventDispatcherResponse): boolean {
-  if (!response.statusCode) {
+  try {
+    let statusCode: number
+    if ('statusCode' in response) {
+      statusCode = response.statusCode
+    } else if ('status' in response) {
+      statusCode = response.status
+    } else {
+      return false
+    }
+
+    return statusCode >= 200 && statusCode < 300
+  } catch (e) {
     return false
   }
-  return response.statusCode >= 200 && response.statusCode < 300
 }


### PR DESCRIPTION
## Summary
- There is a problem right now if you implement your own `eventDispatcher` but dont invoke `callback` with the `response` object, becuase the `eventProcessor` is expecting a `Response` object with `statusCode`.

This change loosens what it expects and also wont throw an error (to be caught by the promise) when invoking `callback()` in a custom event dispatcher

