### PR TITLE
fix (datafile manager) [OASIS-4715]: Rename top-level exports to avoid conflict with interface name

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Changed
+- Changed name of top-level exports in index.node.ts and index.browser.ts from DatafileManager to HttpPollingDatafileManager, to avoid name conflict with DatafileManager interface
+
 ## [0.3.0] - May 13, 2019
 
 ### New Features

--- a/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
+++ b/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import HTTPPollingDatafileManager from '../src/httpPollingDatafileManager'
+import HttpPollingDatafileManager from '../src/httpPollingDatafileManager'
 import { Headers, AbortableRequest, Response } from '../src/http'
 import { DatafileManagerConfig } from '../src/datafileManager';
 import { advanceTimersByTime, getTimerCount } from './testUtils'
@@ -34,7 +34,7 @@ import BackoffController from '../src/backoffController'
 
 // Test implementation:
 //   - Does not make any real requests: just resolves with queued responses (tests push onto queuedResponses)
-class TestDatafileManager extends HTTPPollingDatafileManager {
+class TestDatafileManager extends HttpPollingDatafileManager {
   queuedResponses: (Response | Error)[] = []
 
   responsePromises: Promise<Response>[] = []

--- a/packages/datafile-manager/src/httpPollingDatafileManager.ts
+++ b/packages/datafile-manager/src/httpPollingDatafileManager.ts
@@ -34,7 +34,7 @@ function isSuccessStatusCode(statusCode: number): boolean {
   return statusCode >= 200 && statusCode < 400
 }
 
-export default abstract class HTTPPollingDatafileManager implements DatafileManager {
+export default abstract class HttpPollingDatafileManager implements DatafileManager {
   // Make an HTTP get request to the given URL with the given headers
   // Return an AbortableRequest, which has a promise for a Response.
   // If we can't get a response, the promise is rejected.
@@ -208,7 +208,7 @@ export default abstract class HTTPPollingDatafileManager implements DatafileMana
     }
   }
 
-  private onRequestComplete(this: HTTPPollingDatafileManager): void {
+  private onRequestComplete(this: HttpPollingDatafileManager): void {
     if (!this.isStarted) {
       return
     }

--- a/packages/datafile-manager/src/index.browser.ts
+++ b/packages/datafile-manager/src/index.browser.ts
@@ -15,5 +15,5 @@
  */
 
 export * from './datafileManager'
-export { default as DatafileManager } from './browserDatafileManager'
+export { default as HttpPollingDatafileManager } from './browserDatafileManager'
 export { default as StaticDatafileManager } from './staticDatafileManager';

--- a/packages/datafile-manager/src/index.node.ts
+++ b/packages/datafile-manager/src/index.node.ts
@@ -15,5 +15,5 @@
  */
 
 export * from './datafileManager'
-export { default as DatafileManager } from './nodeDatafileManager'
+export { default as HttpPollingDatafileManager } from './nodeDatafileManager'
 export { default as StaticDatafileManager } from './staticDatafileManager';


### PR DESCRIPTION
## Summary
The interface `DatafileManager`, defined in [src/datafileManager.ts](https://github.com/optimizely/javascript-sdk/blob/d0ac8821a99dd98a5bd36495d78eb39c4b136f92/packages/datafile-manager/src/datafileManager.ts#L32), is exported from [src/index.node.ts](https://github.com/optimizely/javascript-sdk/blob/d0ac8821a99dd98a5bd36495d78eb39c4b136f92/packages/datafile-manager/src/index.node.ts#L17) and [src/index.browser.ts](https://github.com/optimizely/javascript-sdk/blob/d0ac8821a99dd98a5bd36495d78eb39c4b136f92/packages/datafile-manager/src/index.browser.ts#L17).

However, in each of these top-level entry points, [another export statement](https://github.com/optimizely/javascript-sdk/blob/d0ac8821a99dd98a5bd36495d78eb39c4b136f92/packages/datafile-manager/src/index.browser.ts#L18) appears below, which exports something else (the actual implementation of the datafile manager), using the same name.

To avoid the name conflict, we rename the exports of the datafile manager implementations from `DatafileManager` to `HttpPollingDatafileManager`.

## Test plan

Updated unit tests

## Issues
https://optimizely.atlassian.net/browse/OASIS-4715