### PR TITLE
Removed dependency on lodash.isEmpty

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -144,7 +144,7 @@ DecisionService.prototype.__checkIfExperimentIsActive = function(configObj, expe
  * @return {string|null} Forced variation if it exists for user ID, otherwise null
  */
 DecisionService.prototype.__getWhitelistedVariation = function(experiment, userId) {
-  if (!fns.isEmpty(experiment.forcedVariations) && experiment.forcedVariations.hasOwnProperty(userId)) {
+  if (experiment.forcedVariations && experiment.forcedVariations.hasOwnProperty(userId)) {
     var forcedVariationKey = experiment.forcedVariations[userId];
     if (experiment.variationKeyMap.hasOwnProperty(forcedVariationKey)) {
       var forcedBucketingSucceededMessageLog = sprintf(LOG_MESSAGES.USER_FORCED_IN_VARIATION, MODULE_NAME, userId, forcedVariationKey);

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -122,7 +122,7 @@ module.exports = {
    */
   getExperimentId: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
-    if (fns.isEmpty(experiment)) {
+    if (!experiment) {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.id;
@@ -137,7 +137,7 @@ module.exports = {
    */
   getLayerId: function(projectConfig, experimentId) {
     var experiment = projectConfig.experimentIdMap[experimentId];
-    if (fns.isEmpty(experiment)) {
+    if (!experiment) {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_ID, MODULE_NAME, experimentId));
     }
     return experiment.layerId;
@@ -190,7 +190,7 @@ module.exports = {
    */
   getExperimentStatus: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
-    if (fns.isEmpty(experiment)) {
+    if (!experiment) {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.status;
@@ -224,7 +224,7 @@ module.exports = {
    */
   getExperimentAudienceConditions: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
-    if (fns.isEmpty(experiment)) {
+    if (!experiment) {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
 
@@ -286,7 +286,7 @@ module.exports = {
    */
   getTrafficAllocation: function(projectConfig, experimentKey) {
     var experiment = projectConfig.experimentKeyMap[experimentKey];
-    if (fns.isEmpty(experiment)) {
+    if (!experiment) {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
     }
     return experiment.trafficAllocation;

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -375,7 +375,7 @@ Optimizely.prototype.getVariation = function(experimentKey, userId, attributes) 
       }
 
       var experiment = configObj.experimentKeyMap[experimentKey];
-      if (fns.isEmpty(experiment)) {
+      if (!experiment) {
         this.logger.log(LOG_LEVEL.DEBUG, sprintf(ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey));
         return null;
       }

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -27,25 +27,9 @@ module.exports = {
     return Math.round(new Date().getTime());
   },
   isArray: require('lodash/isArray'),
-  isEmpty: function isEmpty(value) {
-    if (value == null) {
-      return true;
-    }
-    var length = value.length;
-    if (typeof length == 'number' && length > -1 && length % 1 === 0 && length <= MAX_SAFE_INTEGER) {
-      var type = typeof value;
-      if (type === 'object') {
-        return !value.length;
-      }
-    }
-    for (var key in value) {
-      if (hasOwnProperty.call(value, key)) {
-        return false;
-      }
-    }
-    return true;
-  }
-  ,
+  isEmpty: function(obj) {
+    return !obj || Object.keys(obj).length === 0;
+  },
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -25,9 +25,6 @@ module.exports = {
     return Math.round(new Date().getTime());
   },
   isArray: require('lodash/isArray'),
-  isEmpty: function(obj) {
-    return !obj || Object.keys(obj).length === 0;
-  },
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -16,6 +16,8 @@
 var uuid = require('uuid');
 var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
+var MAX_SAFE_INTEGER = 9007199254740991;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 module.exports = {
   assign: require('lodash/assign'),
@@ -25,7 +27,25 @@ module.exports = {
     return Math.round(new Date().getTime());
   },
   isArray: require('lodash/isArray'),
-  isEmpty: require('lodash/isEmpty'),
+  isEmpty: function isEmpty(value) {
+    if (value == null) {
+      return true;
+    }
+    var length = value.length;
+    if (typeof length == 'number' && length > -1 && length % 1 === 0 && length <= MAX_SAFE_INTEGER) {
+      var type = typeof value;
+      if (type === 'object') {
+        return !value.length;
+      }
+    }
+    for (var key in value) {
+      if (hasOwnProperty.call(value, key)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  ,
   isFinite: function(number) {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -16,8 +16,6 @@
 var uuid = require('uuid');
 var _isFinite = require('lodash/isFinite');
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
-var MAX_SAFE_INTEGER = 9007199254740991;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 module.exports = {
   assign: require('lodash/assign'),

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,17 +37,5 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
-    describe('isEmpty', function() {
-      it('should return true when object is null', function() {
-        assert.isTrue(fns.isEmpty(null));
-      });
-      it('should return true when object is empty {}', function() {
-        assert.isTrue(fns.isEmpty({}));
-      });
-      it('should return false when object has attributes', function() {
-        var obj = { "key": "value" };
-        assert.isFalse(fns.isEmpty(obj));
-      });
-    });
   });
 });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,5 +37,21 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
+    describe('isEmpty', function() {
+      it('should return true in case of null', function() {
+        assert.isTrue(fns.isEmpty(null));
+      });
+      it('should return True in case of empty {}', function() {
+        assert.isTrue(fns.isEmpty({}));
+      });
+      it('should return false in case of value object', function() {
+        var obj = { "key": "value" };
+        assert.isFalse(fns.isEmpty(obj));
+      });
+      it('should return true if anything else than an object', function() {
+        var obj = { "key": "value" };
+        assert.isTrue(fns.isEmpty(1));
+      });
+    });
   });
 });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,18 +37,6 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
-    
-    describe('isEmpty', function() {
-      it('should return true when object is null', function() {
-        assert.isTrue(fns.isEmpty(null));
-      });
-      it('should return true when object is empty {}', function() {
-        assert.isTrue(fns.isEmpty({}));
-      });
-      it('should return false when object has attributes', function() {
-        var obj = { "key": "value" };
-        assert.isFalse(fns.isEmpty(obj));
-      });
-    });
+
   });
 });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -38,19 +38,15 @@ describe('lib/utils/fns', function() {
       });
     });
     describe('isEmpty', function() {
-      it('should return true in case of null', function() {
+      it('should return true when object is null', function() {
         assert.isTrue(fns.isEmpty(null));
       });
-      it('should return True in case of empty {}', function() {
+      it('should return true when object is empty {}', function() {
         assert.isTrue(fns.isEmpty({}));
       });
-      it('should return false in case of value object', function() {
+      it('should return false when object has attributes', function() {
         var obj = { "key": "value" };
         assert.isFalse(fns.isEmpty(obj));
-      });
-      it('should return true if anything else than an object', function() {
-        var obj = { "key": "value" };
-        assert.isTrue(fns.isEmpty(1));
       });
     });
   });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -39,4 +39,3 @@ describe('lib/utils/fns', function() {
     });
   });
 });
-

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -28,6 +28,7 @@ describe('lib/utils/fns', function() {
         assert.isFalse(fns.isFinite(Math.pow(2, 53) + 2));
         assert.isFalse(fns.isFinite(-Math.pow(2, 53) - 2));
       });
+
       it('should return true for valid numbers', function() {
         assert.isTrue(fns.isFinite(0));
         assert.isTrue(fns.isFinite(10));

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -28,7 +28,6 @@ describe('lib/utils/fns', function() {
         assert.isFalse(fns.isFinite(Math.pow(2, 53) + 2));
         assert.isFalse(fns.isFinite(-Math.pow(2, 53) - 2));
       });
-
       it('should return true for valid numbers', function() {
         assert.isTrue(fns.isFinite(0));
         assert.isTrue(fns.isFinite(10));
@@ -39,3 +38,4 @@ describe('lib/utils/fns', function() {
     });
   });
 });
+

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,6 +37,7 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
+    
     describe('isEmpty', function() {
       it('should return true when object is null', function() {
         assert.isTrue(fns.isEmpty(null));

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,6 +37,17 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
-
+    describe('isEmpty', function() {
+      it('should return true when object is null', function() {
+        assert.isTrue(fns.isEmpty(null));
+      });
+      it('should return true when object is empty {}', function() {
+        assert.isTrue(fns.isEmpty({}));
+      });
+      it('should return false when object has attributes', function() {
+        var obj = { "key": "value" };
+        assert.isFalse(fns.isEmpty(obj));
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
to reduce package size, we are trying to gradually get rid of lodash library. This PR replaces isEmpty function simple implementation for object. Because we are using this methods for object only

## Test plan
Added unit tests for this
