### PR TITLE
fix: Lint errors and global variable declaration in optimizely_config

### DIFF
--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.js
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.js
@@ -55,7 +55,7 @@ function getExperimentsMap(configObj) {
 // Merges feature key and type from feature variables to variation variables.
 function getMergedVariablesMap(configObj, variation, experimentId, featureVariablesMap) {
   var featureId = configObj.experimentFeatureMap[experimentId];
-  variablesObject = {};
+  var variablesObject = {};
   if (featureId) {
     experimentFeatureVariables = featureVariablesMap[featureId];
     // Temporary variation variables map to get values to merge.
@@ -76,7 +76,7 @@ function getMergedVariablesMap(configObj, variation, experimentId, featureVariab
         value: variableValue,
       };
       return variablesMap;
-    }, {})
+    }, {});
   }
   return variablesObject;
 }
@@ -98,7 +98,7 @@ function getFeaturesMap(configObj, allExperiments) {
           key: variable.key,
           type: variable.type,
           value: variable.defaultValue,
-        }
+        };
         return variables;
       }, {}),
     };
@@ -111,9 +111,9 @@ module.exports = {
     // Fetch all feature variables from feature flags to merge them with variation variables
     var experimentsMap = getExperimentsMap(configObj);
     return {
-      experimentsMap,
+      experimentsMap: experimentsMap,
       featuresMap: getFeaturesMap(configObj, experimentsMap),
       revision: configObj.revision,
-    }
+    };
   },
 };


### PR DESCRIPTION
## Summary
Fix lint errors and global variable declaration in optimizely_config

## Test plan
Existing tests
