### PR TITLE
feat (utils): Add notification types to utils package

### DIFF
--- a/packages/utils/CHANGELOG.MD
+++ b/packages/utils/CHANGELOG.MD
@@ -9,6 +9,7 @@ Changes that have landed but are not yet released.
 
 ### New Features
 - Added `objectEntries`
+- Added `NOTIFICATION_TYPES` and `NotificationCenter`
 
 ## [0.1.0] - March 1, 2019
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -138,8 +138,9 @@ export function sprintf(format: string, ...args: any[]): string {
  *
  */
 export enum NOTIFICATION_TYPES {
-  ACTIVATE = "ACTIVATE:experiment, user_id,attributes, variation, event",
-  DECISION = "DECISION:type, userId, attributes, decisionInfo",
-  OPTIMIZELY_CONFIG_UPDATE = "OPTIMIZELY_CONFIG_UPDATE",
-  TRACK = "TRACK:event_key, user_id, attributes, event_tags, event"
+  ACTIVATE = 'ACTIVATE:experiment, user_id,attributes, variation, event',
+  DECISION = 'DECISION:type, userId, attributes, decisionInfo',
+  LOG_EVENT = 'LOG_EVENT:logEvent',
+  OPTIMIZELY_CONFIG_UPDATE = 'OPTIMIZELY_CONFIG_UPDATE',
+  TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -126,7 +126,7 @@ export function sprintf(format: string, ...args: any[]): string {
  *    - decisionInfo {Object|undefined}
  *
  *  LOG_EVENT: A batch of events, which could contain impressions and/or conversions,
- *  was sent to Optimizely
+ *  will be sent to Optimizely
  *  Callbacks will receive an object argument with the following properties:
  *    - url {string}
  *    - httpVerb {string}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -125,6 +125,13 @@ export function sprintf(format: string, ...args: any[]): string {
  *    - attributes {Object|undefined}
  *    - decisionInfo {Object|undefined}
  *
+ *  LOG_EVENT: A batch of events, which could contain impressions and/or conversions,
+ *  was sent to Optimizely
+ *  Callbacks will receive an object argument with the following properties:
+ *    - url {string}
+ *    - httpVerb {string}
+ *    - params {object}
+ *
  *  OPTIMIZELY_CONFIG_UPDATE: This Optimizely instance has been updated with a new
  *  config
  *

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -130,7 +130,7 @@ export function sprintf(format: string, ...args: any[]): string {
  *  Callbacks will receive an object argument with the following properties:
  *    - url {string}
  *    - httpVerb {string}
- *    - params {object}
+ *    - params {Object}
  *
  *  OPTIMIZELY_CONFIG_UPDATE: This Optimizely instance has been updated with a new
  *  config

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -102,3 +102,44 @@ export function sprintf(format: string, ...args: any[]): string {
     }
   })
 }
+/*
+ * Notification types for use with NotificationCenter
+ * Format is EVENT: <list of parameters to callback>
+ *
+ * SDK consumers can use these to register callbacks with the notification center.
+ *
+ *  @deprecated since 3.1.0
+ *  ACTIVATE: An impression event will be sent to Optimizely
+ *  Callbacks will receive an object argument with the following properties:
+ *    - experiment {Object}
+ *    - userId {string}
+ *    - attributes {Object|undefined}
+ *    - variation {Object}
+ *    - logEvent {Object}
+ *
+ *  DECISION: A decision is made in the system. i.e. user activation,
+ *  feature access or feature-variable value retrieval
+ *  Callbacks will receive an object argument with the following properties:
+ *    - type {string}
+ *    - userId {string}
+ *    - attributes {Object|undefined}
+ *    - decisionInfo {Object|undefined}
+ *
+ *  OPTIMIZELY_CONFIG_UPDATE: This Optimizely instance has been updated with a new
+ *  config
+ *
+ *  TRACK: A conversion event will be sent to Optimizely
+ *  Callbacks will receive the an object argument with the following properties:
+ *    - eventKey {string}
+ *    - userId {string}
+ *    - attributes {Object|undefined}
+ *    - eventTags {Object|undefined}
+ *    - logEvent {Object}
+ *
+ */
+export enum NOTIFICATION_TYPES {
+  ACTIVATE = "ACTIVATE:experiment, user_id,attributes, variation, event",
+  DECISION = "DECISION:type, userId, attributes, decisionInfo",
+  OPTIMIZELY_CONFIG_UPDATE = "OPTIMIZELY_CONFIG_UPDATE",
+  TRACK = "TRACK:event_key, user_id, attributes, event_tags, event"
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -151,3 +151,7 @@ export enum NOTIFICATION_TYPES {
   OPTIMIZELY_CONFIG_UPDATE = 'OPTIMIZELY_CONFIG_UPDATE',
   TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
 }
+
+export interface NotificationCenter {
+  sendNotifications(notificationType: NOTIFICATION_TYPES, notificationData?: any): void
+}


### PR DESCRIPTION
## Summary

This PR adds two exports from the utils package:
-  `NOTIFICATION_TYPES`, an `enum`
- `NotificationCenter`, an `interface`.

I want this package to be the home of notification types and the notification center interface, to facilitate using notification center in both the optimizely-sdk package and the event-processor package.

Also, I added a new `LOG_EVENT` notification type. I plan to use this in the event processor when implementing the requirement in OASIS-4976.

## Test plan

Manually tested

## Issues

https://optimizely.atlassian.net/browse/OASIS-4976
