### PR TITLE
fix: Added logger for react native which uses console.warn for error

### DIFF
--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -173,7 +173,7 @@ export class ConsoleLogHandler implements LogHandler {
    * @param {string[]} logArguments
    * @memberof ConsoleLogger
    */
-  private consoleLog(logLevel: LogLevel, logArguments: [string, ...string[]]) {
+  protected consoleLog(logLevel: LogLevel, logArguments: [string, ...string[]]) {
     switch (logLevel) {
       case LogLevel.DEBUG:
         console.log.apply(console, logArguments)
@@ -189,6 +189,22 @@ export class ConsoleLogHandler implements LogHandler {
         break
       default:
         console.log.apply(console, logArguments)
+    }
+  }
+}
+
+export class ReactNativeConsoleLogHandler extends ConsoleLogHandler {
+  /**
+   * @private
+   * @param {LogLevel} logLevel
+   * @param {string[]} logArguments
+   * @memberof ConsoleLogger
+   */
+  protected consoleLog(logLevel: LogLevel, logArguments: [string, ...string[]]) {
+    if (logLevel === LogLevel.ERROR) {
+      console.warn.apply(console, logArguments);
+    } else { 
+      super.consoleLog(logLevel, logArguments);
     }
   }
 }

--- a/packages/optimizely-sdk/lib/index.react_native.js
+++ b/packages/optimizely-sdk/lib/index.react_native.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016-2017, 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var logging = require('@optimizely/js-sdk-logging');
+var browserIndex = require('./index.browser');
+
+/**
+ * Entry point into the Optimizely Browser SDK for React Native Apps
+ */
+module.exports = {
+  ...browserIndex,
+
+  /**
+   * Creates an instance of the Optimizely class
+   * @param  {Object} config
+   * @param  {Object} config.datafile
+   * @param  {Object} config.errorHandler
+   * @param  {Object} config.eventDispatcher
+   * @param  {Object} config.logger
+   * @param  {Object} config.logLevel
+   * @param  {Object} config.userProfileService
+   * @param {Object} config.eventBatchSize
+   * @param {Object} config.eventFlushInterval
+   * @return {Object} the Optimizely object
+   */
+  createInstance: function(config) {
+    return browserIndex.createInstance({
+      logger: new logging.ReactNativeConsoleLogHandler(), 
+      ...config,
+    })
+  }
+};

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
+  "react-native": "lib/index.react_native.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "test": "mocha ./lib/*.tests.js ./lib/**/*.tests.js ./lib/**/**/*tests.js --recursive --exit --require lib/tests/exit_on_unhandled_rejection.js",


### PR DESCRIPTION
## Summary
React Native App shows a full screen Red Message when `console.error` is called. This appears to be distracting for the developers. Added a new logger for React Native which uses `console.warn` to log error.

## Test plan
Manually tested thoroughly. Will add unit tests tomorrow