### PR TITLE
refactor: Convert lib/core to ES module (Part 1/2)

### DIFF
--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2018-2020 Optimizely
+ * Copyright 2016, 2018-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,16 @@ import { sprintf } from '@optimizely/js-sdk-utils';
 import { getLogger } from '@optimizely/js-sdk-logging';
 
 import fns from '../../utils/fns';
-import enums from '../../utils/enums';
+import {
+  LOG_LEVEL,
+  LOG_MESSAGES, 
+  ERROR_MESSAGES,
+} from '../../utils/enums';
 import conditionTreeEvaluator from '../condition_tree_evaluator';
 import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
 
 var logger = getLogger();
-var LOG_LEVEL = enums.LOG_LEVEL;
-var LOG_MESSAGES = enums.LOG_MESSAGES;
 var MODULE_NAME = 'AUDIENCE_EVALUATOR';
-var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 
 /**
  * Construct an instance of AudienceEvaluator with given options

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import conditionTreeEvaluator from '../condition_tree_evaluator';
-import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
-import enums from '../../utils/enums';
-import fns from '../../utils/fns';
 import { sprintf } from '@optimizely/js-sdk-utils';
 import { getLogger } from '@optimizely/js-sdk-logging';
-var logger = getLogger();
 
-var ERROR_MESSAGES = enums.ERROR_MESSAGES;
+import fns from '../../utils/fns';
+import enums from '../../utils/enums';
+import conditionTreeEvaluator from '../condition_tree_evaluator';
+import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
+
+var logger = getLogger();
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;
 var MODULE_NAME = 'AUDIENCE_EVALUATOR';
+var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 
 /**
  * Construct an instance of AudienceEvaluator with given options

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2018-2019 Optimizely
+ * Copyright 2016, 2018-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var conditionTreeEvaluator = require('../condition_tree_evaluator');
-var customAttributeConditionEvaluator = require('../custom_attribute_condition_evaluator');
-var enums = require('../../utils/enums');
-var fns = require('../../utils/fns');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
-var logging = require('@optimizely/js-sdk-logging');
-var logger = logging.getLogger();
+import conditionTreeEvaluator from '../condition_tree_evaluator';
+import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
+import enums from '../../utils/enums';
+import fns from '../../utils/fns';
+import { sprintf } from '@optimizely/js-sdk-utils';
+import { getLogger } from '@optimizely/js-sdk-logging';
+var logger = getLogger();
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var LOG_LEVEL = enums.LOG_LEVEL;
@@ -108,4 +108,4 @@ AudienceEvaluator.prototype.evaluateConditionWithUserAttributes = function(userA
   return null;
 };
 
-module.exports = AudienceEvaluator;
+export default AudienceEvaluator;

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2018-2020 Optimizely
+ * Copyright 2016, 2018-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import sinon from 'sinon';
+import { assert } from 'chai';
 import { getLogger } from '@optimizely/js-sdk-logging';
 
 import AudienceEvaluator from './index';
 import conditionTreeEvaluator from '../condition_tree_evaluator';
 import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
-
-import { assert } from 'chai';
-import sinon from 'sinon';
 
 var mockLogger = getLogger();
 

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import AudienceEvaluator from './index';
-import chai from 'chai';
-import conditionTreeEvaluator from '../condition_tree_evaluator';
-import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
-import sinon from 'sinon';
 import { getLogger } from '@optimizely/js-sdk-logging';
 
-var assert = chai.assert;
+import AudienceEvaluator from './index';
+import conditionTreeEvaluator from '../condition_tree_evaluator';
+import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
+
+import { assert } from 'chai';
+import sinon from 'sinon';
+
 var mockLogger = getLogger();
 
 var chromeUserAudience = {

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2018-2019 Optimizely
+ * Copyright 2016, 2018-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var AudienceEvaluator = require('./');
-var chai = require('chai');
-var conditionTreeEvaluator = require('../condition_tree_evaluator');
-var customAttributeConditionEvaluator = require('../custom_attribute_condition_evaluator');
-var sinon = require('sinon');
+import AudienceEvaluator from './index';
+import chai from 'chai';
+import conditionTreeEvaluator from '../condition_tree_evaluator';
+import customAttributeConditionEvaluator from '../custom_attribute_condition_evaluator';
+import sinon from 'sinon';
+import { getLogger } from '@optimizely/js-sdk-logging';
+
 var assert = chai.assert;
-var logging = require('@optimizely/js-sdk-logging');
-var mockLogger = logging.getLogger();
-var enums = require('../../utils/enums');
-var LOG_LEVEL = enums.LOG_LEVEL;
+var mockLogger = getLogger();
 
 var chromeUserAudience = {
   conditions: [

--- a/packages/optimizely-sdk/lib/core/bucketer/index.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2019-2020 Optimizely
+ * Copyright 2016, 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,15 @@
  * Bucketer API for determining the variation id from the specified parameters
  */
 import { sprintf } from '@optimizely/js-sdk-utils';
-
 import murmurhash from 'murmurhash';
-import enums from '../../utils/enums';
 
-var ERROR_MESSAGES = enums.ERROR_MESSAGES;
+import {
+  ERROR_MESSAGES,
+  LOG_LEVEL,
+  LOG_MESSAGES,
+} from '../../utils/enums';
+
 var HASH_SEED = 1;
-var LOG_LEVEL = enums.LOG_LEVEL;
-var LOG_MESSAGES = enums.LOG_MESSAGES;
 var MAX_HASH_VALUE = Math.pow(2, 32);
 var MAX_TRAFFIC_VALUE = 10000;
 var MODULE_NAME = 'BUCKETER';
@@ -136,7 +137,7 @@ export var bucket = function(bucketerParams) {
   }
 
   return entityId;
-}
+};
 
 /**
  * Returns bucketed experiment ID to compare against experiment user is being called into
@@ -156,7 +157,7 @@ export var bucketUserIntoExperiment = function(group, bucketingId, userId, logge
   var trafficAllocationConfig = group.trafficAllocation;
   var bucketedExperimentId = this._findBucket(bucketValue, trafficAllocationConfig);
   return bucketedExperimentId;
-}
+};
 
 /**
  * Returns entity ID associated with bucket value
@@ -173,7 +174,7 @@ export var _findBucket = function(bucketValue, trafficAllocationConfig) {
     }
   }
   return null;
-}
+};
 
 /**
  * Helper function to generate bucket value in half-closed interval [0, MAX_TRAFFIC_VALUE)
@@ -191,11 +192,11 @@ export var _generateBucketValue = function(bucketingKey) {
   } catch (ex) {
     throw new Error(sprintf(ERROR_MESSAGES.INVALID_BUCKETING_ID, MODULE_NAME, bucketingKey, ex.message));
   }
-}
+};
 
 export default {
-  bucket,
-  bucketUserIntoExperiment,
-  _findBucket,
-  _generateBucketValue,
-}
+  bucket: bucket,
+  bucketUserIntoExperiment: bucketUserIntoExperiment,
+  _findBucket: _findBucket,
+  _generateBucketValue: _generateBucketValue,
+};

--- a/packages/optimizely-sdk/lib/core/bucketer/index.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.js
@@ -17,9 +17,10 @@
 /**
  * Bucketer API for determining the variation id from the specified parameters
  */
-import enums from '../../utils/enums';
-import murmurhash from 'murmurhash';
 import { sprintf } from '@optimizely/js-sdk-utils';
+
+import murmurhash from 'murmurhash';
+import enums from '../../utils/enums';
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var HASH_SEED = 1;

--- a/packages/optimizely-sdk/lib/core/bucketer/index.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016, 2019 Optimizely
+ * Copyright 2016, 2019-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 /**
  * Bucketer API for determining the variation id from the specified parameters
  */
-var enums = require('../../utils/enums');
-var murmurhash = require('murmurhash');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+import enums from '../../utils/enums';
+import murmurhash from 'murmurhash';
+import { sprintf } from '@optimizely/js-sdk-utils';
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var HASH_SEED = 1;
@@ -30,166 +30,171 @@ var MAX_TRAFFIC_VALUE = 10000;
 var MODULE_NAME = 'BUCKETER';
 var RANDOM_POLICY = 'random';
 
-module.exports = {
-  /**
-   * Determines ID of variation to be shown for the given input params
-   * @param  {Object}         bucketerParams
-   * @param  {string}         bucketerParams.experimentId
-   * @param  {string}         bucketerParams.experimentKey
-   * @param  {string}         bucketerParams.userId
-   * @param  {Object[]}       bucketerParams.trafficAllocationConfig
-   * @param  {Array}          bucketerParams.experimentKeyMap
-   * @param  {Object}         bucketerParams.groupIdMap
-   * @param  {Object}         bucketerParams.variationIdMap
-   * @param  {string}         bucketerParams.varationIdMap[].key
-   * @param  {Object}         bucketerParams.logger
-   * @param  {string}         bucketerParams.bucketingId
-   * @return Variation ID that user has been bucketed into, null if user is not bucketed into any experiment
-   */
-  bucket: function(bucketerParams) {
-    // Check if user is in a random group; if so, check if user is bucketed into a specific experiment
-    var experiment = bucketerParams.experimentKeyMap[bucketerParams.experimentKey];
-    var groupId = experiment['groupId'];
-    if (groupId) {
-      var group = bucketerParams.groupIdMap[groupId];
-      if (!group) {
-        throw new Error(sprintf(ERROR_MESSAGES.INVALID_GROUP_ID, MODULE_NAME, groupId));
-      }
-      if (group.policy === RANDOM_POLICY) {
-        var bucketedExperimentId = module.exports.bucketUserIntoExperiment(
-          group,
-          bucketerParams.bucketingId,
+/**
+ * Determines ID of variation to be shown for the given input params
+ * @param  {Object}         bucketerParams
+ * @param  {string}         bucketerParams.experimentId
+ * @param  {string}         bucketerParams.experimentKey
+ * @param  {string}         bucketerParams.userId
+ * @param  {Object[]}       bucketerParams.trafficAllocationConfig
+ * @param  {Array}          bucketerParams.experimentKeyMap
+ * @param  {Object}         bucketerParams.groupIdMap
+ * @param  {Object}         bucketerParams.variationIdMap
+ * @param  {string}         bucketerParams.varationIdMap[].key
+ * @param  {Object}         bucketerParams.logger
+ * @param  {string}         bucketerParams.bucketingId
+ * @return Variation ID that user has been bucketed into, null if user is not bucketed into any experiment
+ */
+export var bucket = function(bucketerParams) {
+  // Check if user is in a random group; if so, check if user is bucketed into a specific experiment
+  var experiment = bucketerParams.experimentKeyMap[bucketerParams.experimentKey];
+  var groupId = experiment['groupId'];
+  if (groupId) {
+    var group = bucketerParams.groupIdMap[groupId];
+    if (!group) {
+      throw new Error(sprintf(ERROR_MESSAGES.INVALID_GROUP_ID, MODULE_NAME, groupId));
+    }
+    if (group.policy === RANDOM_POLICY) {
+      var bucketedExperimentId = this.bucketUserIntoExperiment(
+        group,
+        bucketerParams.bucketingId,
+        bucketerParams.userId,
+        bucketerParams.logger
+      );
+
+      // Return if user is not bucketed into any experiment
+      if (bucketedExperimentId === null) {
+        var notbucketedInAnyExperimentLogMessage = sprintf(
+          LOG_MESSAGES.USER_NOT_IN_ANY_EXPERIMENT,
+          MODULE_NAME,
           bucketerParams.userId,
-          bucketerParams.logger
+          groupId
         );
+        bucketerParams.logger.log(LOG_LEVEL.INFO, notbucketedInAnyExperimentLogMessage);
+        return null;
+      }
 
-        // Return if user is not bucketed into any experiment
-        if (bucketedExperimentId === null) {
-          var notbucketedInAnyExperimentLogMessage = sprintf(
-            LOG_MESSAGES.USER_NOT_IN_ANY_EXPERIMENT,
-            MODULE_NAME,
-            bucketerParams.userId,
-            groupId
-          );
-          bucketerParams.logger.log(LOG_LEVEL.INFO, notbucketedInAnyExperimentLogMessage);
-          return null;
-        }
-
-        // Return if user is bucketed into a different experiment than the one specified
-        if (bucketedExperimentId !== bucketerParams.experimentId) {
-          var notBucketedIntoExperimentOfGroupLogMessage = sprintf(
-            LOG_MESSAGES.USER_NOT_BUCKETED_INTO_EXPERIMENT_IN_GROUP,
-            MODULE_NAME,
-            bucketerParams.userId,
-            bucketerParams.experimentKey,
-            groupId
-          );
-          bucketerParams.logger.log(LOG_LEVEL.INFO, notBucketedIntoExperimentOfGroupLogMessage);
-          return null;
-        }
-
-        // Continue bucketing if user is bucketed into specified experiment
-        var bucketedIntoExperimentOfGroupLogMessage = sprintf(
-          LOG_MESSAGES.USER_BUCKETED_INTO_EXPERIMENT_IN_GROUP,
+      // Return if user is bucketed into a different experiment than the one specified
+      if (bucketedExperimentId !== bucketerParams.experimentId) {
+        var notBucketedIntoExperimentOfGroupLogMessage = sprintf(
+          LOG_MESSAGES.USER_NOT_BUCKETED_INTO_EXPERIMENT_IN_GROUP,
           MODULE_NAME,
           bucketerParams.userId,
           bucketerParams.experimentKey,
           groupId
         );
-        bucketerParams.logger.log(LOG_LEVEL.INFO, bucketedIntoExperimentOfGroupLogMessage);
+        bucketerParams.logger.log(LOG_LEVEL.INFO, notBucketedIntoExperimentOfGroupLogMessage);
+        return null;
       }
-    }
-    var bucketingId = sprintf('%s%s', bucketerParams.bucketingId, bucketerParams.experimentId);
-    var bucketValue = module.exports._generateBucketValue(bucketingId);
 
-    var bucketedUserLogMessage = sprintf(
-      LOG_MESSAGES.USER_ASSIGNED_TO_VARIATION_BUCKET,
+      // Continue bucketing if user is bucketed into specified experiment
+      var bucketedIntoExperimentOfGroupLogMessage = sprintf(
+        LOG_MESSAGES.USER_BUCKETED_INTO_EXPERIMENT_IN_GROUP,
+        MODULE_NAME,
+        bucketerParams.userId,
+        bucketerParams.experimentKey,
+        groupId
+      );
+      bucketerParams.logger.log(LOG_LEVEL.INFO, bucketedIntoExperimentOfGroupLogMessage);
+    }
+  }
+  var bucketingId = sprintf('%s%s', bucketerParams.bucketingId, bucketerParams.experimentId);
+  var bucketValue = this._generateBucketValue(bucketingId);
+
+  var bucketedUserLogMessage = sprintf(
+    LOG_MESSAGES.USER_ASSIGNED_TO_VARIATION_BUCKET,
+    MODULE_NAME,
+    bucketValue,
+    bucketerParams.userId
+  );
+  bucketerParams.logger.log(LOG_LEVEL.DEBUG, bucketedUserLogMessage);
+
+  var entityId = this._findBucket(bucketValue, bucketerParams.trafficAllocationConfig);
+  if (!entityId) {
+    var userHasNoVariationLogMessage = sprintf(
+      LOG_MESSAGES.USER_HAS_NO_VARIATION,
       MODULE_NAME,
-      bucketValue,
-      bucketerParams.userId
+      bucketerParams.userId,
+      bucketerParams.experimentKey
     );
-    bucketerParams.logger.log(LOG_LEVEL.DEBUG, bucketedUserLogMessage);
-
-    var entityId = module.exports._findBucket(bucketValue, bucketerParams.trafficAllocationConfig);
-    if (!entityId) {
-      var userHasNoVariationLogMessage = sprintf(
-        LOG_MESSAGES.USER_HAS_NO_VARIATION,
-        MODULE_NAME,
-        bucketerParams.userId,
-        bucketerParams.experimentKey
-      );
-      bucketerParams.logger.log(LOG_LEVEL.DEBUG, userHasNoVariationLogMessage);
-    } else if (!bucketerParams.variationIdMap.hasOwnProperty(entityId)) {
-      var invalidVariationIdLogMessage = sprintf(LOG_MESSAGES.INVALID_VARIATION_ID, MODULE_NAME);
-      bucketerParams.logger.log(LOG_LEVEL.WARNING, invalidVariationIdLogMessage);
-      return null;
-    } else {
-      var variationKey = bucketerParams.variationIdMap[entityId].key;
-      var userInVariationLogMessage = sprintf(
-        LOG_MESSAGES.USER_HAS_VARIATION,
-        MODULE_NAME,
-        bucketerParams.userId,
-        variationKey,
-        bucketerParams.experimentKey
-      );
-      bucketerParams.logger.log(LOG_LEVEL.INFO, userInVariationLogMessage);
-    }
-
-    return entityId;
-  },
-
-  /**
-   * Returns bucketed experiment ID to compare against experiment user is being called into
-   * @param {Object} group        Group that experiment is in
-   * @param {string} bucketingId  Bucketing ID
-   * @param {string} userId       ID of user to be bucketed into experiment
-   * @param {Object} logger       Logger implementation
-   * @return {string} ID of experiment if user is bucketed into experiment within the group, null otherwise
-   */
-  bucketUserIntoExperiment: function(group, bucketingId, userId, logger) {
-    var bucketingKey = sprintf('%s%s', bucketingId, group.id);
-    var bucketValue = module.exports._generateBucketValue(bucketingKey);
-    logger.log(
-      LOG_LEVEL.DEBUG,
-      sprintf(LOG_MESSAGES.USER_ASSIGNED_TO_EXPERIMENT_BUCKET, MODULE_NAME, bucketValue, userId)
-    );
-    var trafficAllocationConfig = group.trafficAllocation;
-    var bucketedExperimentId = module.exports._findBucket(bucketValue, trafficAllocationConfig);
-    return bucketedExperimentId;
-  },
-
-  /**
-   * Returns entity ID associated with bucket value
-   * @param  {string}   bucketValue
-   * @param  {Object[]} trafficAllocationConfig
-   * @param  {number}   trafficAllocationConfig[].endOfRange
-   * @param  {number}   trafficAllocationConfig[].entityId
-   * @return {string}   Entity ID for bucketing if bucket value is within traffic allocation boundaries, null otherwise
-   */
-  _findBucket: function(bucketValue, trafficAllocationConfig) {
-    for (var i = 0; i < trafficAllocationConfig.length; i++) {
-      if (bucketValue < trafficAllocationConfig[i].endOfRange) {
-        return trafficAllocationConfig[i].entityId;
-      }
-    }
+    bucketerParams.logger.log(LOG_LEVEL.DEBUG, userHasNoVariationLogMessage);
+  } else if (!bucketerParams.variationIdMap.hasOwnProperty(entityId)) {
+    var invalidVariationIdLogMessage = sprintf(LOG_MESSAGES.INVALID_VARIATION_ID, MODULE_NAME);
+    bucketerParams.logger.log(LOG_LEVEL.WARNING, invalidVariationIdLogMessage);
     return null;
-  },
+  } else {
+    var variationKey = bucketerParams.variationIdMap[entityId].key;
+    var userInVariationLogMessage = sprintf(
+      LOG_MESSAGES.USER_HAS_VARIATION,
+      MODULE_NAME,
+      bucketerParams.userId,
+      variationKey,
+      bucketerParams.experimentKey
+    );
+    bucketerParams.logger.log(LOG_LEVEL.INFO, userInVariationLogMessage);
+  }
 
-  /**
-   * Helper function to generate bucket value in half-closed interval [0, MAX_TRAFFIC_VALUE)
-   * @param  {string} bucketingKey String value for bucketing
-   * @return {string} the generated bucket value
-   * @throws If bucketing value is not a valid string
-   */
-  _generateBucketValue: function(bucketingKey) {
-    try {
-      // NOTE: the mmh library already does cast the hash value as an unsigned 32bit int
-      // https://github.com/perezd/node-murmurhash/blob/master/murmurhash.js#L115
-      var hashValue = murmurhash.v3(bucketingKey, HASH_SEED);
-      var ratio = hashValue / MAX_HASH_VALUE;
-      return parseInt(ratio * MAX_TRAFFIC_VALUE, 10);
-    } catch (ex) {
-      throw new Error(sprintf(ERROR_MESSAGES.INVALID_BUCKETING_ID, MODULE_NAME, bucketingKey, ex.message));
+  return entityId;
+}
+
+/**
+ * Returns bucketed experiment ID to compare against experiment user is being called into
+ * @param {Object} group        Group that experiment is in
+ * @param {string} bucketingId  Bucketing ID
+ * @param {string} userId       ID of user to be bucketed into experiment
+ * @param {Object} logger       Logger implementation
+ * @return {string} ID of experiment if user is bucketed into experiment within the group, null otherwise
+ */
+export var bucketUserIntoExperiment = function(group, bucketingId, userId, logger) {
+  var bucketingKey = sprintf('%s%s', bucketingId, group.id);
+  var bucketValue = this._generateBucketValue(bucketingKey);
+  logger.log(
+    LOG_LEVEL.DEBUG,
+    sprintf(LOG_MESSAGES.USER_ASSIGNED_TO_EXPERIMENT_BUCKET, MODULE_NAME, bucketValue, userId)
+  );
+  var trafficAllocationConfig = group.trafficAllocation;
+  var bucketedExperimentId = this._findBucket(bucketValue, trafficAllocationConfig);
+  return bucketedExperimentId;
+}
+
+/**
+ * Returns entity ID associated with bucket value
+ * @param  {string}   bucketValue
+ * @param  {Object[]} trafficAllocationConfig
+ * @param  {number}   trafficAllocationConfig[].endOfRange
+ * @param  {number}   trafficAllocationConfig[].entityId
+ * @return {string}   Entity ID for bucketing if bucket value is within traffic allocation boundaries, null otherwise
+ */
+export var _findBucket = function(bucketValue, trafficAllocationConfig) {
+  for (var i = 0; i < trafficAllocationConfig.length; i++) {
+    if (bucketValue < trafficAllocationConfig[i].endOfRange) {
+      return trafficAllocationConfig[i].entityId;
     }
-  },
-};
+  }
+  return null;
+}
+
+/**
+ * Helper function to generate bucket value in half-closed interval [0, MAX_TRAFFIC_VALUE)
+ * @param  {string} bucketingKey String value for bucketing
+ * @return {string} the generated bucket value
+ * @throws If bucketing value is not a valid string
+ */
+export var _generateBucketValue = function(bucketingKey) {
+  try {
+    // NOTE: the mmh library already does cast the hash value as an unsigned 32bit int
+    // https://github.com/perezd/node-murmurhash/blob/master/murmurhash.js#L115
+    var hashValue = murmurhash.v3(bucketingKey, HASH_SEED);
+    var ratio = hashValue / MAX_HASH_VALUE;
+    return parseInt(ratio * MAX_TRAFFIC_VALUE, 10);
+  } catch (ex) {
+    throw new Error(sprintf(ERROR_MESSAGES.INVALID_BUCKETING_ID, MODULE_NAME, bucketingKey, ex.message));
+  }
+}
+
+export default {
+  bucket,
+  bucketUserIntoExperiment,
+  _findBucket,
+  _generateBucketValue,
+}

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -365,7 +365,6 @@ describe('lib/core/bucketer', function() {
     });
 
     describe('testBucketWithBucketingId', function() {
-      var configObj;
       var bucketerParams;
       var createdLogger = logger.createLogger({
         logLevel: LOG_LEVEL.INFO,
@@ -373,7 +372,7 @@ describe('lib/core/bucketer', function() {
       });
 
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+        var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
         bucketerParams = {
           trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
           variationIdMap: configObj.variationIdMap,

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2019-2020 Optimizely
+ * Copyright 2016-2017, 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import sinon from 'sinon';
+import { assert, expect } from 'chai';
+import { cloneDeep } from 'lodash';
 import { sprintf } from '@optimizely/js-sdk-utils';
 
 import bucketer from './';
-import enums from '../../utils/enums';
+import {
+  ERROR_MESSAGES,
+  LOG_MESSAGES,
+  LOG_LEVEL,
+} from '../../utils/enums';
 import logger from '../../plugins/logger';
 import projectConfig from '../project_config';
 import { getTestProjectConfig } from '../../tests/test_data';
 
-import { assert, expect } from 'chai';
-import sinon from 'sinon';
-import { cloneDeep } from 'lodash';
-
-var ERROR_MESSAGES = enums.ERROR_MESSAGES;
-var LOG_LEVEL = enums.LOG_LEVEL;
-var LOG_MESSAGES = enums.LOG_MESSAGES;
+var testData = getTestProjectConfig();
 
 describe('lib/core/bucketer', function() {
   describe('APIs', function() {
@@ -46,7 +47,7 @@ describe('lib/core/bucketer', function() {
 
       describe('return values for bucketing (excluding groups)', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -102,7 +103,7 @@ describe('lib/core/bucketer', function() {
       describe('return values for bucketing (including groups)', function() {
         var bucketerStub;
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -283,7 +284,7 @@ describe('lib/core/bucketer', function() {
 
       describe('when the bucket value falls into empty traffic allocation ranges', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -313,7 +314,7 @@ describe('lib/core/bucketer', function() {
 
       describe('when the traffic allocation has invalid variation ids', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -372,7 +373,7 @@ describe('lib/core/bucketer', function() {
       });
 
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+        configObj = projectConfig.createProjectConfig(cloneDeep(testData));
         bucketerParams = {
           trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
           variationIdMap: configObj.variationIdMap,

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2019 Optimizely
+ * Copyright 2016-2017, 2019-2020 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var bucketer = require('./');
-var enums = require('../../utils/enums');
-var logger = require('../../plugins/logger');
-var projectConfig = require('../project_config');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
-var testData = require('../../tests/test_data').getTestProjectConfig();
+import bucketer from './';
+import enums from '../../utils/enums';
+import logger from '../../plugins/logger';
+import projectConfig from '../project_config';
+import { sprintf } from '@optimizely/js-sdk-utils';
+import { getTestProjectConfig } from '../../tests/test_data';
+import chai from 'chai';
+import cloneDeep from 'lodash/cloneDeep';
+import sinon from 'sinon';
 
-var chai = require('chai');
 var assert = chai.assert;
 var expect = chai.expect;
-var cloneDeep = require('lodash/cloneDeep');
-var sinon = require('sinon');
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var LOG_LEVEL = enums.LOG_LEVEL;
@@ -47,7 +47,7 @@ describe('lib/core/bucketer', function() {
 
       describe('return values for bucketing (excluding groups)', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -103,7 +103,7 @@ describe('lib/core/bucketer', function() {
       describe('return values for bucketing (including groups)', function() {
         var bucketerStub;
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -284,7 +284,7 @@ describe('lib/core/bucketer', function() {
 
       describe('when the bucket value falls into empty traffic allocation ranges', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -314,7 +314,7 @@ describe('lib/core/bucketer', function() {
 
       describe('when the traffic allocation has invalid variation ids', function() {
         beforeEach(function() {
-          configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+          configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
@@ -365,13 +365,15 @@ describe('lib/core/bucketer', function() {
     });
 
     describe('testBucketWithBucketingId', function() {
+      var configObj;
+      var bucketerParams;
       var createdLogger = logger.createLogger({
         logLevel: LOG_LEVEL.INFO,
         logToConsole: false,
       });
 
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
         bucketerParams = {
           trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
           variationIdMap: configObj.variationIdMap,

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sprintf } from '@optimizely/js-sdk-utils';
+
 import bucketer from './';
 import enums from '../../utils/enums';
 import logger from '../../plugins/logger';
 import projectConfig from '../project_config';
-import { sprintf } from '@optimizely/js-sdk-utils';
 import { getTestProjectConfig } from '../../tests/test_data';
-import chai from 'chai';
-import cloneDeep from 'lodash/cloneDeep';
-import sinon from 'sinon';
 
-var assert = chai.assert;
-var expect = chai.expect;
+import { assert, expect } from 'chai';
+import sinon from 'sinon';
+import { cloneDeep } from 'lodash';
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var LOG_LEVEL = enums.LOG_LEVEL;

--- a/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018, Optimizely, Inc. and contributors                        *
+ * Copyright 2018, 2020 Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -32,7 +32,7 @@ var DEFAULT_OPERATOR_TYPES = [AND_CONDITION, OR_CONDITION, NOT_CONDITION];
  *                                      indicates that the conditions are invalid or unable to be
  *                                      evaluated
  */
-function evaluate(conditions, leafEvaluator) {
+export var evaluate = function(conditions, leafEvaluator) {
   if (Array.isArray(conditions)) {
     var firstOperator = conditions[0];
     var restOfConditions = conditions.slice(1);
@@ -121,6 +121,6 @@ function orEvaluator(conditions, leafEvaluator) {
   return sawNullResult ? null : false;
 }
 
-module.exports = {
-  evaluate: evaluate,
-};
+export default {
+  evaluate,
+}

--- a/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018, 2020 Optimizely, Inc. and contributors                   *
+ * Copyright 2018, 2020, Optimizely, Inc. and contributors                  *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -56,7 +56,7 @@ export var evaluate = function(conditions, leafEvaluator) {
 
   var leafCondition = conditions;
   return leafEvaluator(leafCondition);
-}
+};
 
 /**
  * Evaluates an array of conditions as if the evaluator had been applied
@@ -122,5 +122,5 @@ function orEvaluator(conditions, leafEvaluator) {
 }
 
 export default {
-  evaluate,
-}
+  evaluate: evaluate,
+};

--- a/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-
-import chai from 'chai';
-import sinon from 'sinon';
 import conditionTreeEvaluator from './';
 
-var assert = chai.assert;
+import sinon from 'sinon';
+import { assert } from 'chai';
 
 var conditionA = {
   name: 'browser_type',

--- a/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018, 2020 Optimizely, Inc. and contributors                   *
+ * Copyright 2018, 2020, Optimizely, Inc. and contributors                  *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-import conditionTreeEvaluator from './';
-
 import sinon from 'sinon';
 import { assert } from 'chai';
+
+ import conditionTreeEvaluator from './';
 
 var conditionA = {
   name: 'browser_type',

--- a/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/condition_tree_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018, Optimizely, Inc. and contributors                        *
+ * Copyright 2018, 2020 Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -14,10 +14,11 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
-var chai = require('chai');
-var sinon = require('sinon');
+import chai from 'chai';
+import sinon from 'sinon';
+import conditionTreeEvaluator from './';
+
 var assert = chai.assert;
-var conditionTreeEvaluator = require('./');
 
 var conditionA = {
   name: 'browser_type',

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
+import { sprintf } from '@optimizely/js-sdk-utils';
 
 import fns from '../../utils/fns';
 import enums from '../../utils/enums';
-import { sprintf } from '@optimizely/js-sdk-utils';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
@@ -16,10 +16,11 @@
 import { sprintf } from '@optimizely/js-sdk-utils';
 
 import fns from '../../utils/fns';
-import enums from '../../utils/enums';
+import {
+  LOG_LEVEL,
+  LOG_MESSAGES,
+} from '../../utils/enums';
 
-var LOG_LEVEL = enums.LOG_LEVEL;
-var LOG_MESSAGES = enums.LOG_MESSAGES;
 var MODULE_NAME = 'CUSTOM_ATTRIBUTE_CONDITION_EVALUATOR';
 
 var EXACT_MATCH_TYPE = 'exact';
@@ -71,7 +72,7 @@ export var evaluate = function(condition, userAttributes, logger) {
 
   var evaluatorForMatch = EVALUATORS_BY_MATCH_TYPE[conditionMatch] || exactEvaluator;
   return evaluatorForMatch(condition, userAttributes, logger);
-}
+};
 
 /**
  * Returns true if the value is valid for exact conditions. Valid values include
@@ -299,5 +300,5 @@ function substringEvaluator(condition, userAttributes, logger) {
 }
 
 export default {
-  evaluate,
-}
+  evaluate: evaluate,
+};

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018-2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2018-2019, 2020 Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -14,9 +14,9 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
-var fns = require('../../utils/fns');
-var enums = require('../../utils/enums');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+import fns from '../../utils/fns';
+import enums from '../../utils/enums';
+import { sprintf } from '@optimizely/js-sdk-utils';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;
@@ -53,7 +53,7 @@ EVALUATORS_BY_MATCH_TYPE[SUBSTRING_MATCH_TYPE] = substringEvaluator;
  *                                      null if the given user attributes and condition can't be evaluated
  * TODO: Change to accept and object with named properties
  */
-function evaluate(condition, userAttributes, logger) {
+export var evaluate = function(condition, userAttributes, logger) {
   var conditionMatch = condition.match;
   if (typeof conditionMatch !== 'undefined' && MATCH_TYPES.indexOf(conditionMatch) === -1) {
     logger.log(LOG_LEVEL.WARNING, sprintf(LOG_MESSAGES.UNKNOWN_MATCH_TYPE, MODULE_NAME, JSON.stringify(condition)));
@@ -298,6 +298,6 @@ function substringEvaluator(condition, userAttributes, logger) {
   return userValue.indexOf(conditionValue) !== -1;
 }
 
-module.exports = {
-  evaluate: evaluate,
-};
+export default {
+  evaluate,
+}

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018-2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2018-2019, 2020 Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -14,13 +14,13 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
-var customAttributeEvaluator = require('./');
-var enums = require('../../utils/enums');
-var LOG_LEVEL = enums.LOG_LEVEL;
-var logger = require('../../plugins/logger');
+import customAttributeEvaluator from './';
+import enums from '../../utils/enums';
+import logger from '../../plugins/logger';
+import chai from 'chai';
+import sinon from 'sinon';
 
-var chai = require('chai');
-var sinon = require('sinon');
+var LOG_LEVEL = enums.LOG_LEVEL;
 var assert = chai.assert;
 
 var browserConditionSafari = {

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-
-import customAttributeEvaluator from './';
 import enums from '../../utils/enums';
 import logger from '../../plugins/logger';
-import chai from 'chai';
+import customAttributeEvaluator from './';
+
 import sinon from 'sinon';
+import { assert } from 'chai';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
-var assert = chai.assert;
 
 var browserConditionSafari = {
   name: 'browser_type',

--- a/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/custom_attribute_condition_evaluator/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2018-2019, 2020 Optimizely, Inc. and contributors              *
+ * Copyright 2018-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-import enums from '../../utils/enums';
-import logger from '../../plugins/logger';
-import customAttributeEvaluator from './';
-
 import sinon from 'sinon';
 import { assert } from 'chai';
 
-var LOG_LEVEL = enums.LOG_LEVEL;
+import { LOG_LEVEL } from '../../utils/enums';
+import logger from '../../plugins/logger';
+import customAttributeEvaluator from './';
 
 var browserConditionSafari = {
   name: 'browser_type',

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-import AudienceEvaluator from '../audience_evaluator';
+import { sprintf } from'@optimizely/js-sdk-utils';
+
 import bucketer from '../bucketer';
 import enums from '../../utils/enums';
 import fns from '../../utils/fns';
 import projectConfig from '../project_config';
+import AudienceEvaluator from '../audience_evaluator';
 import stringValidator from '../../utils/string_value_validator';
-import { sprintf } from'@optimizely/js-sdk-utils';
 
 var MODULE_NAME = 'DECISION_SERVICE';
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2019, 2020 Optimizely, Inc. and contributors              *
+ * Copyright 2017-2020 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -726,8 +726,8 @@ DecisionService.prototype.setForcedVariation = function(configObj, experimentKey
  */
 export var createDecisionService = function(options) {
   return new DecisionService(options);
-}
+};
 
 export default {
-  createDecisionService,
-}
+  createDecisionService: createDecisionService,
+};

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2019, Optimizely, Inc. and contributors                   *
+ * Copyright 2017-2019, 2020 Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-
-var AudienceEvaluator = require('../audience_evaluator');
-var bucketer = require('../bucketer');
-var enums = require('../../utils/enums');
-var fns = require('../../utils/fns');
-var projectConfig = require('../project_config');
-var stringValidator = require('../../utils/string_value_validator');
-
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
+import AudienceEvaluator from '../audience_evaluator';
+import bucketer from '../bucketer';
+import enums from '../../utils/enums';
+import fns from '../../utils/fns';
+import projectConfig from '../project_config';
+import stringValidator from '../../utils/string_value_validator';
+import { sprintf } from'@optimizely/js-sdk-utils';
 
 var MODULE_NAME = 'DECISION_SERVICE';
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
@@ -718,15 +716,17 @@ DecisionService.prototype.setForcedVariation = function(configObj, experimentKey
   }
 };
 
-module.exports = {
-  /**
-   * Creates an instance of the DecisionService.
-   * @param  {Object} options               Configuration options
-   * @param  {Object} options.userProfileService
-   * @param  {Object} options.logger
-   * @return {Object} An instance of the DecisionService
-   */
-  createDecisionService: function(options) {
-    return new DecisionService(options);
-  },
-};
+/**
+ * Creates an instance of the DecisionService.
+ * @param  {Object} options               Configuration options
+ * @param  {Object} options.userProfileService
+ * @param  {Object} options.logger
+ * @return {Object} An instance of the DecisionService
+ */
+export var createDecisionService = function(options) {
+  return new DecisionService(options);
+}
+
+export default {
+  createDecisionService,
+}

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -13,24 +13,24 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-import Optimizely from '../../optimizely';
-import eventBuilder from '../../core/event_builder/index.js';
-import eventDispatcher from '../../plugins/event_dispatcher/index.node';
-import errorHandler from '../../plugins/error_handler';
-import bucketer from '../bucketer';
+import { sprintf } from '@optimizely/js-sdk-utils';
+
 import DecisionService from './';
+import bucketer from '../bucketer';
 import enums from '../../utils/enums';
 import cloneDeep from 'lodash/cloneDeep';
 import logger from '../../plugins/logger';
+import Optimizely from '../../optimizely';
 import projectConfig from '../project_config';
-import { sprintf } from '@optimizely/js-sdk-utils';
-import { getTestProjectConfig, getTestProjectConfigWithFeatures } from '../../tests/test_data';
-import jsonSchemaValidator from '../../utils/json_schema_validator';
 import AudienceEvaluator from '../audience_evaluator';
+import errorHandler from '../../plugins/error_handler';
+import eventBuilder from '../../core/event_builder/index.js';
+import eventDispatcher from '../../plugins/event_dispatcher/index.node';
+import jsonSchemaValidator from '../../utils/json_schema_validator';
+import { getTestProjectConfig, getTestProjectConfigWithFeatures } from '../../tests/test_data';
 
-import chai from 'chai';
 import sinon from 'sinon';
-var assert = chai.assert;
+import { assert } from 'chai';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2017-2019, 2020 Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -13,25 +13,23 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
+import Optimizely from '../../optimizely';
+import eventBuilder from '../../core/event_builder/index.js';
+import eventDispatcher from '../../plugins/event_dispatcher/index.node';
+import errorHandler from '../../plugins/error_handler';
+import bucketer from '../bucketer';
+import DecisionService from './';
+import enums from '../../utils/enums';
+import cloneDeep from 'lodash/cloneDeep';
+import logger from '../../plugins/logger';
+import projectConfig from '../project_config';
+import { sprintf } from '@optimizely/js-sdk-utils';
+import { getTestProjectConfig, getTestProjectConfigWithFeatures } from '../../tests/test_data';
+import jsonSchemaValidator from '../../utils/json_schema_validator';
+import AudienceEvaluator from '../audience_evaluator';
 
-var Optimizely = require('../../optimizely').default;
-var eventBuilder = require('../../core/event_builder/index.js');
-var eventDispatcher = require('../../plugins/event_dispatcher/index.node');
-var errorHandler = require('../../plugins/error_handler');
-var bucketer = require('../bucketer');
-var DecisionService = require('./');
-var enums = require('../../utils/enums');
-var cloneDeep = require('lodash/cloneDeep');
-var logger = require('../../plugins/logger');
-var projectConfig = require('../project_config');
-var sprintf = require('@optimizely/js-sdk-utils').sprintf;
-var testData = require('../../tests/test_data').getTestProjectConfig();
-var testDataWithFeatures = require('../../tests/test_data').getTestProjectConfigWithFeatures();
-var jsonSchemaValidator = require('../../utils/json_schema_validator');
-var AudienceEvaluator = require('../audience_evaluator');
-
-var chai = require('chai');
-var sinon = require('sinon');
+import chai from 'chai';
+import sinon from 'sinon';
 var assert = chai.assert;
 
 var LOG_LEVEL = enums.LOG_LEVEL;
@@ -40,7 +38,7 @@ var DECISION_SOURCES = enums.DECISION_SOURCES;
 
 describe('lib/core/decision_service', function() {
   describe('APIs', function() {
-    var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+    var configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
     var decisionServiceInstance;
     var mockLogger = logger.createLogger({ logLevel: LOG_LEVEL.INFO });
     var bucketerStub;
@@ -860,7 +858,7 @@ describe('lib/core/decision_service', function() {
           'control'
         );
         assert.strictEqual(didSetVariation, true);
-        var newDatafile = cloneDeep(testData);
+        var newDatafile = cloneDeep(getTestProjectConfig());
         // Remove 'control' variation from variations, traffic allocation, and datafile forcedVariations.
         newDatafile.experiments[0].variations = [
           {
@@ -892,7 +890,7 @@ describe('lib/core/decision_service', function() {
           'control'
         );
         assert.strictEqual(didSetVariation, true);
-        var newConfigObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
+        var newConfigObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
         var forcedVar = decisionServiceInstance.getForcedVariation(newConfigObj, 'testExperiment', 'user1');
         assert.strictEqual(forcedVar, null);
       });
@@ -917,7 +915,7 @@ describe('lib/core/decision_service', function() {
 
   // TODO: Move tests that test methods of Optimizely to lib/optimizely/index.tests.js
   describe('when a bucketingID is provided', function() {
-    var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+    var configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
     var createdLogger = logger.createLogger({
       logLevel: LOG_LEVEL.DEBUG,
       logToConsole: false,
@@ -926,7 +924,7 @@ describe('lib/core/decision_service', function() {
     beforeEach(function() {
       optlyInstance = new Optimizely({
         clientEngine: 'node-sdk',
-        datafile: cloneDeep(testData),
+        datafile: cloneDeep(getTestProjectConfig()),
         jsonSchemaValidator: jsonSchemaValidator,
         isValidInstance: true,
         logger: createdLogger,
@@ -1050,7 +1048,7 @@ describe('lib/core/decision_service', function() {
 
     beforeEach(function() {
       sinon.stub(mockLogger, 'log');
-      configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+      configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
       decisionService = DecisionService.createDecisionService({
         logger: mockLogger,
       });
@@ -1088,7 +1086,7 @@ describe('lib/core/decision_service', function() {
       var sandbox;
       var mockLogger = logger.createLogger({ logLevel: LOG_LEVEL.INFO });
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
+        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
         sandbox = sinon.sandbox.create();
         sandbox.stub(mockLogger, 'log');
         decisionServiceInstance = DecisionService.createDecisionService({
@@ -1978,7 +1976,7 @@ describe('lib/core/decision_service', function() {
       var __buildBucketerParamsSpy;
 
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
+        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
         feature = configObj.featureKeyMap.test_feature;
         decisionService = DecisionService.createDecisionService({
           logger: logger.createLogger({ logLevel: LOG_LEVEL.INFO }),

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2019, 2020 Optimizely, Inc. and contributors              *
+ * Copyright 2017-2020 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
+import sinon from 'sinon';
+import { assert } from 'chai';
+import cloneDeep from 'lodash/cloneDeep';
 import { sprintf } from '@optimizely/js-sdk-utils';
 
 import DecisionService from './';
 import bucketer from '../bucketer';
-import enums from '../../utils/enums';
-import cloneDeep from 'lodash/cloneDeep';
+import {
+  LOG_LEVEL,
+  LOG_MESSAGES,
+  DECISION_SOURCES,
+} from '../../utils/enums';
 import logger from '../../plugins/logger';
 import Optimizely from '../../optimizely';
 import projectConfig from '../project_config';
@@ -27,18 +33,17 @@ import errorHandler from '../../plugins/error_handler';
 import eventBuilder from '../../core/event_builder/index.js';
 import eventDispatcher from '../../plugins/event_dispatcher/index.node';
 import jsonSchemaValidator from '../../utils/json_schema_validator';
-import { getTestProjectConfig, getTestProjectConfigWithFeatures } from '../../tests/test_data';
+import {
+  getTestProjectConfig,
+  getTestProjectConfigWithFeatures,
+} from '../../tests/test_data';
 
-import sinon from 'sinon';
-import { assert } from 'chai';
-
-var LOG_LEVEL = enums.LOG_LEVEL;
-var LOG_MESSAGES = enums.LOG_MESSAGES;
-var DECISION_SOURCES = enums.DECISION_SOURCES;
+var testData = getTestProjectConfig();
+var testDataWithFeatures = getTestProjectConfigWithFeatures(); 
 
 describe('lib/core/decision_service', function() {
   describe('APIs', function() {
-    var configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+    var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
     var decisionServiceInstance;
     var mockLogger = logger.createLogger({ logLevel: LOG_LEVEL.INFO });
     var bucketerStub;
@@ -858,7 +863,7 @@ describe('lib/core/decision_service', function() {
           'control'
         );
         assert.strictEqual(didSetVariation, true);
-        var newDatafile = cloneDeep(getTestProjectConfig());
+        var newDatafile = cloneDeep(testData);
         // Remove 'control' variation from variations, traffic allocation, and datafile forcedVariations.
         newDatafile.experiments[0].variations = [
           {
@@ -890,7 +895,7 @@ describe('lib/core/decision_service', function() {
           'control'
         );
         assert.strictEqual(didSetVariation, true);
-        var newConfigObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
+        var newConfigObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
         var forcedVar = decisionServiceInstance.getForcedVariation(newConfigObj, 'testExperiment', 'user1');
         assert.strictEqual(forcedVar, null);
       });
@@ -915,7 +920,7 @@ describe('lib/core/decision_service', function() {
 
   // TODO: Move tests that test methods of Optimizely to lib/optimizely/index.tests.js
   describe('when a bucketingID is provided', function() {
-    var configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+    var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
     var createdLogger = logger.createLogger({
       logLevel: LOG_LEVEL.DEBUG,
       logToConsole: false,
@@ -924,7 +929,7 @@ describe('lib/core/decision_service', function() {
     beforeEach(function() {
       optlyInstance = new Optimizely({
         clientEngine: 'node-sdk',
-        datafile: cloneDeep(getTestProjectConfig()),
+        datafile: cloneDeep(testData),
         jsonSchemaValidator: jsonSchemaValidator,
         isValidInstance: true,
         logger: createdLogger,
@@ -1048,7 +1053,7 @@ describe('lib/core/decision_service', function() {
 
     beforeEach(function() {
       sinon.stub(mockLogger, 'log');
-      configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfig()));
+      configObj = projectConfig.createProjectConfig(cloneDeep(testData));
       decisionService = DecisionService.createDecisionService({
         logger: mockLogger,
       });
@@ -1086,7 +1091,7 @@ describe('lib/core/decision_service', function() {
       var sandbox;
       var mockLogger = logger.createLogger({ logLevel: LOG_LEVEL.INFO });
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
+        configObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
         sandbox = sinon.sandbox.create();
         sandbox.stub(mockLogger, 'log');
         decisionServiceInstance = DecisionService.createDecisionService({
@@ -1976,7 +1981,7 @@ describe('lib/core/decision_service', function() {
       var __buildBucketerParamsSpy;
 
       beforeEach(function() {
-        configObj = projectConfig.createProjectConfig(cloneDeep(getTestProjectConfigWithFeatures()));
+        configObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
         feature = configObj.featureKeyMap.test_feature;
         decisionService = DecisionService.createDecisionService({
           logger: logger.createLogger({ logLevel: LOG_LEVEL.INFO }),


### PR DESCRIPTION
## Summary
This converts these folders inside lib/core to ESModule.

lib/core/
→ audience_evaluator,
→ bucketer, 
→ condition_tree_evaluator, 
→ custom_attribute_condition_evaluator, 
→ decision_service

## Test plan
All unit test and Full stack compatibility suite tests pass.
