### PR TITLE
Removed dependency on lodash.isArray

### DIFF
--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -24,7 +24,9 @@ module.exports = {
   currentTimestamp: function() {
     return Math.round(new Date().getTime());
   },
-  isArray: Array.isArray,
+  isArray: function(value) {
+    return Array.isArray(value);
+  },
   isEmpty: require('lodash/isEmpty'),
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -24,7 +24,7 @@ module.exports = {
   currentTimestamp: function() {
     return Math.round(new Date().getTime());
   },
-  isArray: require('lodash/isArray'),
+  isArray: Array.isArray,
   isEmpty: require('lodash/isEmpty'),
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -24,9 +24,6 @@ module.exports = {
   currentTimestamp: function() {
     return Math.round(new Date().getTime());
   },
-  isArray: function(value) {
-    return Array.isArray(value);
-  },
   isEmpty: require('lodash/isEmpty'),
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;

--- a/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var fns = require('../fns');
 var validate = require('json-schema').validate;
 var sprintf = require('@optimizely/js-sdk-utils').sprintf;
 

--- a/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/json_schema_validator/index.js
@@ -40,7 +40,7 @@ module.exports = {
     if (result.valid) {
       return true;
     } else {
-      if (fns.isArray(result.errors)) {
+      if (Array.isArray(result.errors)) {
         throw new Error(sprintf(ERROR_MESSAGES.INVALID_DATAFILE, MODULE_NAME, result.errors[0].property, result.errors[0].message));
       }
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_JSON, MODULE_NAME));


### PR DESCRIPTION
## Summary
to reduce package size, we are trying to gradually get rid of lodash library. This PR replaces `isArray` function with `Array.isArray`. Because lodash is also using this standard built-in objects from javascript. 

## Test plan
All tests pass after this change.