### PR TITLE
Removed dependency on lodash.isFinite

### DIFF
--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
@@ -99,7 +99,7 @@ function exactEvaluator(condition, userAttributes, logger) {
   var userValue = userAttributes[conditionName];
   var userValueType = typeof userValue;
 
-  if (!isValueTypeValidForExactConditions(conditionValue) || (fns.isNumber(conditionValue) && !fns.isFinite(conditionValue))) {
+  if (!isValueTypeValidForExactConditions(conditionValue) || (fns.isNumber(conditionValue) && !fns.isSafeInteger(conditionValue))) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.UNEXPECTED_CONDITION_VALUE, MODULE_NAME, JSON.stringify(condition)));
     return null;
   }
@@ -114,7 +114,7 @@ function exactEvaluator(condition, userAttributes, logger) {
     return null;
   }
 
-  if (fns.isNumber(userValue) && !fns.isFinite(userValue)) {
+  if (fns.isNumber(userValue) && !fns.isSafeInteger(userValue)) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.OUT_OF_BOUNDS, MODULE_NAME, JSON.stringify(condition), conditionName));
     return null;
   }
@@ -152,7 +152,7 @@ function greaterThanEvaluator(condition, userAttributes, logger) {
   var userValueType = typeof userValue;
   var conditionValue = condition.value;
 
-  if (!fns.isFinite(conditionValue)) {
+  if (!fns.isSafeInteger(conditionValue)) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.UNEXPECTED_CONDITION_VALUE, MODULE_NAME, JSON.stringify(condition)));
     return null;
   }
@@ -167,7 +167,7 @@ function greaterThanEvaluator(condition, userAttributes, logger) {
     return null;
   }
 
-  if (!fns.isFinite(userValue)) {
+  if (!fns.isSafeInteger(userValue)) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.OUT_OF_BOUNDS, MODULE_NAME, JSON.stringify(condition), conditionName));
     return null;
   }
@@ -191,7 +191,7 @@ function lessThanEvaluator(condition, userAttributes, logger) {
   var userValueType = typeof userValue;
   var conditionValue = condition.value;
 
-  if (!fns.isFinite(conditionValue)) {
+  if (!fns.isSafeInteger(conditionValue)) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.UNEXPECTED_CONDITION_VALUE, MODULE_NAME, JSON.stringify(condition)));
     return null;
   }
@@ -206,7 +206,7 @@ function lessThanEvaluator(condition, userAttributes, logger) {
     return null;
   }
 
-  if (!fns.isFinite(userValue)) {
+  if (!fns.isSafeInteger(userValue)) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.OUT_OF_BOUNDS, MODULE_NAME, JSON.stringify(condition), conditionName));
     return null;
   }

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -1029,7 +1029,7 @@ Optimizely.prototype.onReady = function(options) {
   if (typeof options === 'object' && options !== null) {
     timeout = options.timeout;
   }
-  if (!fns.isFinite(timeout)) {
+  if (!fns.isSafeInteger(timeout)) {
     timeout = DEFAULT_ONREADY_TIMEOUT;
   }
 

--- a/packages/optimizely-sdk/lib/utils/attributes_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/attributes_validator/index.js
@@ -47,6 +47,6 @@ module.exports = {
 
   isAttributeValid: function(attributeKey, attributeValue) {
     return (typeof attributeKey === 'string') &&
-    (typeof attributeValue === 'string' || typeof attributeValue === 'boolean' || (fns.isNumber(attributeValue) && fns.isFinite(attributeValue)));
+    (typeof attributeValue === 'string' || typeof attributeValue === 'boolean' || (fns.isNumber(attributeValue) && fns.isSafeInteger(attributeValue)));
   },
 };

--- a/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.js
+++ b/packages/optimizely-sdk/lib/utils/event_processor_config_validator/index.js
@@ -22,7 +22,7 @@ var fns = require('../fns');
  * @returns boolean
  */
 function validateEventBatchSize(eventBatchSize) {
-  return fns.isFinite(eventBatchSize) && eventBatchSize >= 1;
+  return fns.isSafeInteger(eventBatchSize) && eventBatchSize >= 1;
 }
 
 /**
@@ -31,7 +31,7 @@ function validateEventBatchSize(eventBatchSize) {
  * @returns boolean
  */
 function validateEventFlushInterval(eventFlushInterval) {
-  return fns.isFinite(eventFlushInterval) && eventFlushInterval > 0;
+  return fns.isSafeInteger(eventFlushInterval) && eventFlushInterval > 0;
 }
 
 module.exports = {

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 var uuid = require('uuid');
-var MAX_NUMBER_LIMIT = Math.pow(2, 53);
+var MAX_SAFE_INTEGER_LIMIT = Math.pow(2, 53);
 var keyBy = require('@optimizely/js-sdk-utils').keyBy;
 module.exports = {
   assign: function (target) {
@@ -43,8 +43,8 @@ module.exports = {
   currentTimestamp: function() {
     return Math.round(new Date().getTime());
   },
-  isFinite: function(number) {
-    return typeof number == 'number' && Math.abs(number) <= MAX_NUMBER_LIMIT;
+  isSafeInteger: function(number) {
+    return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
   },
   keyBy: function(arr, key) {
     if (!arr) return {};

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 var uuid = require('uuid');
-var _isFinite = require('lodash/isFinite');
-var keyBy = require('@optimizely/js-sdk-utils').keyBy;
 var MAX_NUMBER_LIMIT = Math.pow(2, 53);
-
+var keyBy = require('@optimizely/js-sdk-utils').keyBy;
 module.exports = {
   assign: function (target) {
     if (!target) {
@@ -29,7 +27,7 @@ module.exports = {
       var to = Object(target);
       for (var index = 1; index < arguments.length; index++) {
         var nextSource = arguments[index];
-        if (nextSource !== null && nextSource !== undefined) { 
+        if (nextSource !== null && nextSource !== undefined) {
           for (var nextKey in nextSource) {
             // Avoid bugs when hasOwnProperty is shadowed
             if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -46,7 +46,7 @@ module.exports = {
     return Math.round(new Date().getTime());
   },
   isFinite: function(number) {
-    return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
+    return typeof number == 'number' && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },
   keyBy: function(arr, key) {
     if (!arr) return {};

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -22,21 +22,21 @@ describe('lib/utils/fns', function() {
   describe('APIs', function() {
     describe('isFinite', function() {
       it('should return false for invalid numbers', function() {
-        assert.isFalse(fns.isFinite(Infinity));
-        assert.isFalse(fns.isFinite(-Infinity));
-        assert.isFalse(fns.isFinite(NaN));
-        assert.isFalse(fns.isFinite(undefined));
-        assert.isFalse(fns.isFinite('3'));
-        assert.isFalse(fns.isFinite(Math.pow(2, 53) + 2));
-        assert.isFalse(fns.isFinite(-Math.pow(2, 53) - 2));
+        assert.isFalse(fns.isSafeInteger(Infinity));
+        assert.isFalse(fns.isSafeInteger(-Infinity));
+        assert.isFalse(fns.isSafeInteger(NaN));
+        assert.isFalse(fns.isSafeInteger(undefined));
+        assert.isFalse(fns.isSafeInteger('3'));
+        assert.isFalse(fns.isSafeInteger(Math.pow(2, 53) + 2));
+        assert.isFalse(fns.isSafeInteger(-Math.pow(2, 53) - 2));
       });
 
       it('should return true for valid numbers', function() {
-        assert.isTrue(fns.isFinite(0));
-        assert.isTrue(fns.isFinite(10));
-        assert.isTrue(fns.isFinite(10.5));
-        assert.isTrue(fns.isFinite(Math.pow(2, 53)));
-        assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
+        assert.isTrue(fns.isSafeInteger(0));
+        assert.isTrue(fns.isSafeInteger(10));
+        assert.isTrue(fns.isSafeInteger(10.5));
+        assert.isTrue(fns.isSafeInteger(Math.pow(2, 53)));
+        assert.isTrue(fns.isSafeInteger(-Math.pow(2, 53)));
       });
     });
 
@@ -58,7 +58,7 @@ describe('lib/utils/fns', function() {
           row4: { key1: 'row4', key2: 'key2row4' }
         });
       });
-      
+
       it('should return empty object when first argument is null or undefined', function() {
         var obj = fns.keyBy(null, 'key1');
         assert.isEmpty(obj);
@@ -67,7 +67,7 @@ describe('lib/utils/fns', function() {
         assert.isEmpty(obj);
         });
     });
-    
+
     describe('isNumber', function() {
       it('should return true in case of number', function() {
         assert.isTrue(fns.isNumber(3));

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -25,6 +25,8 @@ describe('lib/utils/fns', function() {
         assert.isFalse(fns.isFinite(Infinity));
         assert.isFalse(fns.isFinite(-Infinity));
         assert.isFalse(fns.isFinite(NaN));
+        assert.isFalse(fns.isFinite(undefined));
+        assert.isFalse(fns.isFinite('3'));
         assert.isFalse(fns.isFinite(Math.pow(2, 53) + 2));
         assert.isFalse(fns.isFinite(-Math.pow(2, 53) - 2));
       });


### PR DESCRIPTION
## Summary
to reduce package size, we are trying to gradually get rid of lodash library. This PR replaces isFinite function with simple implementation numbers. As we are using this methods for numbers or strings only

## Test plan
Update Unit Tests
