### PR TITLE
Removed dependency on lodash.forEach

### DIFF
--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -66,7 +66,7 @@ NotificationCenter.prototype.addNotificationListener = function (notificationTyp
     }
 
     var callbackAlreadyAdded = false;
-    fns.forEach(this.__notificationListeners[notificationType], function (listenerEntry) {
+    (this.__notificationListeners[notificationType] || []).forEach(function(listenerEntry) {
       if (listenerEntry.callback === callback) {
         callbackAlreadyAdded = true;
         return false;
@@ -102,7 +102,7 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
     var indexToRemove;
     var typeToRemove;
     fns.forOwn(this.__notificationListeners, function (listenersForType, notificationType) {
-      fns.forEach(listenersForType, function (listenerEntry, i) {
+      (listenersForType || []).forEach(function(listenerEntry, i) {
         if (listenerEntry.id === listenerId) {
           indexToRemove = i;
           typeToRemove = notificationType;
@@ -160,7 +160,7 @@ NotificationCenter.prototype.clearNotificationListeners = function (notification
  */
 NotificationCenter.prototype.sendNotifications = function (notificationType, notificationData) {
   try {
-    fns.forEach(this.__notificationListeners[notificationType], function (listenerEntry) {
+    (this.__notificationListeners[notificationType] || []).forEach(function(listenerEntry) {
       var callback = listenerEntry.callback;
       try {
         callback(notificationData);

--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -102,7 +102,7 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
     var indexToRemove;
     var typeToRemove;
     fns.forOwn(this.__notificationListeners, function (listenersForType, notificationType) {
-      (listenersForType || []).forEach(function(listenerEntry, i) {
+      (listenersForType || []).every(function(listenerEntry, i) {
         if (listenerEntry.id === listenerId) {
           indexToRemove = i;
           typeToRemove = notificationType;

--- a/packages/optimizely-sdk/lib/core/notification_center/index.js
+++ b/packages/optimizely-sdk/lib/core/notification_center/index.js
@@ -108,6 +108,7 @@ NotificationCenter.prototype.removeNotificationListener = function (listenerId) 
           typeToRemove = notificationType;
           return false;
         }
+        return true
       });
       if (indexToRemove !== undefined && typeToRemove !== undefined) {
         return false;

--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -41,7 +41,7 @@ module.exports = {
      * Conditions of audiences in projectConfig.typedAudiences are not
      * expected to be string-encoded as they are here in projectConfig.audiences.
      */
-    fns.forEach(projectConfig.audiences, function(audience) {
+    (projectConfig.audiences || []).forEach(function(audience) {
       audience.conditions = JSON.parse(audience.conditions);
     });
     projectConfig.audiencesById = fns.keyBy(projectConfig.audiences, 'id');
@@ -52,16 +52,16 @@ module.exports = {
     projectConfig.groupIdMap = fns.keyBy(projectConfig.groups, 'id');
 
     var experiments;
-    fns.forEach(projectConfig.groupIdMap, function(group, Id) {
-      experiments = fns.cloneDeep(group.experiments);
-      fns.forEach(experiments, function(experiment) {
+    Object.keys(projectConfig.groupIdMap || {}).forEach(function(Id) {
+      experiments = fns.cloneDeep(projectConfig.groupIdMap[Id].experiments);
+      (experiments || []).forEach(function(experiment) {
         projectConfig.experiments.push(fns.assignIn(experiment, {groupId: Id}));
       });
     });
 
     projectConfig.rolloutIdMap = fns.keyBy(projectConfig.rollouts || [], 'id');
     fns.forOwn(projectConfig.rolloutIdMap, function(rollout) {
-      fns.forEach(rollout.experiments || [], function(experiment) {
+      (rollout.experiments || []).forEach(function(experiment) {
         projectConfig.experiments.push(fns.cloneDeep(experiment));
         // Creates { <variationKey>: <variation> } map inside of the experiment
         experiment.variationKeyMap = fns.keyBy(experiment.variations, 'key');
@@ -73,7 +73,7 @@ module.exports = {
 
     projectConfig.variationIdMap = {};
     projectConfig.variationVariableUsageMap = {};
-    fns.forEach(projectConfig.experiments, function(experiment) {
+    (projectConfig.experiments || []).forEach(function(experiment) {
       // Creates { <variationKey>: <variation> } map inside of the experiment
       experiment.variationKeyMap = fns.keyBy(experiment.variations, 'key');
 
@@ -94,7 +94,7 @@ module.exports = {
     projectConfig.featureKeyMap = fns.keyBy(projectConfig.featureFlags || [], 'key');
     fns.forOwn(projectConfig.featureKeyMap, function(feature) {
       feature.variableKeyMap = fns.keyBy(feature.variables, 'key');
-      fns.forEach(feature.experimentIds || [], function(experimentId) {
+      (feature.experimentIds || []).forEach(function(experimentId) {
         // Add this experiment in experiment-feature map.
         if (projectConfig.experimentFeatureMap[experimentId]) {
           projectConfig.experimentFeatureMap[experimentId].push(feature.id);

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -28,7 +28,25 @@ module.exports = {
     return _isFinite(number) && Math.abs(number) <= MAX_NUMBER_LIMIT;
   },
   keyBy: require('lodash/keyBy'),
-  forEach: require('lodash/forEach'),
+  filter: require('lodash/filter'),
+  forEach: function(collection, iteratee) {
+    // checking iteratee is a function otherwise return identity
+    iteratee = typeof iteratee == 'function' ? iteratee : function(value, index, collection) {
+      return value;
+    };
+    if (Array.isArray(collection)) {
+      var index = -1, length = collection == null ? 0 : collection.length;
+
+      while (++index < length) {
+        if (iteratee(collection[index], index, collection) === false) {
+          break;
+        }
+      }
+      return collection;
+    } else {
+
+    }
+  },
   forOwn: require('lodash/forOwn'),
   uuid: function() {
     return uuid.v4();

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -29,24 +29,6 @@ module.exports = {
   },
   keyBy: require('lodash/keyBy'),
   filter: require('lodash/filter'),
-  forEach: function(collection, iteratee) {
-    // checking iteratee is a function otherwise return identity
-    iteratee = typeof iteratee == 'function' ? iteratee : function(value, index, collection) {
-      return value;
-    };
-    if (Array.isArray(collection)) {
-      var index = -1, length = collection == null ? 0 : collection.length;
-
-      while (++index < length) {
-        if (iteratee(collection[index], index, collection) === false) {
-          break;
-        }
-      }
-      return collection;
-    } else {
-
-    }
-  },
   forOwn: require('lodash/forOwn'),
   uuid: function() {
     return uuid.v4();


### PR DESCRIPTION
## Summary
to reduce package size, we are trying to gradually get rid of lodash library. This PR removes the implementation of fns.forEach and replaced it with default forEach method of arrays and Object.Keys for maps

## Test plan
All tests are passing