### PR TITLE
chore(optimizely-sdk): Prepare for 3.6.0-alpha.1 release

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.6.0-alpha.1] - March 4, 2020
+
+### New Features
+
 - Changed `track()` to log a warning instead of an error when the event isn't in the datafile ([#418](https://github.com/optimizely/javascript-sdk/pull/418))
 
 ## [3.5.0] - February 20th, 2020

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -148,7 +148,7 @@ describe('javascript-sdk', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.5.0');
+        assert.equal(optlyInstance.clientVersion, '3.6.0-alpha.1');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -92,7 +92,7 @@ describe('optimizelyFactory', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.5.0');
+        assert.equal(optlyInstance.clientVersion, '3.6.0-alpha.1');
       });
 
       describe('event processor configuration', function() {

--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -92,7 +92,7 @@ describe('javascript-sdk/react-native', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '3.5.0');
+        assert.equal(optlyInstance.clientVersion, '3.6.0-alpha.1');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -174,7 +174,7 @@ exports.CONTROL_ATTRIBUTES = {
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
 exports.REACT_CLIENT_ENGINE = 'react-sdk';
-exports.NODE_CLIENT_VERSION = '3.5.0';
+exports.NODE_CLIENT_VERSION = '3.6.0-alpha.1';
 
 exports.VALID_CLIENT_ENGINES = [
   exports.NODE_CLIENT_ENGINE,

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.5.0",
+  "version": "3.6.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "3.5.0",
+  "version": "3.6.0-alpha.1",
   "description": "JavaScript SDK for Optimizely X Full Stack",
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",


### PR DESCRIPTION
## Summary
- Bumps the version to `3.6.0-alpha.1`
- Updates changelog

