### PR TITLE
fix(event processor / pending events store): Added a check before accessing localstorage to make it work for React Native

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Fixed
+- Fixed a runtime error when accessing localstorage in `PendingEventsStore` when SDK is used in a React Native application. Pending events will still not be stored when SDK is used in React Native but no error will be thrown anymore.
+
 ## [0.3.1] - August 29, 2019
 
 ### Fixed

--- a/packages/event-processor/src/pendingEventsStore.ts
+++ b/packages/event-processor/src/pendingEventsStore.ts
@@ -72,7 +72,8 @@ export class LocalStorageStore<K extends StoreEntry> implements PendingEventsSto
 
   replace(map: { [key: string]: K }): void {
     try {
-      localStorage.setItem(this.LS_KEY, JSON.stringify(map))
+      // This is a temporary fix to support React Native which does not have localStorage.
+      window.localStorage && localStorage.setItem(this.LS_KEY, JSON.stringify(map))
       this.clean()
     } catch (e) {
       logger.error(e)
@@ -103,7 +104,8 @@ export class LocalStorageStore<K extends StoreEntry> implements PendingEventsSto
 
   private getMap(): { [key: string]: K } {
     try {
-      const data = localStorage.getItem(this.LS_KEY)
+      // This is a temporary fix to support React Native which does not have localStorage.
+      const data = window.localStorage && localStorage.getItem(this.LS_KEY);
       if (data) {
         return (JSON.parse(data) as { [key: string]: K }) || {}
       }


### PR DESCRIPTION
## Summary
React Native does not have localStorage. Added a check to make sure it does not throw error in react native. This is a temporary fix to make sure error is not thrown in React Native. Will implement a better fix in the future.

## Test plan
Manually tested thoroughly.