### PR TITLE
[WIP] Add window.optimizelyDatafile interface

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -35,10 +35,79 @@ declare module "@optimizely/optimizely-sdk" {
     updateInterval?: number;
     urlTemplate?: string;
   }
+  
+  /**
+   * The shape of `window.optimizelyDatafile`
+   * @todo array objects need typing.
+   */
+  export interface Datafile {
+    version: string;
+    /**
+     * rollouts: Rollout[];
+     */
+    rollouts: { experiments: any[] }[];
+    typedAudiences: any[];
+    anonymizeIP: boolean;
+    projectId: string;
+    variables: any[];
+    /**
+     * featureFlags: FeatureFlag[];
+     */
+    featureFlags: {
+      experimentIds: string[];
+      rolloutId: string;
+      variables: any[];
+      id: string;
+      key: string;
+    }[];
+    /**
+     * experiments: Experiment[];
+     */
+    experiments: {
+      status: string;
+      audienceIds: string[];
+      variations: {
+        variables: any[];
+        id: string;
+        key: string;
+      }[];
+      id: string;
+      key: string;
+      layerId: string;
+      trafficAllocation: {
+        entityId: string;
+        endOfRange: number;
+      }[];
+      forcedVariations: {
+        [key: string]: string;
+      };
+    }[];
+    /**
+     * audiences: Audience[];
+     */
+    audiences: any[];
+    groups: any[];
+    attributes: {
+      id: string;
+      key: string;
+    }[];
+    botFiltering: boolean;
+    accountId: string;
+    /**
+     * events: Event[]; 
+     * - note namespace conflits
+     */
+    events: {
+      experimentIds: string[];
+      id: string;
+      key: string;
+    }[];
+    revision: string;
+  }
 
   // The options object given to Optimizely.createInstance.
   export interface Config {
-    datafile?: object | string;
+    datafile?: Datafile | object | string;
     datafileOptions?: DatafileOptions;
     errorHandler?: ErrorHandler;
     eventDispatcher?: EventDispatcher;


### PR DESCRIPTION
## Summary
- This adds a `Datafile` interface, which represents the shape of `window.optimizelyDatafile`

The "why", or other context.

- End goal is to be able to silence TypeScript compiler warnings for the `window` object:

###### /project/declarations.d.ts
```ts
import { ReactSDKClient, Datafile } from '@optimizely/react-sdk';

declare global {
  interface Window { 
    optimizelyDatafile: Datafile;
    optimizelyClientInstance: ReactSDKClient;
  }
}
```

#### Example warning
![image](https://user-images.githubusercontent.com/26389321/74048934-26ef4a00-49a1-11ea-9285-9f6ef42b0daf.png)

## Test plan

- TBD

## Issues

- TBD
