### PR TITLE
Deprecate launched status check

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -121,7 +121,7 @@ DecisionService.prototype.__resolveExperimentBucketMap = function(userId, attrib
 
 
 /**
- * Checks whether the experiment is running or launched
+ * Checks whether the experiment is running
  * @param  {Object}  configObj     The parsed project configuration object
  * @param  {string}  experimentKey Key of experiment being validated
  * @param  {string}  userId        ID of user

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -19,7 +19,6 @@ var sprintf = require('@optimizely/js-sdk-utils').sprintf;
 var configValidator = require('../../utils/config_validator');
 var projectConfigSchema = require('./project_config_schema');
 
-var EXPERIMENT_LAUNCHED_STATUS = 'Launched';
 var EXPERIMENT_RUNNING_STATUS = 'Running';
 var RESERVED_ATTRIBUTE_PREFIX = '$opt_';
 var MODULE_NAME = 'PROJECT_CONFIG';
@@ -198,14 +197,13 @@ module.exports = {
   },
 
   /**
-   * Returns whether experiment has a status of 'Running' or 'Launched'
+   * Returns whether experiment has a status of 'Running'
    * @param  {Object}  projectConfig Object representing project configuration
    * @param  {string}  experimentKey Experiment key for which status is to be compared with 'Running'
    * @return {Boolean}               true if experiment status is set to 'Running', false otherwise
    */
   isActive: function(projectConfig, experimentKey) {
-    return module.exports.getExperimentStatus(projectConfig, experimentKey) === EXPERIMENT_RUNNING_STATUS ||
-      module.exports.getExperimentStatus(projectConfig, experimentKey) === EXPERIMENT_LAUNCHED_STATUS;
+    return module.exports.getExperimentStatus(projectConfig, experimentKey) === EXPERIMENT_RUNNING_STATUS
   },
 
   /**

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -203,7 +203,7 @@ module.exports = {
    * @return {Boolean}               true if experiment status is set to 'Running', false otherwise
    */
   isActive: function(projectConfig, experimentKey) {
-    return module.exports.getExperimentStatus(projectConfig, experimentKey) === EXPERIMENT_RUNNING_STATUS
+    return module.exports.getExperimentStatus(projectConfig, experimentKey) === EXPERIMENT_RUNNING_STATUS;
   },
 
   /**

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -305,13 +305,11 @@ describe('lib/core/project_config', function() {
       }, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, 'PROJECT_CONFIG', 'invalidExperimentKey'));
     });
 
-    it('should return true if experiment status is set to Running or Launch in isActive', function() {
+    it('should return true if experiment status is set to Running in isActive', function() {
       assert.isTrue(projectConfig.isActive(configObj, 'testExperiment'));
-
-      assert.isTrue(projectConfig.isActive(configObj, 'testExperimentLaunched'));
     });
 
-    it('should return true if experiment status is set to Running or Launch in isActive', function() {
+    it('should return false if experiment status is not set to Running in isActive', function() {
       assert.isFalse(projectConfig.isActive(configObj, 'testExperimentNotRunning'));
     });
 

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -786,15 +786,6 @@ describe('lib/optimizely', function() {
         });
       });
 
-      it('returns the variation key but does not dispatch the event if user is in experiment and experiment is set to Launched', function() {
-        bucketStub.returns('144448');
-
-        var bucketedVariation = optlyInstance.activate('testExperimentLaunched', 'testUser');
-        assert.strictEqual(bucketedVariation, 'controlLaunched');
-
-        sinon.assert.notCalled(eventDispatcher.dispatchEvent);
-      });
-
       it('should not activate when optimizely object is not a valid instance', function() {
         var instance = new Optimizely({
           datafile: {},

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -92,7 +92,7 @@ exports.LOG_MESSAGES = {
   ROLLOUT_HAS_NO_EXPERIMENTS: '%s: Rollout of feature %s has no experiments',
   SAVED_VARIATION: '%s: Saved variation "%s" of experiment "%s" for user "%s".',
   SAVED_VARIATION_NOT_FOUND: '%s: User %s was previously bucketed into variation with ID %s for experiment %s, but no matching variation was found.',
-  SHOULD_NOT_DISPATCH_ACTIVATE: '%s: Experiment %s is in "Launched" state. Not activating user.',
+  SHOULD_NOT_DISPATCH_ACTIVATE: '%s: Experiment %s is not in "Running" state. Not activating user.',
   SKIPPING_JSON_VALIDATION: '%s: Skipping JSON schema validation.',
   TRACK_EVENT: '%s: Tracking event %s for user %s.',
   USER_ASSIGNED_TO_VARIATION_BUCKET: '%s: Assigned variation bucket %s to user %s.',


### PR DESCRIPTION
## Summary
- removed launch status check within isActive
- removed or altered associated unit tests
- altered a log message

The only thing I didn't touch was the test data's testExperimentLaunched test since it was being used to check functionality unrelated to the launched status. 
