### PR TITLE
fix(event processor): Stop accepting events after stop is called

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Changed
+- Introduce an explict`DefaultEventQueue` no longer enqueues additional events after being stopped
+
 ## [0.3.0] - August 13, 2019
 
 ### New Features

--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
-### Changed
-- Introduce an explict`DefaultEventQueue` no longer enqueues additional events after being stopped
+### Fixed
+- `DefaultEventQueue` no longer enqueues additional events after being stopped. As a result, `AbstractEventProcessor` no longer processes events after being stopped.
+- `DefaultEventQueue` clears its buffer after being stopped. Event duplication, which was previously possible when additional events were enqueued after the stop, is no longer possible.
 
 ## [0.3.0] - August 13, 2019
 

--- a/packages/event-processor/__tests__/eventQueue.spec.ts
+++ b/packages/event-processor/__tests__/eventQueue.spec.ts
@@ -266,5 +266,25 @@ describe('eventQueue', () => {
       queue.stop()
 
     })
+
+    it('should not enqueue additional events after stop() is called', () => {
+      const sinkFn = jest.fn()
+      const queue = new DefaultEventQueue<number>({
+        flushInterval: 30000,
+        maxQueueSize: 3,
+        sink: sinkFn,
+        batchComparator: () => true
+      })
+      queue.start()
+      queue.enqueue(1)
+      queue.stop()
+      expect(sinkFn).toHaveBeenCalledTimes(1)
+      expect(sinkFn).toHaveBeenCalledWith([1])
+      sinkFn.mockClear()
+      queue.enqueue(2)
+      queue.enqueue(3)
+      queue.enqueue(4)
+      expect(sinkFn).toBeCalledTimes(0)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Before this change, event processor would continue processing user events after its `stop` method was called. If the batch size limit was reached after `stop` was called, it would dispatch a log event as normal. Worse, the internal queue wasn't being emptied when `stop` was called, which could lead to the same user event being included in two different log events.

With this change, the event processor's internal queue stops accepting events after the event processor is stopped. A warning message is logged, but the event is dropped.

## Test plan

Updated unit tests. Will manually test upon integration of a new version in optimizely-sdk.