### PR TITLE
chore (datafile management): Update js-sdk-datafile-manager dependency to v0.4.0

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
@@ -125,7 +125,7 @@ ProjectConfigManager.prototype.__initialize = function(config) {
     if (initialDatafile && this.__configObj) {
       datafileManagerConfig.datafile = initialDatafile;
     }
-    this.datafileManager = new datafileManager.DatafileManager(datafileManagerConfig);
+    this.datafileManager = new datafileManager.HttpPollingDatafileManager(datafileManagerConfig);
     this.datafileManager.start();
     this.__readyPromise = this.datafileManager.onReady().then(
       this.__onDatafileManagerReadyFulfill.bind(this),

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
@@ -31,7 +31,7 @@ var LOG_MESSAGES = enums.LOG_MESSAGES;
 describe('lib/core/project_config/project_config_manager', function() {
   var globalStubErrorHandler;
   beforeEach(function() {
-    sinon.stub(datafileManager, 'DatafileManager').returns({
+    sinon.stub(datafileManager, 'HttpPollingDatafileManager').returns({
       start: sinon.stub(),
       stop: sinon.stub(),
       get: sinon.stub().returns(null),
@@ -50,7 +50,7 @@ describe('lib/core/project_config/project_config_manager', function() {
   });
 
   afterEach(function() {
-    datafileManager.DatafileManager.restore();
+    datafileManager.HttpPollingDatafileManager.restore();
     logging.resetErrorHandler();
     logging.resetLogger();
   });
@@ -187,8 +187,8 @@ describe('lib/core/project_config/project_config_manager', function() {
           updateInterval: 10000,
         },
       });
-      sinon.assert.calledOnce(datafileManager.DatafileManager);
-      sinon.assert.calledWithExactly(datafileManager.DatafileManager, sinon.match({
+      sinon.assert.calledOnce(datafileManager.HttpPollingDatafileManager);
+      sinon.assert.calledWithExactly(datafileManager.HttpPollingDatafileManager, sinon.match({
         datafile: testData.getTestProjectConfig(),
         sdkKey: '12345',
         autoUpdate: true,
@@ -199,7 +199,7 @@ describe('lib/core/project_config/project_config_manager', function() {
     describe('when constructed with sdkKey and without datafile', function() {
       it('updates itself when the datafile manager is ready, fulfills its onReady promise with a successful result, and then emits updates', function() {
         var configWithFeatures = testData.getTestProjectConfigWithFeatures();
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(configWithFeatures),
@@ -231,7 +231,7 @@ describe('lib/core/project_config/project_config_manager', function() {
             variations: [{ key: 'variation', id: '99977477477747747' }],
           });
           nextDatafile.revision = '36';
-          var fakeDatafileManager = datafileManager.DatafileManager.getCall(0).returnValue;
+          var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
           fakeDatafileManager.get.returns(nextDatafile);
           var updateListener = fakeDatafileManager.on.getCall(0).args[1];
           updateListener({ datafile: nextDatafile });
@@ -243,7 +243,7 @@ describe('lib/core/project_config/project_config_manager', function() {
       });
 
       it('calls onUpdate listeners after becoming ready, and after the datafile manager emits updates', function() {
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(testData.getTestProjectConfigWithFeatures()),
@@ -258,7 +258,7 @@ describe('lib/core/project_config/project_config_manager', function() {
         return manager.onReady().then(function() {
           sinon.assert.calledOnce(onUpdateSpy);
 
-          var fakeDatafileManager = datafileManager.DatafileManager.getCall(0).returnValue;
+          var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
           var updateListener = fakeDatafileManager.on.getCall(0).args[1];
           var newDatafile = testData.getTestProjectConfigWithFeatures();
           newDatafile.revision = '36';
@@ -270,7 +270,7 @@ describe('lib/core/project_config/project_config_manager', function() {
       });
 
       it('can remove onUpdate listeners using the function returned from onUpdate', function() {
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(testData.getTestProjectConfigWithFeatures()),
@@ -284,7 +284,7 @@ describe('lib/core/project_config/project_config_manager', function() {
           var onUpdateSpy = sinon.spy();
           var unsubscribe = manager.onUpdate(onUpdateSpy);
 
-          var fakeDatafileManager = datafileManager.DatafileManager.getCall(0).returnValue;
+          var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
           var updateListener = fakeDatafileManager.on.getCall(0).args[1];
           var newDatafile = testData.getTestProjectConfigWithFeatures();
           newDatafile.revision = '36';
@@ -308,7 +308,7 @@ describe('lib/core/project_config/project_config_manager', function() {
       it('fulfills its ready promise with an unsuccessful result when the datafile manager emits an invalid datafile', function() {
         var invalidDatafile = testData.getTestProjectConfig();
         delete invalidDatafile['projectId'];
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(invalidDatafile),
@@ -327,7 +327,7 @@ describe('lib/core/project_config/project_config_manager', function() {
       });
 
       it('fullfils its ready promise with an unsuccessful result when the datafile manager onReady promise rejects', function() {
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(null),
@@ -350,13 +350,13 @@ describe('lib/core/project_config/project_config_manager', function() {
           sdkKey: '12345',
         });
         manager.stop();
-        sinon.assert.calledOnce(datafileManager.DatafileManager.getCall(0).returnValue.stop);
+        sinon.assert.calledOnce(datafileManager.HttpPollingDatafileManager.getCall(0).returnValue.stop);
       });
     });
 
     describe('when constructed with sdkKey and with a valid datafile object', function() {
       it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners after becoming ready', function() {
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(testData.getTestProjectConfigWithFeatures()),
@@ -383,7 +383,7 @@ describe('lib/core/project_config/project_config_manager', function() {
 
     describe('when constructed with sdkKey and with a valid datafile string', function() {
       it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners after becoming ready', function() {
-        datafileManager.DatafileManager.returns({
+        datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
           get: sinon.stub().returns(testData.getTestProjectConfigWithFeatures()),

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@optimizely/js-sdk-datafile-manager": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.3.0.tgz",
-      "integrity": "sha512-Jidj/T30Me8TdmPiAx3dGY7xan2eN/EFgmfCwxMXuLoxtHI1dAKAi5PvCOYNHzFUOadhl0WN9KBIFmZVrXsLAg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.4.0.tgz",
+      "integrity": "sha512-olkXopZBaf6CPOfd9AKFEPjJ422S0IRnPa8S7Xx6EVoXYFvi+ButzJLHbHopFnMfAxKYPPs3owAW6V5feGnaVQ==",
       "requires": {
         "@optimizely/js-sdk-logging": "^0.1.0",
         "@optimizely/js-sdk-utils": "^0.1.0"

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/optimizely-sdk",
   "dependencies": {
-    "@optimizely/js-sdk-datafile-manager": "^0.3.0",
+    "@optimizely/js-sdk-datafile-manager": "^0.4.0",
     "@optimizely/js-sdk-event-processor": "^0.2.1",
     "@optimizely/js-sdk-logging": "^0.1.0",
     "@optimizely/js-sdk-utils": "^0.1.0",


### PR DESCRIPTION
## Summary
Update js-sdk-datafile-manager dependency to v0.4.0, in which the export `DatafileManager` is renamed to `HttpPollingDatafileManager`.

## Test plan

Updated unit tests. Manually tested.

## Issues
https://optimizely.atlassian.net/browse/OASIS-4715
