### PR TITLE
Change functionality of JSON schema validation by removing skipJSONValidation entirely.

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/index.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.js
@@ -499,14 +499,13 @@ module.exports = {
    * @param  {Object} config.datafile
    * @param  {Object} config.jsonSchemaValidator
    * @param  {Object} config.logger
-   * @param  {Object} config.skipJSONValidation
    * @return {Object} Project config object
    */
   tryCreatingProjectConfig: function(config) {
     configValidator.validateDatafile(config.datafile);
-    if (config.skipJSONValidation === true) {
+    if (!config.jsonSchemaValidator) {
       config.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.SKIPPING_JSON_VALIDATION, MODULE_NAME));
-    } else if (config.jsonSchemaValidator) {
+    } else {
       config.jsonSchemaValidator.validate(config.datafile);
       config.logger.log(LOG_LEVEL.INFO, jsSdkUtils.sprintf(LOG_MESSAGES.VALID_DATAFILE, MODULE_NAME));
     }

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -726,7 +726,6 @@ describe('lib/core/project_config', function() {
         datafile: { foo: 'bar' },
         jsonSchemaValidator: stubJsonSchemaValidator,
         logger: logger,
-        skipJSONValidation: false,
       });
       assert.deepEqual(result, configObj);
     });
@@ -739,7 +738,6 @@ describe('lib/core/project_config', function() {
           datafile: { foo: 'bar' },
           jsonSchemaValidator: stubJsonSchemaValidator,
           logger: logger,
-          skipJSONValidation: false,
         });
       });
     });
@@ -752,19 +750,8 @@ describe('lib/core/project_config', function() {
           datafile: { foo: 'bar' },
           jsonSchemaValidator: stubJsonSchemaValidator,
           logger: logger,
-          skipJSONValidation: false,
         });
       });
-    });
-
-    it('does not call jsonSchemaValidator.validate when skipJSONValidation is true', function() {
-      projectConfig.tryCreatingProjectConfig({
-        datafile: { foo: 'bar' },
-        jsonSchemaValidator: stubJsonSchemaValidator,
-        logger: logger,
-        skipJSONValidation: true,
-      });
-      sinon.assert.notCalled(stubJsonSchemaValidator.validate);
     });
 
     it('skips json validation when jsonSchemaValidator is not provided', function() {

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
@@ -54,7 +54,6 @@ function getErrorMessage(maybeError, defaultMessage) {
  * @param {Object=}        config.datafileOptions
  * @param {Object=}        config.jsonSchemaValidator
  * @param {string=}        config.sdkKey
- * @param {boolean=}       config.skipJSONValidation
  */
 function ProjectConfigManager(config) {
   try {
@@ -80,12 +79,10 @@ function ProjectConfigManager(config) {
  * @param {Object=}        config.datafileOptions
  * @param {Object=}        config.jsonSchemaValidator
  * @param {string=}        config.sdkKey
- * @param {boolean=}       config.skipJSONValidation
  */
 ProjectConfigManager.prototype.__initialize = function(config) {
   this.__updateListeners = [];
   this.jsonSchemaValidator = config.jsonSchemaValidator;
-  this.skipJSONValidation = config.skipJSONValidation;
 
   if (!config.datafile && !config.sdkKey) {
     this.__configObj = null;
@@ -106,7 +103,6 @@ ProjectConfigManager.prototype.__initialize = function(config) {
         datafile: initialDatafile,
         jsonSchemaValidator: this.jsonSchemaValidator,
         logger: logger,
-        skipJSONValidation: this.skipJSONValidation,
       });
       this.__optimizelyConfigObj = optimizelyConfig.getOptimizelyConfig(this.__configObj);
     } catch (ex) {
@@ -162,7 +158,6 @@ ProjectConfigManager.prototype.__onDatafileManagerReadyFulfill = function() {
       datafile: newDatafile,
       jsonSchemaValidator: this.jsonSchemaValidator,
       logger: logger,
-      skipJSONValidation: this.skipJSONValidation,
     });
   } catch (ex) {
     logger.error(ex);
@@ -204,7 +199,6 @@ ProjectConfigManager.prototype.__onDatafileManagerUpdate = function() {
       datafile: newDatafile,
       jsonSchemaValidator: this.jsonSchemaValidator,
       logger: logger,
-      skipJSONValidation: this.skipJSONValidation,
     });
   } catch (ex) {
     logger.error(ex);

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
@@ -59,7 +59,6 @@ describe('lib/core/project_config/project_config_manager', function() {
 
   it('should call the error handler and fulfill onReady with an unsuccessful result if neither datafile nor sdkKey are passed into the constructor', function() {
     var manager = new projectConfigManager.ProjectConfigManager({
-      skipJSONValidation: true,
     });
     sinon.assert.calledOnce(globalStubErrorHandler.handleError);
     var errorMessage = globalStubErrorHandler.handleError.lastCall.args[0].message;
@@ -75,7 +74,6 @@ describe('lib/core/project_config/project_config_manager', function() {
     var invalidDatafileJSON = 'abc';
     var manager = new projectConfigManager.ProjectConfigManager({
       datafile: invalidDatafileJSON,
-      skipJSONValidation: true,
     });
     sinon.assert.calledOnce(globalStubErrorHandler.handleError);
     var errorMessage = globalStubErrorHandler.handleError.lastCall.args[0].message;
@@ -131,20 +129,18 @@ describe('lib/core/project_config/project_config_manager', function() {
       jsonSchemaValidator.validate.restore();
     });
 
-    it('should skip JSON schema validation if skipJSONValidation is passed into instance args with `true` value', function() {
+    it('should skip JSON schema validation if jsonSchemaValidator is not provided', function() {
       var manager = new projectConfigManager.ProjectConfigManager({
         datafile: testData.getTestProjectConfig(),
-        skipJSONValidation: true,
       });
       sinon.assert.notCalled(jsonSchemaValidator.validate);
       return manager.onReady();
     });
 
-    it('should not skip JSON schema validation if skipJSONValidation is passed into instance args with any value other than true', function() {
+    it('should not skip JSON schema validation if jsonSchemaValidator is provided', function() {
       var manager = new projectConfigManager.ProjectConfigManager({
         datafile: testData.getTestProjectConfig(),
         jsonSchemaValidator: jsonSchemaValidator,
-        skipJSONValidation: 'hi',
       });
       sinon.assert.calledOnce(jsonSchemaValidator.validate);
       sinon.assert.calledOnce(stubLogHandler.log);

--- a/packages/optimizely-sdk/lib/index.browser.js
+++ b/packages/optimizely-sdk/lib/index.browser.js
@@ -84,12 +84,6 @@ module.exports = {
         config.isValidInstance = false;
       }
 
-      // Explicitly check for null or undefined
-      // prettier-ignore
-      if (config.skipJSONValidation == null) { // eslint-disable-line eqeqeq
-        config.skipJSONValidation = true;
-      }
-
       var eventDispatcher;
       // prettier-ignore
       if (config.eventDispatcher == null) { // eslint-disable-line eqeqeq

--- a/packages/optimizely-sdk/lib/index.browser.umdtests.js
+++ b/packages/optimizely-sdk/lib/index.browser.umdtests.js
@@ -74,7 +74,6 @@ describe('javascript-sdk', function() {
         // checking that INFO logs log for an unspecified logLevel
         var optlyInstance = window.optimizelySdk.createInstance({
           datafile: testData.getTestProjectConfig(),
-          skipJSONValidation: true,
         });
         assert.strictEqual(console.info.getCalls().length, 1);
         call = console.info.getCalls()[0];
@@ -87,7 +86,6 @@ describe('javascript-sdk', function() {
         var optlyInstance = window.optimizelySdk.createInstance({
           datafile: testData.getTestProjectConfig(),
           logLevel: enums.LOG_LEVEL.ERROR,
-          skipJSONValidation: true,
         });
         assert.strictEqual(console.log.getCalls().length, 0);
 

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -49,7 +49,6 @@ declare module '@optimizely/optimizely-sdk' {
       | enums.LOG_LEVEL.INFO
       | enums.LOG_LEVEL.NOTSET
       | enums.LOG_LEVEL.WARNING;
-    skipJSONValidation?: boolean;
     jsonSchemaValidator?: object;
     userProfileService?: UserProfileService | null;
     eventBatchSize?: number;

--- a/packages/optimizely-sdk/lib/index.node.js
+++ b/packages/optimizely-sdk/lib/index.node.js
@@ -19,7 +19,6 @@ var defaultErrorHandler = require('./plugins/error_handler');
 var defaultEventDispatcher = require('./plugins/event_dispatcher/index.node');
 var enums = require('./utils/enums');
 var fns = require('./utils/fns');
-var jsonSchemaValidator = require('./utils/json_schema_validator');
 var loggerPlugin = require('./plugins/logger');
 var Optimizely = require('./optimizely');
 var eventProcessorConfigValidator = require('./utils/event_processor_config_validator');
@@ -48,7 +47,6 @@ module.exports = {
    * @param  {Object} config.datafile
    * @param  {Object} config.errorHandler
    * @param  {Object} config.eventDispatcher
-   * @param  {Object} config.jsonSchemaValidator
    * @param  {Object} config.logger
    * @param  {Object} config.userProfileService
    * @param {Object} config.eventBatchSize
@@ -93,8 +91,6 @@ module.exports = {
           eventBatchSize: DEFAULT_EVENT_BATCH_SIZE,
           eventDispatcher: defaultEventDispatcher,
           eventFlushInterval: DEFAULT_EVENT_FLUSH_INTERVAL,
-          jsonSchemaValidator: jsonSchemaValidator,
-          skipJSONValidation: false,
         },
         config,
         {

--- a/packages/optimizely-sdk/lib/index.react_native.js
+++ b/packages/optimizely-sdk/lib/index.react_native.js
@@ -80,12 +80,6 @@ module.exports = {
         config.isValidInstance = false;
       }
 
-      // Explicitly check for null or undefined
-      // prettier-ignore
-      if (config.skipJSONValidation == null) { // eslint-disable-line eqeqeq
-        config.skipJSONValidation = true;
-      }
-
       config = fns.assign(
         {
           clientEngine: enums.REACT_NATIVE_JS_CLIENT_ENGINE,

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -49,7 +49,6 @@ var DEFAULT_ONREADY_TIMEOUT = 30000;
  * @param {Object} config.errorHandler
  * @param {Object} config.eventDispatcher
  * @param {Object} config.logger
- * @param {Object} config.skipJSONValidation
  * @param {Object} config.userProfileService
  * @param {Object} config.eventBatchSize
  * @param {Object} config.eventFlushInterval
@@ -76,7 +75,6 @@ function Optimizely(config) {
     datafileOptions: config.datafileOptions,
     jsonSchemaValidator: config.jsonSchemaValidator,
     sdkKey: config.sdkKey,
-    skipJSONValidation: config.skipJSONValidation,
   });
 
   this.__disposeOnUpdate = this.projectConfigManager.onUpdate(

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -216,7 +216,6 @@ describe('lib/optimizely', function() {
             jsonSchemaValidator: jsonSchemaValidator,
             logger: createdLogger,
             sdkKey: '12345',
-            skipJSONValidation: false,
           });
           sinon.assert.notCalled(stubErrorHandler.handleError);
         });
@@ -236,7 +235,6 @@ describe('lib/optimizely', function() {
             jsonSchemaValidator: jsonSchemaValidator,
             logger: createdLogger,
             sdkKey: '12345',
-            skipJSONValidation: false,
           });
           sinon.assert.calledOnce(projectConfigManager.ProjectConfigManager);
           sinon.assert.calledWithExactly(projectConfigManager.ProjectConfigManager, {
@@ -247,7 +245,6 @@ describe('lib/optimizely', function() {
             },
             jsonSchemaValidator: jsonSchemaValidator,
             sdkKey: '12345',
-            skipJSONValidation: false,
           });
         });
       });


### PR DESCRIPTION
##  Summary
 - Changed functionality of JSON schema validation by removing skipJSONValidation entirely.
Now user will need to import jsonSchemaValidator from @optimizely/optimizely-sdk/lib/utils/json_schema_validator and pass it to createInstance when validation is desired.
 - Updated existing unit tests to reflect this change.

## Test plan
Existing unit tests
## Issues
OASIS-6102
