### PR TITLE
feat (event processor/pending events dispatcher): In browser entry point, add event listener for pagehide or unload that calls optimizely.close

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -117,17 +117,19 @@ module.exports = {
 
       var optimizely = new Optimizely(config);
 
-      try {
-        var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
-        window.addEventListener(
-          unloadEvent,
-          function() {
-            optimizely.close();
-          },
-          false
-        );
-      } catch (e) {
-        logger.error(enums.LOG_MESSAGES.UNABLE_TO_ATTACH_UNLOAD, MODULE_NAME, e.message);
+      if (typeof window.addEventListener === 'function') {
+        try {
+          var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
+          window.addEventListener(
+            unloadEvent,
+            function() {
+              optimizely.close();
+            },
+            false
+          );
+        } catch (e) {
+          logger.error(enums.LOG_MESSAGES.UNABLE_TO_ATTACH_UNLOAD, MODULE_NAME, e.message);
+        }
       }
 
       return optimizely;

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -117,20 +117,20 @@ module.exports = {
 
       var optimizely = new Optimizely(config);
 
-      if (typeof window.addEventListener === 'function') {
         try {
-          var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
-          window.addEventListener(
-            unloadEvent,
-            function() {
-              optimizely.close();
-            },
-            false
-          );
+          if (typeof window.addEventListener === 'function') {
+            var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
+            window.addEventListener(
+              unloadEvent,
+              function() {
+                optimizely.close();
+              },
+              false
+            );
+          }
         } catch (e) {
           logger.error(enums.LOG_MESSAGES.UNABLE_TO_ATTACH_UNLOAD, MODULE_NAME, e.message);
         }
-      }
 
       return optimizely;
     } catch (e) {

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -29,7 +29,6 @@ var logger = logging.getLogger();
 logging.setLogHandler(loggerPlugin.createLogger());
 logging.setLogLevel(logging.LogLevel.INFO);
 
-
 var MODULE_NAME = 'INDEX_BROWSER';
 
 var DEFAULT_EVENT_BATCH_SIZE = 10;

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -117,20 +117,20 @@ module.exports = {
 
       var optimizely = new Optimizely(config);
 
-        try {
-          if (typeof window.addEventListener === 'function') {
-            var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
-            window.addEventListener(
-              unloadEvent,
-              function() {
-                optimizely.close();
-              },
-              false
-            );
-          }
-        } catch (e) {
-          logger.error(enums.LOG_MESSAGES.UNABLE_TO_ATTACH_UNLOAD, MODULE_NAME, e.message);
+      try {
+        if (typeof window.addEventListener === 'function') {
+          var unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
+          window.addEventListener(
+            unloadEvent,
+            function() {
+              optimizely.close();
+            },
+            false
+          );
         }
+      } catch (e) {
+        logger.error(enums.LOG_MESSAGES.UNABLE_TO_ATTACH_UNLOAD, MODULE_NAME, e.message);
+      }
 
       return optimizely;
     } catch (e) {

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -138,6 +138,7 @@ exports.LOG_MESSAGES = {
   UNKNOWN_MATCH_TYPE: '%s: Audience condition %s uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.',
   UPDATED_OPTIMIZELY_CONFIG: '%s: Updated Optimizely config to revision %s (project id %s)',
   OUT_OF_BOUNDS: '%s: Audience condition %s evaluated to UNKNOWN because the number value for user attribute "%s" is not in the range [-2^53, +2^53].',
+  UNABLE_TO_ATTACH_UNLOAD: '%s: unable to bind optimizely.close() to page unload event: "%s"',
 };
 
 exports.RESERVED_EVENT_KEYWORDS = {


### PR DESCRIPTION
## Summary
With event batching, `optimizely.close()` needs to be called to ensure that events are flushed before the user navigates away.  This PR ensures that optimizely.close() is called when the page unloads by hooking into the `pagehide` event or the `unload` event.

## Test plan
Added a UMD bundle test. Manually tested.