### PR TITLE
fix: Use default event dispatcher in React Native entry point when none provided by user

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Changes that have landed but are not yet released.
+### Bug fixes
+- Fixed default event dispatcher not used in React Native entry point ([#383](https://github.com/optimizely/javascript-sdk/pull/383))
 
 ## [3.4.0-beta] - December 18th, 2019
 ### Bug fixes
@@ -14,7 +15,7 @@ Changes that have landed but are not yet released.
 ### New Features
 
 - Added a new API to get a project configuration static data.
-  - Call `getOptimizelyConfig()` to get a snapshot copy of project configuration static data. 
+  - Call `getOptimizelyConfig()` to get a snapshot copy of project configuration static data.
   - It returns an `OptimizelyConfig` instance which includes a datafile revision number, all experiments, and feature flags mapped by their key values.
   - For details, refer to a documention page: https://docs.developers.optimizely.com/full-stack/docs/optimizelyconfig-javascript-node
 

--- a/packages/optimizely-sdk/lib/index.react_native.js
+++ b/packages/optimizely-sdk/lib/index.react_native.js
@@ -90,11 +90,11 @@ module.exports = {
         {
           clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
           eventBatchSize: DEFAULT_EVENT_BATCH_SIZE,
+          eventDispatcher: defaultEventDispatcher,
           eventFlushInterval: DEFAULT_EVENT_FLUSH_INTERVAL,
         },
         config,
         {
-          eventDispatcher: config.eventDispatcher,
           // always get the OptimizelyLogger facade from logging
           logger: logger,
           errorHandler: logging.getErrorHandler(),


### PR DESCRIPTION
## Summary
In the [`createInstance` factory method of the React Native entry point](https://github.com/optimizely/javascript-sdk/blob/bbdb2cc892ce412d9e163c078e3007877169d817/packages/optimizely-sdk/lib/index.react_native.js#L58), when no event dispatcher is provided by the caller in the options object, [a value of `undefined` is set on the options object](https://github.com/optimizely/javascript-sdk/blob/bbdb2cc892ce412d9e163c078e3007877169d817/packages/optimizely-sdk/lib/index.react_native.js#L97) that is passed on to the `Optimizely` constructor. This results in an invalid instance that can't dispatch events.

With this fix, the default event dispatcher is used when none is provided by the caller.

## Test plan

Added new unit test
