### PR TITLE
feat (Optimizely) [OASIS-5907]: close promise tracks in-flight event dispatcher requests

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug fixes
 - Fixed default event dispatcher not used in React Native entry point ([#383](https://github.com/optimizely/javascript-sdk/pull/383))
 
+### New Features
+- Promise returned from `close` tracks the state of in-flight event dispatcher requests ([#404](https://github.com/optimizely/javascript-sdk/pull/404))
+
 ## [3.4.1] - January 28th, 2020
 
 ### Bug fixes

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -935,20 +935,21 @@ Optimizely.prototype.getOptimizelyConfig = function() {
  * - Pending event queue flushes
  *
  * In-flight datafile requests will be aborted. Any events waiting to be sent
- * as part of a batched event request will be immediately batched and sent to
- * the event dispatcher.
+ * as part of a batched event request will be immediately flushed to the event
+ * dispatcher.
  *
- * If any such requests were sent to the event dispatcher, returns a Promise
- * that fulfills after the event dispatcher calls the response callback for each
- * request. Otherwise, returns an immediately-fulfilled Promise.
+ * Returns a Promise that fulfills after all in-flight event dispatcher requests
+ * (including any final request resulting from flushing the queue as described
+ * above) are complete. If there are no in-flight event dispatcher requests and
+ * no queued events waiting to be sent, returns an immediately-fulfilled Promise.
  *
  * Returned Promises are fulfilled with result objects containing these
  * properties:
- *    - success (boolean): true if all events in the queue at the time close was
- *                         called were combined into requests, sent to the
- *                         event dispatcher, and the event dispatcher called the
- *                         callbacks for each request. false if an unexpected
- *                         error was encountered during the close process.
+ *    - success (boolean): true if the event dispatcher signaled completion of
+ *                         all in-flight and final requests, or if there were no
+ *                         queued events and no in-flight requests. false if an
+ *                         unexpected error was encountered during the close
+ *                         process.
  *    - reason (string=):  If success is false, this is a string property with
  *                         an explanatory message.
  *

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "@optimizely/js-sdk-event-processor": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.3.0.tgz",
-      "integrity": "sha512-KZwl6IO4wigSEhnjOEJ4D9h9plkaiNigTSmfHdkk5ar6pYwEH+KlGFQ4mFZPOZN5iqCFZcX9ZcFdnzuisNZLeg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.4.0.tgz",
+      "integrity": "sha512-5fqBG9N66O+9KWktUTH/OmMiQ4SKi42gP7qqWNKe0Ciu5PlBMTREKmo8+EixcDvDW8yQBvIPBj6GWzKz0RVAxg==",
       "requires": {
         "@optimizely/js-sdk-logging": "^0.1.0",
         "@optimizely/js-sdk-utils": "^0.2.0"

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/optimizely-sdk",
   "dependencies": {
     "@optimizely/js-sdk-datafile-manager": "^0.4.0",
-    "@optimizely/js-sdk-event-processor": "^0.3.0",
+    "@optimizely/js-sdk-event-processor": "^0.4.0",
     "@optimizely/js-sdk-logging": "^0.1.0",
     "@optimizely/js-sdk-utils": "^0.2.0",
     "json-schema": "^0.2.3",


### PR DESCRIPTION
## Summary

Update to js-sdk-event-processor v0.4.0, which supports tracking in-flight event dispatcher requests in its `stop()` promise. The `close` promise (of `Optimizely`) is based on the event processor's `stop` promise, so by this upgrade, we get the new functionality. I updated the `close` doc comment to talk about this new behavior.

## Test plan

Existing tests
Manually tested in Node, browser, and Lambda environments

## Issues

https://optimizely.atlassian.net/browse/OASIS-5907
