### PR TITLE
chore(optimizely-sdk): Prepare for 3.2.2 release.

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [3.2.2] - August 20th, 2019
+
+### Bug fixes
+- Dont use pendingEventsDispatcher with user defined eventDispatcher ([#289](https://github.com/optimizely/javascript-sdk/issues/289))
+Note: This was supposed to be released in 3.2.1 but did not make it into the release.
+- Updated lodash dependency to ^4.17.11 to address security vulnerabilities ([#296](https://github.com/optimizely/javascript-sdk/issues/296))
+
 ## [3.2.1] - July 1st, 2019
 
 ### Changed

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -146,7 +146,7 @@ describe('javascript-sdk', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.2.1');
+        assert.equal(optlyInstance.clientVersion, '3.2.2');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -90,7 +90,7 @@ describe('optimizelyFactory', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.2.1');
+        assert.equal(optlyInstance.clientVersion, '3.2.2');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -155,7 +155,7 @@ exports.CONTROL_ATTRIBUTES = {
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
 exports.REACT_CLIENT_ENGINE = 'react-sdk';
-exports.NODE_CLIENT_VERSION = '3.2.1';
+exports.NODE_CLIENT_VERSION = '3.2.2';
 
 exports.VALID_CLIENT_ENGINES = [
   exports.NODE_CLIENT_ENGINE,

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
## Summary
- Bumps the version to 3.2.2 
- Updates changelog

