### PR TITLE
fix(event processor): Treat eventFlushInterval 0 as invalid

### DIFF
--- a/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.js
@@ -31,7 +31,7 @@ function validateEventBatchSize(eventBatchSize) {
  * @returns boolean
  */
 function validateEventFlushInterval(eventFlushInterval) {
-  return fns.isFinite(eventFlushInterval) && eventFlushInterval >= 0;
+  return fns.isFinite(eventFlushInterval) && eventFlushInterval > 0;
 }
 
 module.exports = {

--- a/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.tests.js
@@ -38,6 +38,10 @@ describe('utils/event_processor_config_validator', function() {
       assert.isFalse(eventProcessorConfigValidator.validateEventFlushInterval(-1000));
     });
 
+    it('returns false for 0', function() {
+      assert.isFalse(eventProcessorConfigValidator.validateEventFlushInterval(0));
+    });
+
     it('returns true for a positive integer', function() {
       assert.isTrue(eventProcessorConfigValidator.validateEventFlushInterval(30000));
     });


### PR DESCRIPTION
## Summary

When `0` is provided for `eventFlushInterval`, it should be ignored and the default used instead.

## Test plan

New unit test