### PR TITLE
Removed lodash.filter

### DIFF
--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -30,7 +30,6 @@ module.exports = {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },
   keyBy: require('lodash/keyBy'),
-  filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
   forOwn: require('lodash/forOwn'),
   map: require('lodash/map'),


### PR DESCRIPTION
## Summary
Removed `lodash.filter` because it wasnt being used anywhere in the project. This is part of an effort to remove lodash dependency to reduce bundle size.

## Test Plan
All Unit tests and Full Stack SDK compatibility passed