### PR TITLE
Removed dependency on lodash.assign

### DIFF
--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -35,7 +35,7 @@ var MODULE_NAME = 'AUDIENCE_EVALUATOR';
  * @constructor
  */
 function AudienceEvaluator(UNSTABLE_conditionEvaluators) {
-  this.typeToEvaluatorMap = fns.assignIn({}, UNSTABLE_conditionEvaluators, {
+  this.typeToEvaluatorMap = fns.assign({}, UNSTABLE_conditionEvaluators, {
     'custom_attribute': customAttributeConditionEvaluator
   });
 }

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -116,7 +116,7 @@ DecisionService.prototype.__resolveExperimentBucketMap = function(userId, attrib
   attributes = attributes || {}
   var userProfile = this.__getUserProfile(userId) || {};
   var attributeExperimentBucketMap = attributes[enums.CONTROL_ATTRIBUTES.STICKY_BUCKETING_KEY];
-  return fns.assignIn({}, userProfile.experiment_bucket_map, attributeExperimentBucketMap);
+  return fns.assign({}, userProfile.experiment_bucket_map, attributeExperimentBucketMap);
 };
 
 

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -55,7 +55,7 @@ module.exports = {
     fns.forEach(projectConfig.groupIdMap, function(group, Id) {
       experiments = fns.cloneDeep(group.experiments);
       fns.forEach(experiments, function(experiment) {
-        projectConfig.experiments.push(fns.assignIn(experiment, {groupId: Id}));
+        projectConfig.experiments.push(fns.assign(experiment, {groupId: Id}));
       });
     });
 
@@ -78,7 +78,7 @@ module.exports = {
       experiment.variationKeyMap = fns.keyBy(experiment.variations, 'key');
 
       // Creates { <variationId>: { key: <variationKey>, id: <variationId> } } mapping for quick lookup
-      fns.assignIn(projectConfig.variationIdMap, fns.keyBy(experiment.variations, 'id'));
+      fns.assign(projectConfig.variationIdMap, fns.keyBy(experiment.variations, 'id'));
 
       fns.forOwn(experiment.variationKeyMap, function(variation) {
         if (variation.variables) {

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -25,7 +25,6 @@ var loggerPlugin = require('./plugins/logger');
 var Optimizely = require('./optimizely');
 var eventProcessorConfigValidator = require('./utils/event_processor_config_validator');
 
-fns.applyPolyfills();
 var logger = logging.getLogger();
 logging.setLogHandler(loggerPlugin.createLogger());
 logging.setLogLevel(logging.LogLevel.INFO);

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -14,6 +14,37 @@
  * limitations under the License.
  */
 require('promise-polyfill/dist/polyfill');
+
+// Temporary adding code here to test polyfill for Object.assign
+if (typeof Object.assign !== 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target === null || target === undefined) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource !== null && nextSource !== undefined) { 
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}
 var logging = require('@optimizely/js-sdk-logging');
 var fns = require('./utils/fns');
 var configValidator = require('./utils/config_validator');

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -14,37 +14,6 @@
  * limitations under the License.
  */
 require('promise-polyfill/dist/polyfill');
-
-// Temporary adding code here to test polyfill for Object.assign
-if (typeof Object.assign !== 'function') {
-  // Must be writable: true, enumerable: false, configurable: true
-  Object.defineProperty(Object, "assign", {
-    value: function assign(target) {
-      'use strict';
-      if (target === null || target === undefined) {
-        throw new TypeError('Cannot convert undefined or null to object');
-      }
-
-      var to = Object(target);
-
-      for (var index = 1; index < arguments.length; index++) {
-        var nextSource = arguments[index];
-
-        if (nextSource !== null && nextSource !== undefined) { 
-          for (var nextKey in nextSource) {
-            // Avoid bugs when hasOwnProperty is shadowed
-            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-              to[nextKey] = nextSource[nextKey];
-            }
-          }
-        }
-      }
-      return to;
-    },
-    writable: true,
-    configurable: true
-  });
-}
 var logging = require('@optimizely/js-sdk-logging');
 var fns = require('./utils/fns');
 var configValidator = require('./utils/config_validator');
@@ -55,6 +24,8 @@ var eventProcessor = require('@optimizely/js-sdk-event-processor');
 var loggerPlugin = require('./plugins/logger');
 var Optimizely = require('./optimizely');
 var eventProcessorConfigValidator = require('./utils/event_processor_config_validator');
+
+fns.applyAssignPolyfill();
 
 var logger = logging.getLogger();
 logging.setLogHandler(loggerPlugin.createLogger());

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -25,8 +25,7 @@ var loggerPlugin = require('./plugins/logger');
 var Optimizely = require('./optimizely');
 var eventProcessorConfigValidator = require('./utils/event_processor_config_validator');
 
-fns.applyAssignPolyfill();
-
+fns.applyPolyfills();
 var logger = logging.getLogger();
 logging.setLogHandler(loggerPlugin.createLogger());
 logging.setLogLevel(logging.LogLevel.INFO);

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -19,7 +19,7 @@ require('promise-polyfill/dist/polyfill');
 if (typeof Object.assign !== 'function') {
   // Must be writable: true, enumerable: false, configurable: true
   Object.defineProperty(Object, "assign", {
-    value: function assign(target, varArgs) { // .length of function is 2
+    value: function assign(target) {
       'use strict';
       if (target === null || target === undefined) {
         throw new TypeError('Cannot convert undefined or null to object');

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -107,7 +107,7 @@ module.exports = {
         eventDispatcher = config.eventDispatcher;
       }
 
-      config = fns.assignIn(
+      config = fns.assign(
         {
           clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
           eventBatchSize: DEFAULT_EVENT_BATCH_SIZE,

--- a/packages/optimizely-sdk/lib/index.react_native.js
+++ b/packages/optimizely-sdk/lib/index.react_native.js
@@ -86,7 +86,7 @@ module.exports = {
         config.skipJSONValidation = true;
       }
 
-      config = fns.assignIn(
+      config = fns.assign(
         {
           clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
           eventBatchSize: DEFAULT_EVENT_BATCH_SIZE,

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -18,7 +18,10 @@ var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 
 module.exports = {
-  assign: require('lodash/assign'),
+  assign: function (target) {
+    // Object.assign crashes if target object is undefined or null
+    return !!target ? Object.assign.apply(Object, arguments) : {};
+  },
   assignIn: require('lodash/assignIn'),
   cloneDeep: require('lodash/cloneDeep'),
   currentTimestamp: function() {

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -40,7 +40,6 @@ module.exports = {
       return to;
     }
   },
-  assignIn: require('lodash/assignIn'),
   cloneDeep: require('lodash/cloneDeep'),
   currentTimestamp: function() {
     return Math.round(new Date().getTime());

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -18,7 +18,7 @@ var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 
 // Polyfill Object.assign for older browsers
-var applyAssignPolyfill = function() {
+var applyPolyfills = function() {
   if (typeof Object.assign !== 'function') {
     // Must be writable: true, enumerable: false, configurable: true
     Object.defineProperty(Object, "assign", {
@@ -73,5 +73,5 @@ module.exports = {
   },
   values: require('lodash/values'),
   isNumber: require('lodash/isNumber'),
-  applyAssignPolyfill: applyAssignPolyfill,
+  applyPolyfills: applyPolyfills,
 };

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -17,6 +17,37 @@ var uuid = require('uuid');
 var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 
+// Polyfill Object.assign for older browsers
+var applyAssignPolyfill = function() {
+  if (typeof Object.assign !== 'function') {
+    // Must be writable: true, enumerable: false, configurable: true
+    Object.defineProperty(Object, "assign", {
+      value: function assign(target) {
+        'use strict';
+        if (target === null || target === undefined) {
+          throw new TypeError('Cannot convert undefined or null to object');
+        }
+        var to = Object(target);
+        for (var index = 1; index < arguments.length; index++) {
+          var nextSource = arguments[index];
+
+          if (nextSource !== null && nextSource !== undefined) { 
+            for (var nextKey in nextSource) {
+              // Avoid bugs when hasOwnProperty is shadowed
+              if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                to[nextKey] = nextSource[nextKey];
+              }
+            }
+          }
+        }
+        return to;
+      },
+      writable: true,
+      configurable: true
+    });
+  }
+}
+
 module.exports = {
   assign: function (target) {
     // Object.assign crashes if target object is undefined or null
@@ -42,4 +73,5 @@ module.exports = {
   },
   values: require('lodash/values'),
   isNumber: require('lodash/isNumber'),
+  applyAssignPolyfill: applyAssignPolyfill,
 };

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -17,41 +17,28 @@ var uuid = require('uuid');
 var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 
-// Polyfills for older browsers
-var applyPolyfills = function() {
-  if (typeof Object.assign !== 'function') {
-    // Must be writable: true, enumerable: false, configurable: true
-    Object.defineProperty(Object, "assign", {
-      value: function assign(target) {
-        'use strict';
-        if (target === null || target === undefined) {
-          throw new TypeError('Cannot convert undefined or null to object');
-        }
-        var to = Object(target);
-        for (var index = 1; index < arguments.length; index++) {
-          var nextSource = arguments[index];
-
-          if (nextSource !== null && nextSource !== undefined) { 
-            for (var nextKey in nextSource) {
-              // Avoid bugs when hasOwnProperty is shadowed
-              if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                to[nextKey] = nextSource[nextKey];
-              }
+module.exports = {
+  assign: function (target) {
+    if (!target) {
+      return {};
+    }
+    if (typeof Object.assign === 'function') {
+      return Object.assign.apply(Object, arguments);
+    } else {
+      var to = Object(target);
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+        if (nextSource !== null && nextSource !== undefined) { 
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
             }
           }
         }
-        return to;
-      },
-      writable: true,
-      configurable: true
-    });
-  }
-}
-
-module.exports = {
-  assign: function (target) {
-    // Object.assign crashes if target object is undefined or null
-    return target ? Object.assign.apply(Object, arguments) : {};
+      }
+      return to;
+    }
   },
   assignIn: require('lodash/assignIn'),
   cloneDeep: require('lodash/cloneDeep'),
@@ -68,7 +55,6 @@ module.exports = {
     return uuid.v4();
   },
   values: require('lodash/values'),
-  applyPolyfills: applyPolyfills,
   isNumber: function(value) {
     return typeof value === 'number';
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -17,7 +17,7 @@ var uuid = require('uuid');
 var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 
-// Polyfill Object.assign for older browsers
+// Polyfills for older browsers
 var applyPolyfills = function() {
   if (typeof Object.assign !== 'function') {
     // Must be writable: true, enumerable: false, configurable: true

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -20,7 +20,7 @@ var MAX_NUMBER_LIMIT = Math.pow(2, 53);
 module.exports = {
   assign: function (target) {
     // Object.assign crashes if target object is undefined or null
-    return !!target ? Object.assign.apply(Object, arguments) : {};
+    return target ? Object.assign.apply(Object, arguments) : {};
   },
   assignIn: require('lodash/assignIn'),
   cloneDeep: require('lodash/cloneDeep'),


### PR DESCRIPTION
## Summary
to reduce package size, we are trying to gradually get rid of lodash library. This PR replaces `assign` function with `Object.assign`. Also added a polyfill method to support old browsers. Polyfill was taken from MDN. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill

## Test Plan
All tests pass after this change.