### PR TITLE
Add onpagehide event automatically in browser

### DIFF
--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -138,6 +138,7 @@ exports.LOG_MESSAGES = {
   UNKNOWN_MATCH_TYPE: '%s: Audience condition %s uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.',
   UPDATED_OPTIMIZELY_CONFIG: '%s: Updated Optimizely config to revision %s (project id %s)',
   OUT_OF_BOUNDS: '%s: Audience condition %s evaluated to UNKNOWN because the number value for user attribute "%s" is not in the range [-2^53, +2^53].',
+  UNABLE_TO_ATTACH_UNLOAD: '%s: unable to bind optimizely.close() to page unload event: "%s"',
 };
 
 exports.RESERVED_EVENT_KEYWORDS = {


### PR DESCRIPTION
## Summary
With event batching, `optimizely.close()` needs to be called to ensure that events are flushed before the user navigates away.  This PR ensures that optimizely.close() is called when the page unloads by hooking into the `pagehide` event or the `unload` event.

## Test plan
- Added a UMD bundle test, but this should be tested manually as well.
