### PR TITLE
fix: Correct decision notification payload type for getVariation feature test decision

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -98,16 +98,15 @@ module.exports = {
       fns.forEach(feature.experimentIds || [], function(experimentId) {
         // Add this experiment in experiment-feature map.
         if (projectConfig.experimentFeatureMap[experimentId]) {
-          projectConfig.experimentFeatureMap[experimentId].push(feature.id);  
+          projectConfig.experimentFeatureMap[experimentId].push(feature.id);
         } else {
           projectConfig.experimentFeatureMap[experimentId] = [feature.id];
         }
-        
+
         var experimentInFeature = projectConfig.experimentIdMap[experimentId];
-        if (experimentInFeature.groupId) {
+        // Experiments in feature can only belong to one mutex group.
+        if (experimentInFeature.groupId && !feature.groupId) {
           feature.groupId = experimentInFeature.groupId;
-          // Experiments in feature can only belong to one mutex group.
-          return false;
         }
       });
     });

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -559,6 +559,28 @@ describe('lib/core/project_config', function() {
         assert.deepEqual(result, ['and', ['or', '3468206642', '3988293898'], ['or', '3988293899', '3468206646', '3468206647', '3468206644', '3468206643']]);
       });
     });
+
+    describe('#isFeatureExperiment', function() {
+      it('returns true for a feature test', function() {
+        var config = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
+        var result = projectConfig.isFeatureExperiment(config, '594098'); // id of 'testing_my_feature'
+        assert.isTrue(result);
+      });
+
+      it('returns false for an A/B test', function() {
+        var config = projectConfig.createProjectConfig(testDatafile.getTestProjectConfig());
+        var result = projectConfig.isFeatureExperiment(config, '111127'); // id of 'testExperiment'
+        assert.isFalse(result);
+      });
+
+      it('returns true for a feature test in a mutex group', function() {
+        var config = projectConfig.createProjectConfig(testDatafile.getMutexFeatureTestsConfig());
+        var result = projectConfig.isFeatureExperiment(config, '17128410791'); // id of 'f_test1'
+        assert.isTrue(result);
+        result = projectConfig.isFeatureExperiment(config, '17139931304'); // id of 'f_test2'
+        assert.isTrue(result);
+      });
+    });
   });
 
   describe('#tryCreatingProjectConfig', function() {

--- a/packages/optimizely-sdk/lib/tests/test_data.js
+++ b/packages/optimizely-sdk/lib/tests/test_data.js
@@ -2489,6 +2489,95 @@ var typedAudiencesById = {
   },
 };
 
+var mutexFeatureTestsConfig = {
+  version: '4',
+  rollouts: [
+    {
+      experiments: [
+        {
+          status: 'Not started',
+          audienceIds: [],
+          variations: [{ variables: [], id: '17138530965', key: '17138530965', featureEnabled: false }],
+          id: '17138130490',
+          key: '17138130490',
+          layerId: '17151011617',
+          trafficAllocation: [{ entityId: '17138530965', endOfRange: 0 }],
+          forcedVariations: {},
+        }
+      ],
+      id: '17151011617',
+    }
+  ],
+  typedAudiences: [],
+  anonymizeIP: false,
+  projectId: '1715448053799999',
+  variables: [],
+  featureFlags: [
+    {
+      experimentIds: ['17128410791', '17139931304'],
+      rolloutId: '17151011617',
+      variables: [],
+      id: '17146211047',
+      key: 'f',
+    },
+  ],
+  experiments: [],
+  audiences: [],
+  groups: [
+    {
+      policy: 'random',
+      trafficAllocation: [
+        { entityId: '17139931304', endOfRange: 9900 },
+        { entityId: '17128410791', endOfRange: 10000 }
+      ],
+      experiments: [
+        {
+          status: 'Running',
+          audienceIds: [],
+          variations: [
+            { variables: [], id: 17155031309, key: 'variation_1', featureEnabled: false },
+            { variables: [], id: 17124610952, key: 'variation_2', featureEnabled: true }
+          ],
+          id: '17139931304',
+          key: 'f_test2',
+          layerId: '17149391594',
+          trafficAllocation: [
+            { entityId: '17155031309', endOfRange: 5000 },
+            { entityId: '17124610952', endOfRange: 10000 }
+          ],
+          forcedVariations: {}
+        },
+        {
+          status: 'Running',
+          audienceIds: [],
+          variations: [
+            { variables: [], id: '17175820099', key: 'variation_1', featureEnabled: false },
+            { variables: [], id: '17144050391', key: 'variation_2', featureEnabled: true }
+          ],
+          id: '17128410791',
+          key: 'f_test1',
+          layerId: '17145581153',
+          trafficAllocation: [
+            { entityId: '17175820099', endOfRange: 5000 },
+            { entityId: '17144050391', endOfRange: 10000 }
+          ],
+          forcedVariations: {}
+        }
+      ],
+      id: '17142090293'
+    }
+  ],
+  attributes: [],
+  botFiltering: false,
+  accountId: '4879520872999',
+  events: [{ experimentIds: ['17128410791', '17139931304'], id: '17140380990', key: 'e' }],
+  revision: '12',
+};
+
+var getMutexFeatureTestsConfig = function() {
+  return cloneDeep(mutexFeatureTestsConfig);
+};
+
 module.exports = {
   getTestProjectConfig: getTestProjectConfig,
   getParsedAudiences: getParsedAudiences,
@@ -2497,4 +2586,5 @@ module.exports = {
   getUnsupportedVersionConfig: getUnsupportedVersionConfig,
   getTypedAudiencesConfig: getTypedAudiencesConfig,
   typedAudiencesById: typedAudiencesById,
+  getMutexFeatureTestsConfig: getMutexFeatureTestsConfig,
 };


### PR DESCRIPTION
## Summary
In `createProjectConfig`, we [attempt to create an object `experimentFeatureMap`](https://github.com/optimizely/javascript-sdk/blob/9a4d96b170768b3e96f509f6f12854fd37082aad/packages/optimizely-sdk/lib/core/project_config/index.js#L93) whose keys are experiment IDs, and whose values are arrays of feature IDs. We [loop over each experiment ID](https://github.com/optimizely/javascript-sdk/blob/9a4d96b170768b3e96f509f6f12854fd37082aad/packages/optimizely-sdk/lib/core/project_config/index.js#L98) in each feature flag's `experimentIds`, and update `experimentFeatureMap` accordingly.

The problem occurs when one of these experiments is in a group (had a `groupId` property). The inner loop [breaks out by returning `false`](https://github.com/optimizely/javascript-sdk/blob/9a4d96b170768b3e96f509f6f12854fd37082aad/packages/optimizely-sdk/lib/core/project_config/index.js#L110) (this early iteration exit by returning false is a feature of [lodash `forEach`](https://lodash.com/docs/4.17.15#forEach)). Then, any remaining experiment IDs are wrongfully excluded from `experimentFeatureMap`. For any of these skipped feature experiment IDs, the `isFeatureExperiment` function will wrongly return `false`, leading to an incorrect decision notification payload.

With this change, the loop always runs over all experiment IDs of each feature. The previous behavior of only assigning `feature.groupId` once is maintained.

## Test plan

New unit tests for `isFeatureExperiment` function of project config module

## Issues
https://optimizely.atlassian.net/browse/OASIS-5759
