### PR TITLE
refactor: Convert lib/plugins from CJS to ES module

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -55,6 +55,7 @@ describe('javascript-sdk', function() {
         sinon.stub(configValidator, 'validate');
 
         xhr = sinon.useFakeXMLHttpRequest();
+        global.XMLHttpRequest = xhr;
         requests = [];
         xhr.onCreate = function(req) {
           requests.push(req);

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020 Optimizely
+ * Copyright 2016-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/index.browser.umdtests.js
+++ b/packages/optimizely-sdk/lib/index.browser.umdtests.js
@@ -42,6 +42,7 @@ describe('javascript-sdk', function() {
         sinon.stub(Optimizely.prototype, 'close');
 
         xhr = sinon.useFakeXMLHttpRequest();
+        global.XMLHttpRequest = xhr;
         requests = [];
         xhr.onCreate = function(req) {
           requests.push(req);

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.js
@@ -20,3 +20,7 @@
 export var handleError = function() {
   // no-op
 }
+
+export default {
+  handleError,
+}

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020 Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020, Optimizely
+ * Copyright 2016, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,6 @@
 /**
  * Default error handler implementation
  */
-module.exports = {
-  /**
-   * Handle given exception
-   * @param  {Object} exception An exception object
-   */
-  handleError: function() {
-    // no-op
-  },
-};
+export var handleError = function() {
+  // no-op
+}

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var errorHandler = require('./');
+import { handleError } from './';
 
-var chai = require('chai');
+import chai from 'chai';
 var assert = chai.assert;
 
 describe('lib/plugins/error_handler', function() {
   describe('APIs', function() {
     describe('handleError', function() {
       it('should just be a no-op function', function() {
-        assert.isFunction(errorHandler.handleError);
+        assert.isFunction(handleError);
       });
     });
   });

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { handleError } from './';
+import { assert } from 'chai';
 
-import chai from 'chai';
-var assert = chai.assert;
+import { handleError } from './';
 
 describe('lib/plugins/error_handler', function() {
   describe('APIs', function() {

--- a/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/error_handler/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020, Optimizely
+ * Copyright 2016, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -23,7 +23,7 @@ var READYSTATE_COMPLETE = 4;
  * @param  {Object} eventObj
  * @param  {Function} callback
  */
-export const dispatchEvent = function(eventObj, callback) {
+export var dispatchEvent = function(eventObj, callback) {
   var url = eventObj.url;
   var params = eventObj.params;
   var req;

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -70,3 +70,7 @@ function toQueryString(obj) {
     })
     .join('&');
 }
+
+export default {
+  dispatchEvent,
+}

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020 Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,14 +63,14 @@ export var dispatchEvent = function(eventObj, callback) {
   }
 }
 
-function toQueryString(obj) {
+var toQueryString = function(obj) {
   return Object.keys(obj)
     .map(function(k) {
       return encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]);
     })
     .join('&');
-}
+};
 
 export default {
   dispatchEvent,
-}
+};

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,58 +17,56 @@ var POST_METHOD = 'POST';
 var GET_METHOD = 'GET';
 var READYSTATE_COMPLETE = 4;
 
-module.exports = {
-  /**
-   * Sample event dispatcher implementation for tracking impression and conversions
-   * Users of the SDK can provide their own implementation
-   * @param  {Object} eventObj
-   * @param  {Function} callback
-   */
-  dispatchEvent: function(eventObj, callback) {
-    var url = eventObj.url;
-    var params = eventObj.params;
-    var req;
-    if (eventObj.httpVerb === POST_METHOD) {
-      req = new XMLHttpRequest();
-      req.open(POST_METHOD, url, true);
-      req.setRequestHeader('Content-Type', 'application/json');
-      req.onreadystatechange = function() {
-        if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
-          try {
-            callback(params);
-          } catch (e) {
-            // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
-          }
+/**
+ * Sample event dispatcher implementation for tracking impression and conversions
+ * Users of the SDK can provide their own implementation
+ * @param  {Object} eventObj
+ * @param  {Function} callback
+ */
+export const dispatchEvent = function(eventObj, callback) {
+  var url = eventObj.url;
+  var params = eventObj.params;
+  var req;
+  if (eventObj.httpVerb === POST_METHOD) {
+    req = new XMLHttpRequest();
+    req.open(POST_METHOD, url, true);
+    req.setRequestHeader('Content-Type', 'application/json');
+    req.onreadystatechange = function() {
+      if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
+        try {
+          callback(params);
+        } catch (e) {
+          // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
         }
-      };
-      req.send(JSON.stringify(params));
-    } else {
-      // add param for cors headers to be sent by the log endpoint
-      url += '?wxhr=true';
-      if (params) {
-        url += '&' + toQueryString(params);
       }
-
-      req = new XMLHttpRequest();
-      req.open(GET_METHOD, url, true);
-      req.onreadystatechange = function() {
-        if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
-          try {
-            callback();
-          } catch (e) {
-            // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
-          }
-        }
-      };
-      req.send();
+    };
+    req.send(JSON.stringify(params));
+  } else {
+    // add param for cors headers to be sent by the log endpoint
+    url += '?wxhr=true';
+    if (params) {
+      url += '&' + toQueryString(params);
     }
-  },
-};
 
-var toQueryString = function(obj) {
+    req = new XMLHttpRequest();
+    req.open(GET_METHOD, url, true);
+    req.onreadystatechange = function() {
+      if (req.readyState === READYSTATE_COMPLETE && callback && typeof callback === 'function') {
+        try {
+          callback();
+        } catch (e) {
+          // TODO: Log this somehow (consider adding a logger to the EventDispatcher interface)
+        }
+      }
+    };
+    req.send();
+  }
+}
+
+function toQueryString(obj) {
   return Object.keys(obj)
     .map(function(k) {
       return encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]);
     })
     .join('&');
-};
+}

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020, Optimizely
+ * Copyright 2016-2017, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var eventDispatcher = require('./index.browser');
-var chai = require('chai');
+import { dispatchEvent } from './index.browser';
+import chai from 'chai';
+import sinon from 'sinon';
 var assert = chai.assert;
-var sinon = require('sinon');
 
 describe('lib/plugins/event_dispatcher/browser', function() {
   describe('APIs', function() {
@@ -25,7 +25,6 @@ describe('lib/plugins/event_dispatcher/browser', function() {
       var requests;
       beforeEach(function() {
         xhr = sinon.useFakeXMLHttpRequest();
-        global.XMLHttpRequest = xhr;
         requests = [];
         xhr.onCreate = function(req) {
           requests.push(req);
@@ -48,7 +47,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         };
 
         var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
+        dispatchEvent(eventObj, callback);
         assert.strictEqual(1, requests.length);
         assert.strictEqual(requests[0].method, 'POST');
         assert.strictEqual(requests[0].requestBody, JSON.stringify(eventParams));
@@ -67,7 +66,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         };
 
         var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
+        dispatchEvent(eventObj, callback);
         requests[0].respond([
           200,
           {},
@@ -84,7 +83,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
         };
 
         var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
+        dispatchEvent(eventObj, callback);
         requests[0].respond([200, {}, '{"url":"https://cdn.com/event","httpVerb":"GET"']);
         sinon.assert.calledOnce(callback);
         done();

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020, Optimizely
+ * Copyright 2016-2017, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020 Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { dispatchEvent } from './index.browser';
-import chai from 'chai';
+import { assert } from 'chai';
 import sinon from 'sinon';
-var assert = chai.assert;
+
+import { dispatchEvent } from './index.browser';
 
 describe('lib/plugins/event_dispatcher/browser', function() {
   describe('APIs', function() {

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -59,3 +59,7 @@ export var dispatchEvent = function(eventObj, callback) {
   req.end();
   return req;
 }
+
+export default {
+  dispatchEvent,
+}

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, 2020 Optimizely
+ * Copyright 2016-2018, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,8 @@ export var dispatchEvent = function(eventObj, callback) {
   req.write(dataString);
   req.end();
   return req;
-}
+};
 
 export default {
   dispatchEvent,
-}
+};

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, 2020, Optimizely
+ * Copyright 2016-2018, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2018, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,51 +13,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var http = require('http');
-var https = require('https');
-var url = require('url');
+import http from 'http';
+import https from 'https';
+import url from 'url';
 
-module.exports = {
-  /**
-   * Dispatch an HTTP request to the given url and the specified options
-   * @param {Object}  eventObj          Event object containing
-   * @param {string}  eventObj.url      the url to make the request to
-   * @param {Object}  eventObj.params   parameters to pass to the request (i.e. in the POST body)
-   * @param {string}  eventObj.httpVerb the HTTP request method type. only POST is supported.
-   * @param {function} callback         callback to execute
-   * @return {ClientRequest|undefined}          ClientRequest object which made the request, or undefined if no request was made (error)
-   */
-  dispatchEvent: function(eventObj, callback) {
-    // Non-POST requests not supported
-    if (eventObj.httpVerb !== 'POST') {
-      return;
+/**
+ * Dispatch an HTTP request to the given url and the specified options
+ * @param {Object}  eventObj          Event object containing
+ * @param {string}  eventObj.url      the url to make the request to
+ * @param {Object}  eventObj.params   parameters to pass to the request (i.e. in the POST body)
+ * @param {string}  eventObj.httpVerb the HTTP request method type. only POST is supported.
+ * @param {function} callback         callback to execute
+ * @return {ClientRequest|undefined}          ClientRequest object which made the request, or undefined if no request was made (error)
+ */
+export const dispatchEvent = function(eventObj, callback) {
+  // Non-POST requests not supported
+  if (eventObj.httpVerb !== 'POST') {
+    return;
+  }
+
+  var parsedUrl = url.parse(eventObj.url);
+
+  var dataString = JSON.stringify(eventObj.params);
+
+  var requestOptions = {
+    host: parsedUrl.host,
+    path: parsedUrl.path,
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-length': dataString.length.toString(),
+    },
+  };
+
+  var requestCallback = function(response) {
+    if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400) {
+      callback(response);
     }
+  };
 
-    var parsedUrl = url.parse(eventObj.url);
-
-    var dataString = JSON.stringify(eventObj.params);
-
-    var requestOptions = {
-      host: parsedUrl.host,
-      path: parsedUrl.path,
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'content-length': dataString.length.toString(),
-      },
-    };
-
-    var requestCallback = function(response) {
-      if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400) {
-        callback(response);
-      }
-    };
-
-    var req = (parsedUrl.protocol === 'http:' ? http : https).request(requestOptions, requestCallback);
-    // Add no-op error listener to prevent this from throwing
-    req.on('error', function() {});
-    req.write(dataString);
-    req.end();
-    return req;
-  },
-};
+  var req = (parsedUrl.protocol === 'http:' ? http : https).request(requestOptions, requestCallback);
+  // Add no-op error listener to prevent this from throwing
+  req.on('error', function() {});
+  req.write(dataString);
+  req.end();
+  return req;
+}

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.js
@@ -26,7 +26,7 @@ import url from 'url';
  * @param {function} callback         callback to execute
  * @return {ClientRequest|undefined}          ClientRequest object which made the request, or undefined if no request was made (error)
  */
-export const dispatchEvent = function(eventObj, callback) {
+export var dispatchEvent = function(eventObj, callback) {
   // Non-POST requests not supported
   if (eventObj.httpVerb !== 'POST') {
     return;

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, 2020, Optimizely
+ * Copyright 2016-2018, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, 2020 Optimizely
+ * Copyright 2016-2018, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { dispatchEvent } from './index.node';
 import nock from 'nock';
 import sinon from 'sinon';
-import chai from 'chai';
+import { assert } from 'chai';
 
-var assert = chai.assert;
+import { dispatchEvent } from './index.node';
 
 describe('lib/plugins/event_dispatcher/node', function() {
   describe('APIs', function() {

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2018, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var eventDispatcher = require('./index.node');
-var chai = require('chai');
+import { dispatchEvent } from './index.node';
+import nock from 'nock';
+import sinon from 'sinon';
+import chai from 'chai';
+
 var assert = chai.assert;
-var nock = require('nock');
-var sinon = require('sinon');
 
 describe('lib/plugins/event_dispatcher/node', function() {
   describe('APIs', function() {
@@ -49,7 +50,7 @@ describe('lib/plugins/event_dispatcher/node', function() {
           httpVerb: 'POST',
         };
 
-        eventDispatcher.dispatchEvent(eventObj, function(resp) {
+        dispatchEvent(eventObj, function(resp) {
           assert.equal(200, resp.statusCode);
           done();
         });
@@ -64,8 +65,7 @@ describe('lib/plugins/event_dispatcher/node', function() {
           httpVerb: 'POST',
         };
 
-        eventDispatcher
-          .dispatchEvent(eventObj, stubCallback.callback)
+        dispatchEvent(eventObj, stubCallback.callback)
           .on('response', function(response) {
             sinon.assert.calledOnce(stubCallback.callback);
             done();
@@ -85,7 +85,7 @@ describe('lib/plugins/event_dispatcher/node', function() {
         };
 
         var callback = sinon.spy();
-        eventDispatcher.dispatchEvent(eventObj, callback);
+        dispatchEvent(eventObj, callback);
         sinon.assert.notCalled(callback);
       });
     });
@@ -98,7 +98,7 @@ describe('lib/plugins/event_dispatcher/node', function() {
       };
 
       var callback = sinon.spy();
-      eventDispatcher.dispatchEvent(eventObj, callback);
+      dispatchEvent(eventObj, callback);
       sinon.assert.notCalled(callback);
     });
   });

--- a/packages/optimizely-sdk/lib/plugins/logger/enums.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/enums.js
@@ -15,4 +15,4 @@
  */
 import { LogLevel } from '@optimizely/js-sdk-logging';
 
-export const LOG_LEVEL = LogLevel;
+export var LOG_LEVEL = LogLevel;

--- a/packages/optimizely-sdk/lib/plugins/logger/enums.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/enums.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020 Optimizely
+ * Copyright 2016, 2020. Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { LogLevel } from '@optimizely/js-sdk-logging';
-
-export var LOG_LEVEL = LogLevel;
+export { LOG_LEVEL as LogLevel } from '@optimizely/js-sdk-logging';

--- a/packages/optimizely-sdk/lib/plugins/logger/enums.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/enums.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020, Optimizely
+ * Copyright 2016, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/logger/enums.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/enums.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-exports.LOG_LEVEL = require('@optimizely/js-sdk-logging').LogLevel;
+import { LogLevel } from '@optimizely/js-sdk-logging';
+
+export const LOG_LEVEL = LogLevel;

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -26,3 +26,8 @@ export var createLogger = function(opts) {
 export var createNoOpLogger = function() {
   return new NoOpLogger();
 }
+
+export default {
+  createLogger,
+  createNoOpLogger,
+}

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020 Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ NoOpLogger.prototype.log = function() {};
 
 export var createLogger = function(opts) {
   return new ConsoleLogHandler(opts);
-}
+};
 
 export var createNoOpLogger = function() {
   return new NoOpLogger();
-}
+};
 
 export default {
   createLogger,
   createNoOpLogger,
-}
+};

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -19,10 +19,10 @@ function NoOpLogger() {}
 
 NoOpLogger.prototype.log = function() {};
 
-export const createLogger = function(opts) {
+export var createLogger = function(opts) {
   return new ConsoleLogHandler(opts);
 }
 
-export const createNoOpLogger = function() {
+export var createNoOpLogger = function() {
   return new NoOpLogger();
 }

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2017, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var logging = require('@optimizely/js-sdk-logging');
+import { ConsoleLogHandler } from '@optimizely/js-sdk-logging';
 
 function NoOpLogger() {}
 
 NoOpLogger.prototype.log = function() {};
 
-module.exports = {
-  createLogger: function(opts) {
-    return new logging.ConsoleLogHandler(opts);
-  },
+export const createLogger = function(opts) {
+  return new ConsoleLogHandler(opts);
+}
 
-  createNoOpLogger: function() {
-    return new NoOpLogger();
-  },
-};
+export const createNoOpLogger = function() {
+  return new NoOpLogger();
+}

--- a/packages/optimizely-sdk/lib/plugins/logger/index.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2020, Optimizely
+ * Copyright 2016-2017, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Optimizely
+ * Copyright 2019, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var LogLevel = require('@optimizely/js-sdk-logging').LogLevel;
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+import { LogLevel } from '@optimizely/js-sdk-logging';
+import { sprintf } from '@optimizely/js-sdk-utils';
 
 function getLogLevelName(level) {
   switch (level) {
@@ -54,12 +54,10 @@ function NoOpLogger() {}
 
 NoOpLogger.prototype.log = function() {};
 
-module.exports = {
-  createLogger: function() {
-    return new ReactNativeLogger();
-  },
+export const createLogger = function() {
+  return new ReactNativeLogger();
+}
 
-  createNoOpLogger: function() {
-    return new NoOpLogger();
-  },
-};
+export const createNoOpLogger = function() {
+  return new NoOpLogger();
+}

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, 2020 Optimizely
+ * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,4 +65,4 @@ export var createNoOpLogger = function() {
 export default {
   createLogger,
   createNoOpLogger,
-}
+};

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
@@ -61,3 +61,8 @@ export var createLogger = function() {
 export var createNoOpLogger = function() {
   return new NoOpLogger();
 }
+
+export default {
+  createLogger,
+  createNoOpLogger,
+}

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
@@ -54,10 +54,10 @@ function NoOpLogger() {}
 
 NoOpLogger.prototype.log = function() {};
 
-export const createLogger = function() {
+export var createLogger = function() {
   return new ReactNativeLogger();
 }
 
-export const createNoOpLogger = function() {
+export var createNoOpLogger = function() {
   return new NoOpLogger();
 }

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, 2020, Optimizely
+ * Copyright 2019, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, 2020 Optimizely
+ * Copyright 2019-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createLogger } from './index.react_native';
-import enums from '../../utils/enums';
 import sinon from 'sinon';
-import chai from 'chai';
+import { assert } from 'chai';
 
-var assert = chai.assert;
+import { createLogger } from './index.react_native';
+import { LOG_LEVEL } from '../../utils/enums';
 
-var LOG_LEVEL = enums.LOG_LEVEL;
 describe('lib/plugins/logger/react_native', function() {
   describe('APIs', function() {
     var defaultLogger;

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, 2020, Optimizely
+ * Copyright 2019, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.react_native.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Optimizely
+ * Copyright 2019, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var logger = require('./index.react_native');
-var chai = require('chai');
-var enums = require('../../utils/enums');
+import { createLogger } from './index.react_native';
+import enums from '../../utils/enums';
+import sinon from 'sinon';
+import chai from 'chai';
+
 var assert = chai.assert;
-var sinon = require('sinon');
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 describe('lib/plugins/logger/react_native', function() {
@@ -25,14 +26,14 @@ describe('lib/plugins/logger/react_native', function() {
     var defaultLogger;
     describe('createLogger', function() {
       it('should return an instance of the default logger', function() {
-        defaultLogger = logger.createLogger();
+        defaultLogger = createLogger();
         assert.isObject(defaultLogger);
       });
     });
 
     describe('log', function() {
       beforeEach(function() {
-        defaultLogger = logger.createLogger();
+        defaultLogger = createLogger();
 
         sinon.stub(console, 'log');
         sinon.stub(console, 'info');

--- a/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var logger = require('./');
-var chai = require('chai');
-var enums = require('../../utils/enums');
+import { createLogger } from './';
+import enums from '../../utils/enums';
+import chai from 'chai';
+import sinon from 'sinon';
+
 var assert = chai.assert;
 var expect = chai.expect;
-var sinon = require('sinon');
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 describe('lib/plugins/logger', function() {
@@ -26,7 +27,7 @@ describe('lib/plugins/logger', function() {
     var defaultLogger;
     describe('createLogger', function() {
       it('should return an instance of the default logger', function() {
-        defaultLogger = logger.createLogger({ logLevel: LOG_LEVEL.NOTSET });
+        defaultLogger = createLogger({ logLevel: LOG_LEVEL.NOTSET });
         assert.isObject(defaultLogger);
         expect(defaultLogger.logLevel).to.equal(LOG_LEVEL.NOTSET);
       });
@@ -34,7 +35,7 @@ describe('lib/plugins/logger', function() {
 
     describe('log', function() {
       beforeEach(function() {
-        defaultLogger = logger.createLogger({ logLevel: LOG_LEVEL.INFO });
+        defaultLogger = createLogger({ logLevel: LOG_LEVEL.INFO });
 
         sinon.stub(console, 'log');
         sinon.stub(console, 'info');
@@ -81,7 +82,7 @@ describe('lib/plugins/logger', function() {
 
     describe('setLogLevel', function() {
       beforeEach(function() {
-        defaultLogger = logger.createLogger({ logLevel: LOG_LEVEL.NOTSET });
+        defaultLogger = createLogger({ logLevel: LOG_LEVEL.NOTSET });
       });
 
       it('should set the log level to the specified log level', function() {

--- a/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020 Optimizely
+ * Copyright 2016, 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createLogger } from './';
-import enums from '../../utils/enums';
-import chai from 'chai';
+import { assert, expect } from 'chai';
 import sinon from 'sinon';
 
-var assert = chai.assert;
-var expect = chai.expect;
+import { createLogger } from './';
+import { LOG_LEVEL } from '../../utils/enums';;
 
-var LOG_LEVEL = enums.LOG_LEVEL;
 describe('lib/plugins/logger', function() {
   describe('APIs', function() {
     var defaultLogger;

--- a/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/logger/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2020, Optimizely
+ * Copyright 2016, 2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/rollup.config.js
+++ b/packages/optimizely-sdk/rollup.config.js
@@ -54,6 +54,7 @@ const umdconfig = {
     commonjs({
       namedExports: {
         '@optimizely/js-sdk-logging': [
+          'ConsoleLogHandler',
           'getLogger',
           'setLogLevel',
           'LogLevel',


### PR DESCRIPTION
## Summary
This PR converts contents inside `lib/plugins` to ESModule.


## Test plan
All unit test and Full stack compatibility suite tests pass.