### PR TITLE
fix(unit tests): Make test assertion for json schema validation failure less specific

### DIFF
--- a/packages/optimizely-sdk/lib/utils/json_schema_validator/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/json_schema_validator/index.tests.js
@@ -32,7 +32,7 @@ describe('lib/utils/json_schema_validator', function() {
       it('should throw an error if the object is not valid', function() {
         assert.throws(function() {
           jsonSchemaValidator.validate({'type': 'number'}, 'not a number');
-        }, sprintf(ERROR_MESSAGES.INVALID_DATAFILE, 'JSON_SCHEMA_VALIDATOR', '', 'string value found, but a number is required'));
+        }, 'string value found, but a number is required');
       });
 
       it('should throw an error if no schema is passed in', function() {


### PR DESCRIPTION
## Summary
A new patch version of json-schema was released that changed an error message. Our test specifically asserts on the old version of the error message.

With this change we assert on a substring that's included in both the old & new versions.

## Test plan

Run unit tests
