### PR TITLE
refactor: Removed dependency on lodash.forOwn

### DIFF
--- a/packages/optimizely-sdk/lib/core/event_builder/event_helpers.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/event_helpers.js
@@ -140,7 +140,8 @@ exports.buildConversionEvent = function buildConversionEvent(config) {
 function buildVisitorAttributes(configObj, attributes) {
   var builtAttributes = [];
   // Omit attribute values that are not supported by the log endpoint.
-  fns.forOwn(attributes, function(attributeValue, attributeKey) {
+  Object.keys(attributes || {}).forEach(function(attributeKey) {
+    var attributeValue = attributes[attributeKey];
     if (attributesValidator.isAttributeValid(attributeKey, attributeValue)) {
       var attributeId = projectConfig.getAttributeId(configObj, attributeKey, logger);
       if (attributeId) {

--- a/packages/optimizely-sdk/lib/core/event_builder/index.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.js
@@ -61,7 +61,8 @@ function getCommonEventParams(options) {
   };
 
   // Omit attribute values that are not supported by the log endpoint.
-  fns.forOwn(attributes, function(attributeValue, attributeKey) {
+  Object.keys(attributes || {}).forEach(function(attributeKey) {
+    var attributeValue = attributes[attributeKey];
     if (attributeValidator.isAttributeValid(attributeKey, attributeValue)) {
       var attributeId = projectConfig.getAttributeId(options.configObj, attributeKey, options.logger);
       if (attributeId) {

--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -16,7 +16,7 @@
 
 var enums = require('../../utils/enums');
 var fns = require('../../utils/fns');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+var jsSdkUtils = require('@optimizely/js-sdk-utils');
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;
@@ -38,8 +38,7 @@ function NotificationCenter(options) {
   this.errorHandler = options.errorHandler;
   this.__notificationListeners = {};
 
-  Object.keys(enums.NOTIFICATION_TYPES).forEach(function(key) {
-    var notificationTypeEnum = enums.NOTIFICATION_TYPES[key];
+  jsSdkUtils.objectValues(enums.NOTIFICATION_TYPES).forEach(function(notificationTypeEnum) {
     this.__notificationListeners[notificationTypeEnum] = [];
   }.bind(this));
   this.__listenerId = 1;
@@ -104,7 +103,7 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
     var indexToRemove;
     var typeToRemove;
 
-    Object.keys(this.__notificationListeners).forEach(function(notificationType) {
+    Object.keys(this.__notificationListeners).some(function(notificationType) {
       var listenersForType = this.__notificationListeners[notificationType];      
       fns.forEach(listenersForType, function (listenerEntry, i) {
         if (listenerEntry.id === listenerId) {
@@ -113,6 +112,9 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
           return false;
         }
       });
+      if (indexToRemove !== undefined && typeToRemove !== undefined) {
+        return true;
+      }
     }.bind(this));
     
     if (indexToRemove !== undefined && typeToRemove !== undefined) {
@@ -131,8 +133,7 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
  */
 NotificationCenter.prototype.clearAllNotificationListeners = function () {
   try{
-    Object.keys(enums.NOTIFICATION_TYPES).forEach(function (key) {
-      var notificationTypeEnum = enums.NOTIFICATION_TYPES[key];
+    jsSdkUtils.objectValues(enums.NOTIFICATION_TYPES).forEach(function (notificationTypeEnum) {
       this.__notificationListeners[notificationTypeEnum] = [];
     }.bind(this));
   } catch (e) {
@@ -167,7 +168,7 @@ NotificationCenter.prototype.sendNotifications = function (notificationType, not
       try {
         callback(notificationData);
       } catch (ex) {
-        this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.NOTIFICATION_LISTENER_EXCEPTION, MODULE_NAME, notificationType, ex.message));
+        this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.NOTIFICATION_LISTENER_EXCEPTION, MODULE_NAME, notificationType, ex.message));
       }
     }.bind(this));
   } catch (e) {

--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -15,7 +15,6 @@
  */
 
 var enums = require('../../utils/enums');
-var fns = require('../../utils/fns');
 var jsSdkUtils = require('@optimizely/js-sdk-utils');
 
 var LOG_LEVEL = enums.LOG_LEVEL;

--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -37,7 +37,9 @@ function NotificationCenter(options) {
   this.logger = options.logger;
   this.errorHandler = options.errorHandler;
   this.__notificationListeners = {};
-  fns.forOwn(enums.NOTIFICATION_TYPES, function(notificationTypeEnum) {
+
+  Object.keys(enums.NOTIFICATION_TYPES).forEach(function(key) {
+    var notificationTypeEnum = enums.NOTIFICATION_TYPES[key];
     this.__notificationListeners[notificationTypeEnum] = [];
   }.bind(this));
   this.__listenerId = 1;
@@ -101,7 +103,9 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
   try {
     var indexToRemove;
     var typeToRemove;
-    fns.forOwn(this.__notificationListeners, function (listenersForType, notificationType) {
+
+    Object.keys(this.__notificationListeners).forEach(function(notificationType) {
+      var listenersForType = this.__notificationListeners[notificationType];      
       fns.forEach(listenersForType, function (listenerEntry, i) {
         if (listenerEntry.id === listenerId) {
           indexToRemove = i;
@@ -109,11 +113,8 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
           return false;
         }
       });
-      if (indexToRemove !== undefined && typeToRemove !== undefined) {
-        return false;
-      }
-    });
-
+    }.bind(this));
+    
     if (indexToRemove !== undefined && typeToRemove !== undefined) {
       this.__notificationListeners[typeToRemove].splice(indexToRemove, 1);
       return true;
@@ -130,7 +131,8 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
  */
 NotificationCenter.prototype.clearAllNotificationListeners = function () {
   try{
-    fns.forOwn(enums.NOTIFICATION_TYPES, function (notificationTypeEnum) {
+    Object.keys(enums.NOTIFICATION_TYPES).forEach(function (key) {
+      var notificationTypeEnum = enums.NOTIFICATION_TYPES[key];
       this.__notificationListeners[notificationTypeEnum] = [];
     }.bind(this));
   } catch (e) {

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -15,7 +15,7 @@
  */
 var fns = require('../../utils/fns');
 var enums = require('../../utils/enums');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+var jsSdkUtils = require('@optimizely/js-sdk-utils');
 var configValidator = require('../../utils/config_validator');
 var projectConfigSchema = require('./project_config_schema');
 
@@ -60,8 +60,7 @@ module.exports = {
     });
 
     projectConfig.rolloutIdMap = fns.keyBy(projectConfig.rollouts || [], 'id');
-    Object.keys(projectConfig.rolloutIdMap || {}).forEach(function (rolloutId) {
-      var rollout = projectConfig.rolloutIdMap[rolloutId];
+    jsSdkUtils.objectValues(projectConfig.rolloutIdMap || {}).forEach(function (rollout) {
       fns.forEach(rollout.experiments || [], function(experiment) {
         projectConfig.experiments.push(fns.cloneDeep(experiment));
         // Creates { <variationKey>: <variation> } map inside of the experiment
@@ -80,8 +79,7 @@ module.exports = {
 
       // Creates { <variationId>: { key: <variationKey>, id: <variationId> } } mapping for quick lookup
       fns.assignIn(projectConfig.variationIdMap, fns.keyBy(experiment.variations, 'id'));
-      Object.keys(experiment.variationKeyMap || {}).forEach(function (variationKey) {
-        var variation = experiment.variationKeyMap[variationKey];
+      jsSdkUtils.objectValues(experiment.variationKeyMap || {}).forEach(function (variation) {
         if (variation.variables) {
           projectConfig.variationVariableUsageMap[variation.id] = fns.keyBy(variation.variables, 'id');
         }
@@ -93,8 +91,7 @@ module.exports = {
     projectConfig.experimentFeatureMap = {};
 
     projectConfig.featureKeyMap = fns.keyBy(projectConfig.featureFlags || [], 'key');
-    Object.keys(projectConfig.featureKeyMap || {}).forEach(function (featureKey) {
-      var feature = projectConfig.featureKeyMap[featureKey];
+    jsSdkUtils.objectValues(projectConfig.featureKeyMap || {}).forEach(function (feature) {
       feature.variableKeyMap = fns.keyBy(feature.variables, 'key');
       fns.forEach(feature.experimentIds || [], function(experimentId) {
         // Add this experiment in experiment-feature map.
@@ -125,7 +122,7 @@ module.exports = {
   getExperimentId: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
     if (!experiment) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.id;
   },
@@ -140,7 +137,7 @@ module.exports = {
   getLayerId: function(projectConfig, experimentId) {
     var experiment = projectConfig.experimentIdMap[experimentId];
     if (!experiment) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_ID, MODULE_NAME, experimentId));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_ID, MODULE_NAME, experimentId));
     }
     return experiment.layerId;
   },
@@ -158,14 +155,14 @@ module.exports = {
     if (attribute) {
       if (hasReservedPrefix) {
         logger.log(LOG_LEVEL.WARN,
-                   sprintf('Attribute %s unexpectedly has reserved prefix %s; using attribute ID instead of reserved attribute name.', attributeKey, RESERVED_ATTRIBUTE_PREFIX));
+                   jsSdkUtils.sprintf('Attribute %s unexpectedly has reserved prefix %s; using attribute ID instead of reserved attribute name.', attributeKey, RESERVED_ATTRIBUTE_PREFIX));
       }
       return attribute.id;
     } else if (hasReservedPrefix) {
       return attributeKey;
     }
 
-    logger.log(LOG_LEVEL.DEBUG, sprintf(ERROR_MESSAGES.UNRECOGNIZED_ATTRIBUTE, MODULE_NAME, attributeKey));
+    logger.log(LOG_LEVEL.DEBUG, jsSdkUtils.sprintf(ERROR_MESSAGES.UNRECOGNIZED_ATTRIBUTE, MODULE_NAME, attributeKey));
     return null;
   },
 
@@ -193,7 +190,7 @@ module.exports = {
   getExperimentStatus: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
     if (!experiment) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.status;
   },
@@ -227,7 +224,7 @@ module.exports = {
   getExperimentAudienceConditions: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
     if (!experiment) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
 
     return experiment.audienceConditions || experiment.audienceIds;
@@ -276,7 +273,7 @@ module.exports = {
       }
     }
 
-    throw new Error(sprintf(ERROR_MESSAGES.EXPERIMENT_KEY_NOT_IN_DATAFILE, MODULE_NAME, experimentKey));
+    throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.EXPERIMENT_KEY_NOT_IN_DATAFILE, MODULE_NAME, experimentKey));
   },
 
   /**
@@ -289,7 +286,7 @@ module.exports = {
   getTrafficAllocation: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
     if (!experiment) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.trafficAllocation;
   },
@@ -309,7 +306,7 @@ module.exports = {
       }
     }
 
-    logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_ID, MODULE_NAME, experimentId));
+    logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_ID, MODULE_NAME, experimentId));
     return null;
   },
 
@@ -330,7 +327,7 @@ module.exports = {
       }
     }
 
-    logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.FEATURE_NOT_IN_DATAFILE, MODULE_NAME, featureKey));
+    logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.FEATURE_NOT_IN_DATAFILE, MODULE_NAME, featureKey));
     return null;
   },
 
@@ -348,13 +345,13 @@ module.exports = {
   getVariableForFeature: function(projectConfig, featureKey, variableKey, logger) {
     var feature = projectConfig.featureKeyMap[featureKey];
     if (!feature) {
-      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.FEATURE_NOT_IN_DATAFILE, MODULE_NAME, featureKey));
+      logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.FEATURE_NOT_IN_DATAFILE, MODULE_NAME, featureKey));
       return null;
     }
 
     var variable = feature.variableKeyMap[variableKey];
     if (!variable) {
-      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.VARIABLE_KEY_NOT_IN_DATAFILE, MODULE_NAME, variableKey, featureKey));
+      logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.VARIABLE_KEY_NOT_IN_DATAFILE, MODULE_NAME, variableKey, featureKey));
       return null;
     }
 
@@ -379,7 +376,7 @@ module.exports = {
     }
 
     if (!projectConfig.variationVariableUsageMap.hasOwnProperty(variation.id)) {
-      logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.VARIATION_ID_NOT_IN_DATAFILE_NO_EXPERIMENT, MODULE_NAME, variation.id));
+      logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.VARIATION_ID_NOT_IN_DATAFILE_NO_EXPERIMENT, MODULE_NAME, variation.id));
       return null;
     }
 
@@ -411,7 +408,7 @@ module.exports = {
     switch (variableType) {
       case FEATURE_VARIABLE_TYPES.BOOLEAN:
         if (variableValue !== 'true' && variableValue !== 'false') {
-          logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
+          logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
           castValue = null;
         } else {
           castValue = variableValue === 'true';
@@ -421,7 +418,7 @@ module.exports = {
       case FEATURE_VARIABLE_TYPES.INTEGER:
         castValue = parseInt(variableValue, 10);
         if (isNaN(castValue)) {
-          logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
+          logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
           castValue = null;
         }
         break;
@@ -429,7 +426,7 @@ module.exports = {
       case FEATURE_VARIABLE_TYPES.DOUBLE:
         castValue = parseFloat(variableValue);
         if (isNaN(castValue)) {
-          logger.log(LOG_LEVEL.ERROR, sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
+          logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(ERROR_MESSAGES.UNABLE_TO_CAST_VALUE, MODULE_NAME, variableValue, variableType));
           castValue = null;
         }
         break;
@@ -487,10 +484,10 @@ module.exports = {
   tryCreatingProjectConfig: function(config) {
     configValidator.validateDatafile(config.datafile);
     if (config.skipJSONValidation === true) {
-      config.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.SKIPPING_JSON_VALIDATION, MODULE_NAME));
+      config.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.SKIPPING_JSON_VALIDATION, MODULE_NAME));
     } else if (config.jsonSchemaValidator) {
       config.jsonSchemaValidator.validate(projectConfigSchema, config.datafile);
-      config.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.VALID_DATAFILE, MODULE_NAME));
+      config.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.VALID_DATAFILE, MODULE_NAME));
     }
     return module.exports.createProjectConfig(config.datafile);
   },

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -60,7 +60,8 @@ module.exports = {
     });
 
     projectConfig.rolloutIdMap = fns.keyBy(projectConfig.rollouts || [], 'id');
-    fns.forOwn(projectConfig.rolloutIdMap, function(rollout) {
+    Object.keys(projectConfig.rolloutIdMap || {}).forEach(function (rolloutId) {
+      var rollout = projectConfig.rolloutIdMap[rolloutId];
       fns.forEach(rollout.experiments || [], function(experiment) {
         projectConfig.experiments.push(fns.cloneDeep(experiment));
         // Creates { <variationKey>: <variation> } map inside of the experiment
@@ -79,8 +80,8 @@ module.exports = {
 
       // Creates { <variationId>: { key: <variationKey>, id: <variationId> } } mapping for quick lookup
       fns.assignIn(projectConfig.variationIdMap, fns.keyBy(experiment.variations, 'id'));
-
-      fns.forOwn(experiment.variationKeyMap, function(variation) {
+      Object.keys(experiment.variationKeyMap || {}).forEach(function (variationKey) {
+        var variation = experiment.variationKeyMap[variationKey];
         if (variation.variables) {
           projectConfig.variationVariableUsageMap[variation.id] = fns.keyBy(variation.variables, 'id');
         }
@@ -92,7 +93,8 @@ module.exports = {
     projectConfig.experimentFeatureMap = {};
 
     projectConfig.featureKeyMap = fns.keyBy(projectConfig.featureFlags || [], 'key');
-    fns.forOwn(projectConfig.featureKeyMap, function(feature) {
+    Object.keys(projectConfig.featureKeyMap || {}).forEach(function (featureKey) {
+      var feature = projectConfig.featureKeyMap[featureKey];
       feature.variableKeyMap = fns.keyBy(feature.variables, 'key');
       fns.forEach(feature.experimentIds || [], function(experimentId) {
         // Add this experiment in experiment-feature map.

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -629,14 +629,12 @@ Optimizely.prototype.getEnabledFeatures = function(userId, attributes) {
       return enabledFeatures;
     }
 
-    fns.forOwn(
-      configObj.featureKeyMap,
-      function(feature) {
-        if (this.isFeatureEnabled(feature.key, userId, attributes)) {
-          enabledFeatures.push(feature.key);
-        }
-      }.bind(this)
-    );
+    Object.keys(configObj.featureKeyMap).forEach(function (featureKey) {
+      var feature = configObj.featureKeyMap[featureKey];
+      if (this.isFeatureEnabled(feature.key, userId, attributes)) {
+        enabledFeatures.push(feature.key);
+      }
+    }.bind(this));
 
     return enabledFeatures;
   } catch (e) {

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -24,7 +24,7 @@ var eventProcessor = require('@optimizely/js-sdk-event-processor');
 var eventTagsValidator = require('../utils/event_tags_validator');
 var notificationCenter = require('../core/notification_center');
 var projectConfig = require('../core/project_config');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+var jsSdkUtils = require('@optimizely/js-sdk-utils');
 var userProfileServiceValidator = require('../utils/user_profile_service_validator');
 var stringValidator = require('../utils/string_value_validator');
 var projectConfigManager = require('../core/project_config/project_config_manager');
@@ -57,7 +57,7 @@ var DEFAULT_ONREADY_TIMEOUT = 30000;
 function Optimizely(config) {
   var clientEngine = config.clientEngine;
   if (enums.VALID_CLIENT_ENGINES.indexOf(clientEngine) === -1) {
-    config.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.INVALID_CLIENT_ENGINE, MODULE_NAME, clientEngine));
+    config.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_CLIENT_ENGINE, MODULE_NAME, clientEngine));
     clientEngine = enums.NODE_CLIENT_ENGINE;
   }
 
@@ -77,7 +77,7 @@ function Optimizely(config) {
   });
 
   this.__disposeOnUpdate = this.projectConfigManager.onUpdate(function(configObj) {
-    this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.UPDATED_OPTIMIZELY_CONFIG, MODULE_NAME, configObj.revision, configObj.projectId));
+    this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.UPDATED_OPTIMIZELY_CONFIG, MODULE_NAME, configObj.revision, configObj.projectId));
     this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
   }.bind(this));
 
@@ -88,7 +88,7 @@ function Optimizely(config) {
     try {
       if (userProfileServiceValidator.validate(config.userProfileService)) {
         userProfileService = config.userProfileService;
-        this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.VALID_USER_PROFILE_SERVICE, MODULE_NAME));
+        this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.VALID_USER_PROFILE_SERVICE, MODULE_NAME));
       }
     } catch (ex) {
       this.logger.log(LOG_LEVEL.WARNING, ex.message);
@@ -138,7 +138,7 @@ Optimizely.prototype.__isValidInstance = function() {
 Optimizely.prototype.activate = function(experimentKey, userId, attributes) {
   try {
     if (!this.__isValidInstance()) {
-      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'activate'));
+      this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'activate'));
       return null;
     }
 
@@ -159,7 +159,7 @@ Optimizely.prototype.activate = function(experimentKey, userId, attributes) {
 
       // If experiment is not set to 'Running' status, log accordingly and return variation key
       if (!projectConfig.isRunning(configObj, experimentKey)) {
-        var shouldNotDispatchActivateLogMessage = sprintf(
+        var shouldNotDispatchActivateLogMessage = jsSdkUtils.sprintf(
           LOG_MESSAGES.SHOULD_NOT_DISPATCH_ACTIVATE,
           MODULE_NAME,
           experimentKey
@@ -173,7 +173,7 @@ Optimizely.prototype.activate = function(experimentKey, userId, attributes) {
       return variationKey;
     } catch (ex) {
       this.logger.log(LOG_LEVEL.ERROR, ex.message);
-      var failedActivationLogMessage = sprintf(LOG_MESSAGES.NOT_ACTIVATING_USER, MODULE_NAME, userId, experimentKey);
+      var failedActivationLogMessage = jsSdkUtils.sprintf(LOG_MESSAGES.NOT_ACTIVATING_USER, MODULE_NAME, userId, experimentKey);
       this.logger.log(LOG_LEVEL.INFO, failedActivationLogMessage);
       this.errorHandler.handleError(ex);
       return null;
@@ -271,7 +271,7 @@ Optimizely.prototype.__emitNotificationCenterActivate = function(experimentKey, 
 Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
   try {
     if (!this.__isValidInstance()) {
-      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'track'));
+      this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'track'));
       return;
     }
 
@@ -285,7 +285,7 @@ Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
     }
 
     if (!projectConfig.eventWithKeyExists(configObj, eventKey)) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_EVENT_KEY, MODULE_NAME, eventKey));
+      throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EVENT_KEY, MODULE_NAME, eventKey));
     }
 
     // remove null values from eventTags
@@ -299,14 +299,14 @@ Optimizely.prototype.track = function(eventKey, userId, attributes, eventTags) {
       clientVersion: this.clientVersion,
       configObj: configObj,
     });
-    this.logger.log(LOG_LEVEL.INFO, sprintf(enums.LOG_MESSAGES.TRACK_EVENT, MODULE_NAME, eventKey, userId));
+    this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(enums.LOG_MESSAGES.TRACK_EVENT, MODULE_NAME, eventKey, userId));
     // TODO is it okay to not pass a projectConfig as second argument
     this.eventProcessor.process(conversionEvent);
     this.__emitNotificationCenterTrack(eventKey, userId, attributes, eventTags);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
     this.errorHandler.handleError(e);
-    var failedTrackLogMessage = sprintf(LOG_MESSAGES.NOT_TRACKING_USER, MODULE_NAME, userId);
+    var failedTrackLogMessage = jsSdkUtils.sprintf(LOG_MESSAGES.NOT_TRACKING_USER, MODULE_NAME, userId);
     this.logger.log(LOG_LEVEL.INFO, failedTrackLogMessage);
   }
 };
@@ -360,7 +360,7 @@ Optimizely.prototype.__emitNotificationCenterTrack = function(eventKey, userId, 
 Optimizely.prototype.getVariation = function(experimentKey, userId, attributes) {
   try {
     if (!this.__isValidInstance()) {
-      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getVariation'));
+      this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getVariation'));
       return null;
     }
 
@@ -376,7 +376,7 @@ Optimizely.prototype.getVariation = function(experimentKey, userId, attributes) 
 
       var experiment = configObj.experimentKeyMap[experimentKey];
       if (!experiment) {
-        this.logger.log(LOG_LEVEL.DEBUG, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
+        this.logger.log(LOG_LEVEL.DEBUG, jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
         return null;
       }
 
@@ -475,7 +475,7 @@ Optimizely.prototype.__validateInputs = function(stringInputs, userAttributes, e
     if (stringInputs.hasOwnProperty('user_id')) {
       var userId = stringInputs.user_id;
       if (typeof userId !== 'string' || userId === null || userId === 'undefined') {
-        throw new Error(sprintf(ERROR_MESSAGES.INVALID_INPUT_FORMAT, MODULE_NAME, 'user_id'));
+        throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_INPUT_FORMAT, MODULE_NAME, 'user_id'));
       }
 
       delete stringInputs.user_id;
@@ -485,7 +485,7 @@ Optimizely.prototype.__validateInputs = function(stringInputs, userAttributes, e
     for (var index = 0; index < inputKeys.length; index++) {
       var key = inputKeys[index];
       if (!stringValidator.validate(stringInputs[key])) {
-        throw new Error(sprintf(ERROR_MESSAGES.INVALID_INPUT_FORMAT, MODULE_NAME, key));
+        throw new Error(jsSdkUtils.sprintf(ERROR_MESSAGES.INVALID_INPUT_FORMAT, MODULE_NAME, key));
       }
     }
     if (userAttributes) {
@@ -509,7 +509,7 @@ Optimizely.prototype.__validateInputs = function(stringInputs, userAttributes, e
  * @return {null}
  */
 Optimizely.prototype.__notActivatingExperiment = function(experimentKey, userId) {
-  var failedActivationLogMessage = sprintf(LOG_MESSAGES.NOT_ACTIVATING_USER, MODULE_NAME, userId, experimentKey);
+  var failedActivationLogMessage = jsSdkUtils.sprintf(LOG_MESSAGES.NOT_ACTIVATING_USER, MODULE_NAME, userId, experimentKey);
   this.logger.log(LOG_LEVEL.INFO, failedActivationLogMessage);
   return null;
 };
@@ -538,7 +538,7 @@ Optimizely.prototype.__filterEmptyValues = function(map) {
 Optimizely.prototype.isFeatureEnabled = function(featureKey, userId, attributes) {
   try {
     if (!this.__isValidInstance()) {
-      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'isFeatureEnabled'));
+      this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'isFeatureEnabled'));
       return false;
     }
 
@@ -574,9 +574,9 @@ Optimizely.prototype.isFeatureEnabled = function(featureKey, userId, attributes)
     }
 
     if (featureEnabled === true) {
-      this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.FEATURE_ENABLED_FOR_USER, MODULE_NAME, featureKey, userId));
+      this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.FEATURE_ENABLED_FOR_USER, MODULE_NAME, featureKey, userId));
     } else {
-      this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.FEATURE_NOT_ENABLED_FOR_USER, MODULE_NAME, featureKey, userId));
+      this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.FEATURE_NOT_ENABLED_FOR_USER, MODULE_NAME, featureKey, userId));
       featureEnabled = false;
     }
 
@@ -616,7 +616,7 @@ Optimizely.prototype.getEnabledFeatures = function(userId, attributes) {
   try {
     var enabledFeatures = [];
     if (!this.__isValidInstance()) {
-      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getEnabledFeatures'));
+      this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getEnabledFeatures'));
       return enabledFeatures;
     }
 
@@ -629,8 +629,7 @@ Optimizely.prototype.getEnabledFeatures = function(userId, attributes) {
       return enabledFeatures;
     }
 
-    Object.keys(configObj.featureKeyMap).forEach(function (featureKey) {
-      var feature = configObj.featureKeyMap[featureKey];
+    jsSdkUtils.objectValues(configObj.featureKeyMap).forEach(function (feature) {
       if (this.isFeatureEnabled(feature.key, userId, attributes)) {
         enabledFeatures.push(feature.key);
       }
@@ -694,7 +693,7 @@ Optimizely.prototype.getFeatureVariable = function(featureKey, variableKey, user
 Optimizely.prototype._getFeatureVariableForType = function(featureKey, variableKey, variableType, userId, attributes) {
   if (!this.__isValidInstance()) {
     var apiName = (variableType) ? 'getFeatureVariable' + variableType.charAt(0).toUpperCase() + variableType.slice(1) : 'getFeatureVariable';
-    this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, apiName));
+    this.logger.log(LOG_LEVEL.ERROR, jsSdkUtils.sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, apiName));
     return null;
   }
 
@@ -722,7 +721,7 @@ Optimizely.prototype._getFeatureVariableForType = function(featureKey, variableK
   } else if (variable.type !== variableType) {
     this.logger.log(
       LOG_LEVEL.WARNING,
-      sprintf(LOG_MESSAGES.VARIABLE_REQUESTED_WITH_WRONG_TYPE, MODULE_NAME, variableType, variable.type)
+      jsSdkUtils.sprintf(LOG_MESSAGES.VARIABLE_REQUESTED_WITH_WRONG_TYPE, MODULE_NAME, variableType, variable.type)
     );
     return null;
   }
@@ -737,16 +736,16 @@ Optimizely.prototype._getFeatureVariableForType = function(featureKey, variableK
     if (value !== null) {
       if (featureEnabled === true) {
         variableValue = value;
-        this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.USER_RECEIVED_VARIABLE_VALUE, MODULE_NAME, variableKey, featureFlag.key, variableValue, userId));
+        this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.USER_RECEIVED_VARIABLE_VALUE, MODULE_NAME, variableKey, featureFlag.key, variableValue, userId));
       } else {
-        this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.FEATURE_NOT_ENABLED_RETURN_DEFAULT_VARIABLE_VALUE, MODULE_NAME,
+        this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.FEATURE_NOT_ENABLED_RETURN_DEFAULT_VARIABLE_VALUE, MODULE_NAME,
           featureFlag.key, userId, variableKey));
       }
     } else {
-      this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.VARIABLE_NOT_USED_RETURN_DEFAULT_VARIABLE_VALUE, MODULE_NAME, variableKey, decision.variation.key));
+      this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.VARIABLE_NOT_USED_RETURN_DEFAULT_VARIABLE_VALUE, MODULE_NAME, variableKey, decision.variation.key));
     }
   } else {
-    this.logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.USER_RECEIVED_DEFAULT_VARIABLE_VALUE, MODULE_NAME, userId,
+    this.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.USER_RECEIVED_DEFAULT_VARIABLE_VALUE, MODULE_NAME, userId,
       variableKey, featureFlag.key));
   }
 
@@ -1043,7 +1042,7 @@ Optimizely.prototype.onReady = function(options) {
     delete this.__readyTimeouts[timeoutId];
     resolveTimeoutPromise({
       success: false,
-      reason: sprintf('onReady timeout expired after %s ms', timeout),
+      reason: jsSdkUtils.sprintf('onReady timeout expired after %s ms', timeout),
     });
   }.bind(this);
   var readyTimeout = setTimeout(onReadyTimeout, timeout);

--- a/packages/optimizely-sdk/lib/utils/attributes_validator/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/attributes_validator/index.tests.js
@@ -72,7 +72,8 @@ describe('lib/utils/attributes_validator', function() {
           '': 'javascript',
         };
 
-        fns.forOwn(userAttributes, function(value, key) {
+        Object.keys(userAttributes).forEach(function (key) {
+          var value = userAttributes[key];  
           assert.isTrue(attributesValidator.isAttributeValid(key, value));
         });
       });
@@ -88,7 +89,8 @@ describe('lib/utils/attributes_validator', function() {
           'outOfBound': Math.pow(2, 53) + 2,
         };
 
-        fns.forOwn(userAttributes, function(value, key) {
+        Object.keys(userAttributes).forEach(function (key) {
+          var value = userAttributes[key];
           assert.isFalse(attributesValidator.isAttributeValid(key, value));
         });
       });

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -33,10 +33,13 @@ module.exports = {
   filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
   forOwn: function(obj, callback) {
-    for(var key in obj) {
-      if(obj.hasOwnProperty(key)){
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)){
         var val = obj[key];
-        callback(val, key, obj);
+        // Breaking early when callback returns false
+        if (callback(val, key, obj) === false) {
+          break;
+        }
       }
     }
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -31,17 +31,6 @@ module.exports = {
   },
   keyBy: require('lodash/keyBy'),
   forEach: require('lodash/forEach'),
-  forOwn: function(obj, callback) {
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)){
-        var val = obj[key];
-        // Breaking early when callback returns false
-        if (callback(val, key, obj) === false) {
-          break;
-        }
-      }
-    }
-  },
   map: require('lodash/map'),
   uuid: function() {
     return uuid.v4();

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -33,9 +33,9 @@ module.exports = {
   filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
   forOwn: function(obj, callback) {
-    for(key in obj) {
+    for(var key in obj) {
       if(obj.hasOwnProperty(key)){
-        val = obj[key];
+        var val = obj[key];
         callback(val, key, obj);
       }
     }

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -32,7 +32,14 @@ module.exports = {
   keyBy: require('lodash/keyBy'),
   filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
-  forOwn: require('lodash/forOwn'),
+  forOwn: function(obj, callback) {
+    for(key in obj) {
+      if(obj.hasOwnProperty(key)){
+        val = obj[key];
+        callback(val, key, obj);
+      }
+    }
+  },
   map: require('lodash/map'),
   uuid: function() {
     return uuid.v4();

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,5 +37,29 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
+    
+    describe('forOwn', function() {
+      it('should return early if false is returned', function() {
+        var obj = {
+          prop1: 'prop1',
+          prop2: 'prop2',
+          prop3: 'prop3',
+          prop4: 'prop4'
+        }
+        var calledCount = 0;
+        fns.forOwn(obj, function(val) {
+          calledCount ++;
+          if (val === 'prop3') {
+            return false;
+          }
+        });
+        assert.equal(calledCount, 3);
+      });
+
+      it('should not crash when first argument is null or undefined', function() {
+        fns.forOwn(null, function() {});
+        fns.forOwn(undefined, function() {});
+      });
+    });
   });
 });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,29 +37,5 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
-    
-    describe('forOwn', function() {
-      it('should return early if false is returned', function() {
-        var obj = {
-          prop1: 'prop1',
-          prop2: 'prop2',
-          prop3: 'prop3',
-          prop4: 'prop4'
-        }
-        var calledCount = 0;
-        fns.forOwn(obj, function(val) {
-          calledCount ++;
-          if (val === 'prop3') {
-            return false;
-          }
-        });
-        assert.equal(calledCount, 3);
-      });
-
-      it('should not crash when first argument is null or undefined', function() {
-        fns.forOwn(null, function() {});
-        fns.forOwn(undefined, function() {});
-      });
-    });
   });
 });


### PR DESCRIPTION
## Summary
Removed `lodash.forOwn` function and replaced all the usaes with `Object.keys`. This is part of an effort to remove lodash dependency to reduce bundle size.

## Test Plan
All Unit tests and Full Stack SDK compatibility passed