### PR TITLE
Fix return type for close

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -115,7 +115,7 @@ declare module "@optimizely/optimizely-sdk" {
     onReady(options?: {
       timeout?: number;
     }): Promise<{ success: boolean; reason?: string }>;
-    close(): void;
+    close(): Promise<{ success: boolean; reason?: string }>;
   }
 
   // An event to be submitted to Optimizely, enabling tracking the reach and impact of


### PR DESCRIPTION
## Summary
- optimizely.close() does return a Promise. See [here](https://github.com/optimizely/javascript-sdk/blob/9fe10a04a1b30e255e8f5e9f5af433ce5a5565be/packages/optimizely-sdk/lib/optimizely/index.js#L977)
- [Docs](https://docs.developers.optimizely.com/full-stack/docs/event-batching-javascript-node#section-close-optimizely-on-application-exit) also mentions awaiting on close

Fixes `'await' has no effect on the type of this expression.ts(80007)`
