### PR TITLE
fix(event processor): Flush current batch when event with different context received

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -13,6 +13,7 @@ Changes that have landed but are not yet released.
 
 ### Changed
 - Removed transformers, interceptors, and callbacks from `AbstractEventProcessor`
+- Removed grouping events by context and dispatching one event per group at flush time. Instead, only maintain one group and flush immediately when an incompatible event is processed.
 
 ## [0.2.1] - June 6, 2019
 

--- a/packages/event-processor/__tests__/eventQueue.spec.ts
+++ b/packages/event-processor/__tests__/eventQueue.spec.ts
@@ -149,7 +149,7 @@ describe('eventQueue', () => {
       queue.stop()
     })
 
-    it('should invoke the sink function when an event incompatable with the current batch (according to batchComparator) is received', () => {
+    it('should invoke the sink function when an item incompatable with the current batch (according to batchComparator) is received', () => {
       const sinkFn = jest.fn()
       const queue = new DefaultEventQueue<number>({
         flushInterval: 100,

--- a/packages/event-processor/__tests__/eventQueue.spec.ts
+++ b/packages/event-processor/__tests__/eventQueue.spec.ts
@@ -56,6 +56,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: -1,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       queue.start()
@@ -76,6 +77,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 0,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       queue.start()
@@ -96,6 +98,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 3,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       queue.start()
@@ -123,6 +126,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       queue.start()
@@ -145,12 +149,33 @@ describe('eventQueue', () => {
       queue.stop()
     })
 
+    it('should invoke the sink function when an event incompatable with the current batch (according to batchComparator) is received', () => {
+      const sinkFn = jest.fn()
+      const queue = new DefaultEventQueue<number>({
+        flushInterval: 100,
+        maxQueueSize: 100,
+        sink: sinkFn,
+        batchComparator: (n1, n2) => (n1 % 2) === (n2 % 2)
+      })
+
+      queue.start()
+
+      queue.enqueue(2)
+      queue.enqueue(4)
+      expect(sinkFn).not.toHaveBeenCalled()
+
+      queue.enqueue(3)
+      expect(sinkFn).toHaveBeenCalledTimes(1)
+      expect(sinkFn).toHaveBeenCalledWith([2, 4])
+    })
+
     it('stop() should flush the existing queue and call timer.stop()', () => {
       const sinkFn = jest.fn()
       const queue = new DefaultEventQueue<number>({
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       jest.spyOn(queue.timer, 'stop')
@@ -174,6 +199,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       jest.spyOn(queue.timer, 'refresh')
@@ -196,6 +222,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       expect(queue.stop()).toBe(promise)
@@ -207,6 +234,7 @@ describe('eventQueue', () => {
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
+        batchComparator: () => true
       })
 
       queue.start()

--- a/packages/event-processor/__tests__/eventQueue.spec.ts
+++ b/packages/event-processor/__tests__/eventQueue.spec.ts
@@ -151,22 +151,26 @@ describe('eventQueue', () => {
 
     it('should invoke the sink function when an item incompatable with the current batch (according to batchComparator) is received', () => {
       const sinkFn = jest.fn()
-      const queue = new DefaultEventQueue<number>({
+      const queue = new DefaultEventQueue<string>({
         flushInterval: 100,
         maxQueueSize: 100,
         sink: sinkFn,
-        batchComparator: (n1, n2) => (n1 % 2) === (n2 % 2)
+        // This batchComparator returns true when the argument strings start with the same letter
+        batchComparator: (s1, s2) => s1[0] === s2[0]
       })
 
       queue.start()
 
-      queue.enqueue(2)
-      queue.enqueue(4)
+      queue.enqueue('a1')
+      queue.enqueue('a2')
+      // After enqueuing these strings, both starting with 'a', the sinkFn should not yet be called. Thus far all the items enqueued are
+      // compatible according to the batchComparator.
       expect(sinkFn).not.toHaveBeenCalled()
 
-      queue.enqueue(3)
+      // Enqueuing a string starting with 'b' should cause the sinkFn to be called
+      queue.enqueue('b1')
       expect(sinkFn).toHaveBeenCalledTimes(1)
-      expect(sinkFn).toHaveBeenCalledWith([2, 4])
+      expect(sinkFn).toHaveBeenCalledWith(['a1', 'a2'])
     })
 
     it('stop() should flush the existing queue and call timer.stop()', () => {

--- a/packages/event-processor/__tests__/v1EventProcessor.spec.ts
+++ b/packages/event-processor/__tests__/v1EventProcessor.spec.ts
@@ -297,6 +297,9 @@ describe('LogTierV1EventProcessor', () => {
       const conversionEvent = createConversionEvent()
       const impressionEvent2 = createImpressionEvent()
 
+      // createImpressionEvent and createConversionEvent create events with revision '1'
+      // We modify this one's revision to '2' in order to test that the queue is flushed
+      // when an event with a different revision is processed.
       impressionEvent2.context.revision = '2'
 
       processor.process(impressionEvent1)

--- a/packages/event-processor/__tests__/v1EventProcessor.spec.ts
+++ b/packages/event-processor/__tests__/v1EventProcessor.spec.ts
@@ -353,7 +353,6 @@ describe('LogTierV1EventProcessor', () => {
         httpVerb: 'POST',
         params: makeBatchedEventV1([impressionEvent2]),
       })
-
     })
 
     it('should flush the queue when the flush interval happens', () => {

--- a/packages/event-processor/__tests__/v1EventProcessor.spec.ts
+++ b/packages/event-processor/__tests__/v1EventProcessor.spec.ts
@@ -291,26 +291,30 @@ describe('LogTierV1EventProcessor', () => {
       })
     })
 
-    it("should flush two batches if the event context isn't the same", () => {
+    it("should flush the current batch when it receives an event with a different context than the current batch", async () => {
       const impressionEvent1 = createImpressionEvent()
-      const impressionEvent2 = createImpressionEvent()
       const conversionEvent = createConversionEvent()
+      const impressionEvent2 = createImpressionEvent()
 
       impressionEvent2.context.revision = '2'
 
       processor.process(impressionEvent1)
-      processor.process(impressionEvent2)
+      processor.process(conversionEvent)
 
       expect(dispatchStub).toHaveBeenCalledTimes(0)
 
-      processor.process(conversionEvent)
+      processor.process(impressionEvent2)
 
-      expect(dispatchStub).toHaveBeenCalledTimes(2)
+      expect(dispatchStub).toHaveBeenCalledTimes(1)
       expect(dispatchStub).toHaveBeenCalledWith({
         url: 'https://logx.optimizely.com/v1/events',
         httpVerb: 'POST',
         params: makeBatchedEventV1([impressionEvent1, conversionEvent]),
       })
+
+      await processor.stop()
+
+      expect(dispatchStub).toHaveBeenCalledTimes(2)
 
       expect(dispatchStub).toHaveBeenCalledWith({
         url: 'https://logx.optimizely.com/v1/events',

--- a/packages/event-processor/src/eventProcessor.ts
+++ b/packages/event-processor/src/eventProcessor.ts
@@ -67,6 +67,12 @@ export abstract class AbstractEventProcessor implements EventProcessor {
   drainQueue(buffer: ProcessableEvents[]): Promise<void> {
     return new Promise(resolve => {
       logger.debug('draining queue with %s events', buffer.length)
+
+      if (buffer.length === 0) {
+        resolve()
+        return
+      }
+
       this.dispatcher.dispatchEvent(this.formatEvents(buffer), () => {
         resolve()
       })

--- a/packages/event-processor/src/eventProcessor.ts
+++ b/packages/event-processor/src/eventProcessor.ts
@@ -93,7 +93,7 @@ export abstract class AbstractEventProcessor implements EventProcessor {
       }
 
       const formattedEvent = this.formatEvents(buffer)
-      this.dispatcher.dispatchEvent(this.formatEvents(buffer), () => {
+      this.dispatcher.dispatchEvent(formattedEvent, () => {
         resolve()
       })
       if (this.notificationCenter) {

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -80,3 +80,9 @@ export interface ConversionEvent extends BaseEvent {
 export type EventTags = {
   [key: string]: string | number | null
 }
+
+export function areEventContextsEqual(eventA: BaseEvent, eventB: BaseEvent): boolean {
+  return Object.keys(eventA.context).every(
+    contextKey => eventA.context[contextKey] === eventB.context[contextKey],
+  )
+}

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -82,12 +82,15 @@ export type EventTags = {
 }
 
 export function areEventContextsEqual(eventA: BaseEvent, eventB: BaseEvent): boolean {
-  const eventAContextKeys = Object.keys(eventA.context)
-  const eventBContextKeys = Object.keys(eventB.context)
-  if (eventAContextKeys.length !== eventBContextKeys.length) {
-    return false
-  }
-  return eventAContextKeys.every(
-    contextKey => eventA.context[contextKey] === eventB.context[contextKey],
+  const contextA = eventA.context
+  const contextB = eventB.context
+  return (
+    contextA.accountId === contextB.accountId &&
+    contextA.projectId === contextB.projectId &&
+    contextA.clientName === contextB.clientName &&
+    contextA.clientVersion === contextB.clientVersion &&
+    contextA.revision === contextB.revision &&
+    contextA.anonymizeIP === contextB.anonymizeIP &&
+    contextA.botFiltering === contextB.botFiltering
   )
 }

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -82,7 +82,12 @@ export type EventTags = {
 }
 
 export function areEventContextsEqual(eventA: BaseEvent, eventB: BaseEvent): boolean {
-  return Object.keys(eventA.context).every(
+  const eventAContextKeys = Object.keys(eventA.context)
+  const eventBContextKeys = Object.keys(eventB.context)
+  if (eventAContextKeys.length !== eventBContextKeys.length) {
+    return false
+  }
+  return eventAContextKeys.every(
     contextKey => eventA.context[contextKey] === eventB.context[contextKey],
   )
 }

--- a/packages/event-processor/src/v1/v1EventProcessor.ts
+++ b/packages/event-processor/src/v1/v1EventProcessor.ts
@@ -1,17 +1,24 @@
-import { groupBy, objectValues } from '@optimizely/js-sdk-utils'
+/**
+ * Copyright 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { AbstractEventProcessor, ProcessableEvents } from '../eventProcessor'
 import { EventV1Request } from '../eventDispatcher'
 import { makeBatchedEventV1 } from './buildEventV1'
 
 export class LogTierV1EventProcessor extends AbstractEventProcessor {
-  private buildGroupByKey(event: ProcessableEvents): string {
-    return objectValues(event.context).join('|')
-  }
-
-  protected groupEvents(events: ProcessableEvents[]): ProcessableEvents[][] {
-    return groupBy(events, event => this.buildGroupByKey(event))
-  }
-
   protected formatEvents(events: ProcessableEvents[]): EventV1Request {
     return {
       url: 'https://logx.optimizely.com/v1/events',


### PR DESCRIPTION
## Summary

Prior to this change, event processor's buffer could contain events with different contexts. At flush time, the buffered events would be grouped by context and a request would be dispatched for each group.

With this change, we introduce an invariant: all events in the buffer share the same context. As soon as an event with different context is received, the queue is flushed. With this restriction, at most one request is dispatched per flush.

- A new comparator function (`batchComparator`) is provided to `DefaultEventQueue`. When enqueuing an event, `batchComparator` is used to determine whether the incoming event can be included into the current batch. If not, we flush.
- `LogTierV1EventProcessor` provides a `batchComparator` when constructing a `DefaultEventQueue` that checks equality of all context properties.
- In `AbstractEventProcessor`, the grouping step is removed from the flush process.

## Test plan

New unit tests. Manually tested.

## Issues
[OASIS-5160](https://optimizely.atlassian.net/browse/OASIS-5160)