### PR TITLE
feat(event processor)[OASIS-4921] Return Promise from close method representing the close process

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### New Features
+- Updated the `close` method to return a `Promise` representing the process of closing the instance. When `close` is called, any events waiting to be sent as part of a batched event request will be immediately batched and sent to the event dispatcher.
+  - If any such requests were sent to the event dispatcher, `close` returns a `Promise` that fulfills after the event dispatcher calls the response callback for each request. Otherwise, `close` returns an immediately-fulfilled `Promise`.
+  - The `Promise` returned from `close` is fulfilled with a result object containing `success` (boolean) and `reason` (string, only when success is `false`) properties. In the result object, `success` is `true` if all events in the queue at the time close was called were combined into requests, sent to the event dispatcher, and the event dispatcher called the callbacks for each request. `success` is false if an unexpected error was encountered during the close process.
+
 ## [3.2.1] - July 1st, 2019
 
 ### Changed

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -894,16 +894,19 @@ Optimizely.prototype.close = function() {
       readyTimeoutRecord.onClose();
     }.bind(this));
     this.__readyTimeouts = {};
-    return eventProcessorStoppedPromise.then(function() {
-      return {
-        success: true,
-      };
-    }).catch(function(err) {
-      return {
-        success: false,
-        reason: String(err),
-      };
-    });
+    return eventProcessorStoppedPromise.then(
+      function() {
+        return {
+          success: true,
+        };
+      },
+      function(err) {
+        return {
+          success: false,
+          reason: String(err),
+        };
+      }
+    );
   } catch (err) {
     this.logger.log(LOG_LEVEL.ERROR, err.message);
     this.errorHandler.handleError(err);

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -857,12 +857,14 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  * - Pending event queue flushes
  *
  * In-flight datafile requests will be aborted. Any events waiting to be sent
- * as part of a batched event request will be immediately batched and sent.
+ * as part of a batched event request will be immediately batched and sent to
+ * the event dispatcher.
  *
- * Returns a Promise that fulfills after the response is received from the final
- * batched event request (if any)
+ * If any such requests were sent to the event dispatcher, returns a Promise
+ * that fulfills after the event dispatcher calls the response callback for each
+ * request. Otherwise, returns an immediately-fulfilled Promise.
  *
- * The returned Promise is fulfilled with a result object containing these
+ * Returned Promises are fulfilled with result objects containing these
  * properties:
  *    - success (boolean): True if all events in the queue at the time close was
  *                         called were combined into requests, sent to the
@@ -873,6 +875,8 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  *
  * NOTE: After close is called, this instance is no longer usable. Any events
  * generated will not be sent.
+ *
+ * TODO: Implement a configurable timeout, so that the returned promise can't remain pending forever
  *
  * @return {Promise}
  */

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -876,8 +876,6 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  * NOTE: After close is called, this instance is no longer usable. Any events
  * generated will not be sent.
  *
- * TODO: Implement a configurable timeout, so that the returned promise can't remain pending forever
- *
  * @return {Promise}
  */
 Optimizely.prototype.close = function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -850,7 +850,31 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
 };
 
 /**
- * Cleanup method for killing an running timers and flushing eventQueue
+ * Stop background processes belonging to this instance, including:
+ *
+ * - Active datafile requests
+ * - Pending datafile requests
+ * - Pending event queue flushes
+ *
+ * In-flight datafile requests will be aborted. Any events waiting to be sent
+ * as part of a batched event request will be immediately batched and sent.
+ *
+ * Returns a Promise that fulfills after the response is received from the final
+ * batched event request (if any)
+ *
+ * The returned Promise is fulfilled with a result object containing these
+ * properties:
+ *    - success (boolean): True if all events in the queue at the time close was
+ *                         called were combined into requests, sent to the
+ *                         event dispatcher, and the event dispatcher called the
+ *                         callbacks for each request.
+ *    - reason (string=):  If success is false, this is a string property with
+ *                         an explanatory message.
+ *
+ * NOTE: After close is called, this instance is no longer usable. Any events
+ * generated will not be sent.
+ *
+ * @return {Promise}
  */
 Optimizely.prototype.close = function() {
   try {

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -873,8 +873,8 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  *    - reason (string=):  If success is false, this is a string property with
  *                         an explanatory message.
  *
- * NOTE: After close is called, this instance is no longer usable. Any events
- * generated will not be sent.
+ * NOTE: After close is called, this instance is no longer usable - any events
+ * generated will no longer be sent to the event dispatcher.
  *
  * @return {Promise}
  */

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -866,10 +866,11 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  *
  * Returned Promises are fulfilled with result objects containing these
  * properties:
- *    - success (boolean): True if all events in the queue at the time close was
+ *    - success (boolean): true if all events in the queue at the time close was
  *                         called were combined into requests, sent to the
  *                         event dispatcher, and the event dispatcher called the
- *                         callbacks for each request.
+ *                         callbacks for each request. false if an unexpected
+ *                         error was encountered during the close process.
  *    - reason (string=):  If success is false, this is a string property with
  *                         an explanatory message.
  *

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -4709,6 +4709,7 @@ describe('lib/optimizely', function() {
 
         optlyInstance.track('testEvent', 'testUser');
 
+
         sinon.assert.notCalled(eventDispatcher.dispatchEvent);
 
         optlyInstance.close();

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -4523,6 +4523,7 @@ describe('lib/optimizely', function() {
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
       sinon.stub(uuid, 'v4').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
+
       clock = sinon.useFakeTimers(new Date().getTime());
     });
 
@@ -4701,7 +4702,7 @@ describe('lib/optimizely', function() {
         assert.deepEqual(eventDispatcherCall[0], expectedObj);
       });
 
-      it('should flush the queue when optimizely.close() is called', function(done) {
+      it('should flush the queue when optimizely.close() is called', function() {
         bucketStub.returns('111129');
         var activate = optlyInstance.activate('testExperiment', 'testUser');
         assert.strictEqual(activate, 'variation');
@@ -4710,7 +4711,7 @@ describe('lib/optimizely', function() {
 
         sinon.assert.notCalled(eventDispatcher.dispatchEvent);
 
-        var closedPromise = optlyInstance.close();
+        optlyInstance.close();
 
         sinon.assert.calledOnce(eventDispatcher.dispatchEvent);
 
@@ -4764,15 +4765,6 @@ describe('lib/optimizely', function() {
         };
         var eventDispatcherCall = eventDispatcher.dispatchEvent.args[0];
         assert.deepEqual(eventDispatcherCall[0], expectedObj);
-
-        // Responding to the dispatched event request should fulfill the close promise
-        eventDispatcherCall[1]({ statusCode: 200 });
-        setTimeout(function() {
-          closedPromise.then(function() {
-            done();
-          });
-        });
-        clock.tick(1);
       });
     });
 
@@ -4953,11 +4945,9 @@ describe('lib/optimizely', function() {
         sdkKey: '12345',
         isValidInstance: true,
       });
-      var closedPromise = optlyInstance.close();
+      optlyInstance.close();
       var fakeManager = projectConfigManager.ProjectConfigManager.getCall(0).returnValue;
       sinon.assert.calledOnce(fakeManager.stop);
-
-      return closedPromise;
     });
 
     describe('when no datafile is available yet ', function() {
@@ -5084,12 +5074,11 @@ describe('lib/optimizely', function() {
           isValidInstance: true,
         });
         var readyPromise = optlyInstance.onReady({ timeout: 100 });
-        var closedPromise = optlyInstance.close();
+        optlyInstance.close();
         return readyPromise.then(function(result) {
           assert.include(result, {
             success: false,
           });
-          return closedPromise;
         });
       });
 
@@ -5113,8 +5102,8 @@ describe('lib/optimizely', function() {
         }).then(function() {
           // readyPromise3 has not resolved yet because only 201 ms have elapsed.
           // Calling close on the instance should resolve readyPromise3
-          var closedPromise = optlyInstance.close();
-          return Promise.all([readyPromise3, closedPromise]);
+          optlyInstance.close();
+          return readyPromise3;
         });
       });
 


### PR DESCRIPTION
## Summary
The `close` method flushes the event processor's queue. If the queue was non-empty, requests will be sent to the event dispatcher. Users may want to wait until the dispatcher finishes sending these, so we return a `Promise` that fulfills after the event dispatcher calls the "done" callback for each request.

The event processor already returns a `Promise` from its `stop` method, so this change is just making use of that.

## Test plan

New unit tests. Manually tested

## Issues
https://optimizely.atlassian.net/browse/OASIS-4921
