### PR TITLE
Removed dependency on lodash.map

### DIFF
--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -68,7 +68,7 @@ module.exports = {
 };
 
 var toQueryString = function(obj) {
-  return fns.map(obj, function(v, k) {
-    return encodeURIComponent(k) + '=' + encodeURIComponent(v);
+  return Object.keys(obj).map(function(k) {
+    return encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]);
   }).join('&');
 };

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var fns = require('../../utils/fns');
-
 var POST_METHOD = 'POST';
 var GET_METHOD = 'GET';
 var READYSTATE_COMPLETE = 4;

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -33,7 +33,17 @@ module.exports = {
   filter: require('lodash/filter'),
   forEach: require('lodash/forEach'),
   forOwn: require('lodash/forOwn'),
-  map: require('lodash/map'),
+  map: function(obj, callback) {
+    if (Array.isArray(obj)) {
+      // Use available map method for array
+      return obj.map(callback)
+    } else {
+      // custom implementation for Object type
+      return Object.keys(obj).map(function(k) {
+        return callback(obj[k], k);
+      });
+    }
+  },
   uuid: function() {
     return uuid.v4();
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -32,17 +32,6 @@ module.exports = {
   keyBy: require('lodash/keyBy'),
   forEach: require('lodash/forEach'),
   forOwn: require('lodash/forOwn'),
-  map: function(obj, callback) {
-    if (Array.isArray(obj)) {
-      // Use available map method for array
-      return obj.map(callback)
-    } else {
-      // custom implementation for Object type
-      return Object.keys(obj).map(function(k) {
-        return callback(obj[k], k);
-      });
-    }
-  },
   uuid: function() {
     return uuid.v4();
   },

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,5 +37,26 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
+
+    describe('map', function() {
+      it('should work correctly with object', function() {
+        var obj = {
+          prop1: 'p1',
+          prop2: 'p2'
+        }
+        var result = fns.map(obj, function(v, k) {
+          return k + '=' + v;
+        }).join('&');
+        assert.equal('prop1=p1&prop2=p2', result);
+      });
+
+      it('should work correctly with array', function() {
+        var obj = ['item1', 'item2'];
+        var result = fns.map(obj, function(v) {
+          return v;
+        }).join('&');
+        assert.equal('item1&item2', result);
+      });
+    });
   });
 });

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -37,26 +37,5 @@ describe('lib/utils/fns', function() {
         assert.isTrue(fns.isFinite(-Math.pow(2, 53)));
       });
     });
-
-    describe('map', function() {
-      it('should work correctly with object', function() {
-        var obj = {
-          prop1: 'p1',
-          prop2: 'p2'
-        }
-        var result = fns.map(obj, function(v, k) {
-          return k + '=' + v;
-        }).join('&');
-        assert.equal('prop1=p1&prop2=p2', result);
-      });
-
-      it('should work correctly with array', function() {
-        var obj = ['item1', 'item2'];
-        var result = fns.map(obj, function(v) {
-          return v;
-        }).join('&');
-        assert.equal('item1&item2', result);
-      });
-    });
   });
 });


### PR DESCRIPTION
## Summary
To reduce package size, we are trying to gradually get rid of lodash library. This PR removes the `map` function.

## Test plan
All tests pass after this change.