### PR TITLE
fix: Remove iphone 6 from browserstack tests

### DIFF
--- a/packages/optimizely-sdk/karma.base.conf.js
+++ b/packages/optimizely-sdk/karma.base.conf.js
@@ -70,12 +70,6 @@ module.exports = {
       device: null,
       browser_version: '10.0'
     },
-    bs_iphone6: {
-      base: 'BrowserStack',
-      device: 'iPhone 6',
-      os: 'ios',
-      os_version: '8.3'
-    },
     bs_opera_mac: {
       base: 'BrowserStack',
       browser: 'opera',

--- a/packages/optimizely-sdk/karma.base.conf.js
+++ b/packages/optimizely-sdk/karma.base.conf.js
@@ -87,7 +87,7 @@ module.exports = {
     }
   },
 
-  browsers: ['bs_chrome_mac', 'bs_edge', 'bs_firefox_mac', 'bs_ie', 'bs_iphone6', 'bs_opera_mac', 'bs_safari'],
+  browsers: ['bs_chrome_mac', 'bs_edge', 'bs_firefox_mac', 'bs_ie', 'bs_opera_mac', 'bs_safari'],
 
   // frameworks to use
   // available frameworks: https://npmjs.org/browse/keyword/karma-adapter


### PR DESCRIPTION
## Summary
Browserstack has stopped supporting emulators and simulators, causing our cross browser tests to fail when we try to launch them on iphone 6. This removes iphone 6 from our test configuration.

## Test plan
Existing tests
