### PR TITLE
feat: Added React Native Client Engines to be sent in events

### DIFF
--- a/packages/optimizely-sdk/lib/index.react_native.js
+++ b/packages/optimizely-sdk/lib/index.react_native.js
@@ -88,7 +88,7 @@ module.exports = {
 
       config = fns.assign(
         {
-          clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
+          clientEngine: enums.REACT_NATIVE_JS_CLIENT_ENGINE,
           eventBatchSize: DEFAULT_EVENT_BATCH_SIZE,
           eventDispatcher: defaultEventDispatcher,
           eventFlushInterval: DEFAULT_EVENT_FLUSH_INTERVAL,
@@ -100,6 +100,11 @@ module.exports = {
           errorHandler: logging.getErrorHandler(),
         }
       );
+
+      // If client engine is react, convert it to react native
+      if (config.clientEngine === enums.REACT_CLIENT_ENGINE) {
+        config.clientEngine = enums.REACT_NATIVE_CLIENT_ENGINE
+      }
 
       if (!eventProcessorConfigValidator.validateEventBatchSize(config.eventBatchSize)) {
         logger.warn('Invalid eventBatchSize %s, defaulting to %s', config.eventBatchSize, DEFAULT_EVENT_BATCH_SIZE);

--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -95,7 +95,7 @@ describe('javascript-sdk/react-native', function() {
         assert.equal(optlyInstance.clientVersion, '3.6.0-alpha.1');
       });
 
-      it('should set the JavaScript client engine and version', function() {
+      it('should set the React Native JS client engine and javascript SDK version', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           datafile: {},
           errorHandler: fakeErrorHandler,
@@ -104,11 +104,11 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('javascript-sdk', optlyInstance.clientEngine);
+        assert.equal('react-native-js', optlyInstance.clientEngine);
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
       });
 
-      it('should allow passing of "react-sdk" as the clientEngine', function() {
+      it('should allow passing of "react-sdk" as the clientEngine and convert it to "react-native"', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           clientEngine: 'react-sdk',
           datafile: {},
@@ -118,7 +118,7 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('react-sdk', optlyInstance.clientEngine);
+        assert.equal('react-native', optlyInstance.clientEngine);
       });
 
       it('should activate with provided event dispatcher', function() {

--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -104,11 +104,11 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('react-native-js', optlyInstance.clientEngine);
+        assert.equal('react-native-js-sdk', optlyInstance.clientEngine);
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
       });
 
-      it('should allow passing of "react-sdk" as the clientEngine and convert it to "react-native"', function() {
+      it('should allow passing of "react-sdk" as the clientEngine and convert it to "react-native-sdk"', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           clientEngine: 'react-sdk',
           datafile: {},
@@ -118,7 +118,7 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('react-native', optlyInstance.clientEngine);
+        assert.equal('react-native-sdk', optlyInstance.clientEngine);
       });
 
       it('should activate with provided event dispatcher', function() {

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -174,12 +174,16 @@ exports.CONTROL_ATTRIBUTES = {
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
 exports.REACT_CLIENT_ENGINE = 'react-sdk';
+exports.REACT_NATIVE_CLIENT_ENGINE = 'react-native';
+exports.REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js';
 exports.NODE_CLIENT_VERSION = '3.6.0-alpha.1';
 
 exports.VALID_CLIENT_ENGINES = [
   exports.NODE_CLIENT_ENGINE,
   exports.REACT_CLIENT_ENGINE,
   exports.JAVASCRIPT_CLIENT_ENGINE,
+  exports.REACT_NATIVE_CLIENT_ENGINE,
+  exports.REACT_NATIVE_JS_CLIENT_ENGINE,
 ];
 
 exports.NOTIFICATION_TYPES = jsSdkUtils.NOTIFICATION_TYPES;

--- a/packages/optimizely-sdk/lib/utils/enums/index.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.js
@@ -174,8 +174,8 @@ exports.CONTROL_ATTRIBUTES = {
 exports.JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 exports.NODE_CLIENT_ENGINE = 'node-sdk';
 exports.REACT_CLIENT_ENGINE = 'react-sdk';
-exports.REACT_NATIVE_CLIENT_ENGINE = 'react-native';
-exports.REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js';
+exports.REACT_NATIVE_CLIENT_ENGINE = 'react-native-sdk';
+exports.REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
 exports.NODE_CLIENT_VERSION = '3.6.0-alpha.1';
 
 exports.VALID_CLIENT_ENGINES = [

--- a/packages/optimizely-sdk/lib/utils/enums/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/enums/index.tests.js
@@ -1,0 +1,29 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+var chai = require('chai')
+var enums = require('./')
+var assert = chai.assert;
+
+describe('lib/utils/enums', function() {
+  describe('valid client engines', function() {
+    it('all valid client engines should end with "-sdk"', function() {
+      enums.VALID_CLIENT_ENGINES.forEach(function(clientEngine) {
+        assert.isTrue(clientEngine.endsWith('-sdk'))
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Added Two new client engine values to be sent in events.
#### react-native-js
Client Engine will be set to `react-native-js` when a react native application will use javascript sdk directly
#### react-native
Client Engine will be set to `react-native` when a react native application will use react sdk 
#### Client Versions
Client versions behave correctly without any change. Current behaviour is.
1. When a react native app uses javascript SDK directly, clientVersion will be the version of javascript SDK. Which means `react-native-js` goes with `clientVersion` of javascript SDK
2. When a react native app uses React SDK, clientVersion will be the version passed in by react SDK. This means `react-native` goes with `clientVersion` of react SDK. 

## Test plan
Made appropriate changes to already existing unit tests.