### PR TITLE
fix: log error message when user allocated to vacated space in group or experiment

### DIFF
--- a/packages/optimizely-sdk/lib/core/bucketer/index.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.js
@@ -87,7 +87,7 @@ module.exports = {
     bucketerParams.logger.log(LOG_LEVEL.DEBUG, bucketedUserLogMessage);
 
     var entityId = module.exports._findBucket(bucketValue, bucketerParams.trafficAllocationConfig);
-    if (entityId === null || entityId === '') {
+    if (!entityId) {
       var userHasNoVariationLogMessage = sprintf(LOG_MESSAGES.USER_HAS_NO_VARIATION, MODULE_NAME, bucketerParams.userId, bucketerParams.experimentKey);
       bucketerParams.logger.log(LOG_LEVEL.DEBUG, userHasNoVariationLogMessage);
     } else if (!bucketerParams.variationIdMap.hasOwnProperty(entityId)) {

--- a/packages/optimizely-sdk/lib/core/bucketer/index.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.js
@@ -87,10 +87,10 @@ module.exports = {
     bucketerParams.logger.log(LOG_LEVEL.DEBUG, bucketedUserLogMessage);
 
     var entityId = module.exports._findBucket(bucketValue, bucketerParams.trafficAllocationConfig);
-    if (entityId === null) {
+    if (entityId === null || entityId === '') {
       var userHasNoVariationLogMessage = sprintf(LOG_MESSAGES.USER_HAS_NO_VARIATION, MODULE_NAME, bucketerParams.userId, bucketerParams.experimentKey);
       bucketerParams.logger.log(LOG_LEVEL.DEBUG, userHasNoVariationLogMessage);
-    } else if (entityId === '' || !bucketerParams.variationIdMap.hasOwnProperty(entityId)) {
+    } else if (!bucketerParams.variationIdMap.hasOwnProperty(entityId)) {
       var invalidVariationIdLogMessage = sprintf(LOG_MESSAGES.INVALID_VARIATION_ID, MODULE_NAME);
       bucketerParams.logger.log(LOG_LEVEL.WARNING, invalidVariationIdLogMessage);
       return null;

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -258,7 +258,7 @@ describe('lib/core/bucketer', function() {
         it('should return null', function() {
           var bucketerParamsTest1 = cloneDeep(bucketerParams);
           bucketerParamsTest1.userId = 'ppid1';
-          expect(bucketer.bucket(bucketerParamsTest1)).to.equal(null);
+          expect(bucketer.bucket(bucketerParamsTest1)).to.equal('');
         });
       });
 

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -349,7 +349,7 @@ DecisionService.prototype._getVariationForFeatureExperiment = function(configObj
 
 DecisionService.prototype._getExperimentInGroup = function(configObj, group, userId) {
   var experimentId = bucketer.bucketUserIntoExperiment(group, userId, userId, this.logger);
-  if (experimentId !== null && experimentId !== '') {
+  if (experimentId) {
     this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.USER_BUCKETED_INTO_EXPERIMENT_IN_GROUP, MODULE_NAME, userId, experimentId, group.id));
     var experiment = projectConfig.getExperimentFromId(configObj, experimentId, this.logger);
     if (experiment) {

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -349,7 +349,7 @@ DecisionService.prototype._getVariationForFeatureExperiment = function(configObj
 
 DecisionService.prototype._getExperimentInGroup = function(configObj, group, userId) {
   var experimentId = bucketer.bucketUserIntoExperiment(group, userId, userId, this.logger);
-  if (experimentId !== null) {
+  if (experimentId !== null && experimentId !== '') {
     this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.USER_BUCKETED_INTO_EXPERIMENT_IN_GROUP, MODULE_NAME, userId, experimentId, group.id));
     var experiment = projectConfig.getExperimentFromId(configObj, experimentId, this.logger);
     if (experiment) {


### PR DESCRIPTION
**Summary**

When a user is allocated to space in a group that used to be occupied by an experiment, but is now unallocated, the JS SDK logs an error message. This is not an error, so it shouldn't log an error message.

**Expected:**
An info level message saying “User not in any experiment in group” should be logged

**Actual:**
An error level message saying 'Experiment ID " " is not in the datafile' is logged.