### PR TITLE
Dont use pendingEventsDispatcher with user defined eventDispatcher

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -85,18 +85,26 @@ module.exports = {
         config.skipJSONValidation = true;
       }
 
-      var wrappedEventDispatcher = new eventProcessor.LocalStoragePendingEventsDispatcher({
-        eventDispatcher: config.eventDispatcher || defaultEventDispatcher,
-      });
-      if (!hasRetriedEvents) {
-        wrappedEventDispatcher.sendPendingEvents();
-        hasRetriedEvents = true;
+      var eventDispatcher;
+      // prettier-ignore
+      if (config.eventDispatcher == null) { // eslint-disable-line eqeqeq
+        // only wrap the event dispatcher with pending events retry if the user didnt override
+        eventDispatcher = new eventProcessor.LocalStoragePendingEventsDispatcher({
+          eventDispatcher: defaultEventDispatcher,
+        });
+
+        if (!hasRetriedEvents) {
+          eventDispatcher.sendPendingEvents();
+          hasRetriedEvents = true;
+        }
+      } else {
+        eventDispatcher = config.eventDispatcher;
       }
 
       config = fns.assignIn({
         clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
       }, config, {
-        eventDispatcher: wrappedEventDispatcher,
+        eventDispatcher: eventDispatcher,
         // always get the OptimizelyLogger facade from logging
         logger: logger,
         errorHandler: logging.getErrorHandler(),

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -88,7 +88,7 @@ describe('javascript-sdk', function() {
       });
 
       describe('when an eventDispatcher is passed in', function() {
-        it('should wrap the default eventDispatcher and invoke sendPendingEvents', function() {
+        it('should NOT wrap the default eventDispatcher and invoke sendPendingEvents', function() {
           var optlyInstance = optimizelyFactory.createInstance({
             datafile: {},
             errorHandler: fakeErrorHandler,

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -62,7 +62,7 @@ describe('javascript-sdk', function() {
           requests.push(req);
         };
 
-        sinon.spy(LocalStoragePendingEventsDispatcher.prototype, 'sendPendingEvents');
+        sinon.stub(LocalStoragePendingEventsDispatcher.prototype, 'sendPendingEvents');
       });
 
       afterEach(function() {
@@ -73,11 +73,39 @@ describe('javascript-sdk', function() {
         xhr.restore();
       });
 
+      describe('when an eventDispatcher is not passed in', function() {
+        it('should wrap the default eventDispatcher and invoke sendPendingEvents', function() {
+          var optlyInstance = optimizelyFactory.createInstance({
+            datafile: {},
+            errorHandler: fakeErrorHandler,
+            logger: silentLogger,
+          });
+          // Invalid datafile causes onReady Promise rejection - catch this error
+          optlyInstance.onReady().catch(function() {});
+
+          sinon.assert.calledOnce(LocalStoragePendingEventsDispatcher.prototype.sendPendingEvents);
+        });
+      });
+
+      describe('when an eventDispatcher is passed in', function() {
+        it('should wrap the default eventDispatcher and invoke sendPendingEvents', function() {
+          var optlyInstance = optimizelyFactory.createInstance({
+            datafile: {},
+            errorHandler: fakeErrorHandler,
+            eventDispatcher: fakeEventDispatcher,
+            logger: silentLogger,
+          });
+          // Invalid datafile causes onReady Promise rejection - catch this error
+          optlyInstance.onReady().catch(function() {});
+
+          sinon.assert.notCalled(LocalStoragePendingEventsDispatcher.prototype.sendPendingEvents);
+        });
+      });
+
       it('should invoke resendPendingEvents at most once', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           datafile: {},
           errorHandler: fakeErrorHandler,
-          eventDispatcher: fakeEventDispatcher,
           logger: silentLogger,
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
@@ -88,7 +116,6 @@ describe('javascript-sdk', function() {
         optlyInstance = optimizelyFactory.createInstance({
           datafile: {},
           errorHandler: fakeErrorHandler,
-          eventDispatcher: fakeEventDispatcher,
           logger: silentLogger,
         });
         optlyInstance.onReady().catch(function() {});


### PR DESCRIPTION
## Summary
The is an edge case where the `sendPendingEvents()` mechanism keeps sending events because a custom eventDispatcher never invoked the `callback()` denoting the request completed.  This leads to events piling up in localStorage and sending every event each time the SDK is initialized.  

To prevent this only use the pendingEventDispatcher if the default event dispatcher is used, since this guarantees the callback is properly called.

## Test plan
- Added unit tests

## Issues
- OASIS-4887
