### PR TITLE
refactor: Added a separate bundle for Json Schema Validator

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed `Promise` polyfill from browser entry point ([417](https://github.com/optimizely/javascript-sdk/pull/417)).
 - Changed functionality of JSON schema validation in all entry points ([442](https://github.com/optimizely/javascript-sdk/pull/442)).
    - Previously, `skipJSONValidation` flag was used by the user to specify whether the JSON object should be validated.
-   - Now, `skipJSONValidation` has been removed entirely from all entry points. Instead, a user will need to import `jsonSchemaValidator` from `@optimizely/optimizely-sdk/lib/utils/json_schema_validator` and pass it to `createInstance` to perform validation as shown below:
+   - Now, `skipJSONValidation` has been removed entirely from all entry points. Instead, a user will need to import `jsonSchemaValidator` from `@optimizely/optimizely-sdk/dist/optimizely.json_schema_validator.min.js` and pass it to `createInstance` to perform validation as shown below:
    
   ```js
   const optimizelySDK = require('@optimizely/optimizely-sdk');
-  const jsonSchemaValidator = require('@optimizely/optimizely-sdk/lib/utils/json_schema_validator');
+  const jsonSchemaValidator = require('@optimizely/optimizely-sdk/dist/optimizely.json_schema_validator.min');
   
   // Require JSON schema validation for the datafile
   var optimizelyClientInstance = optimizely.createInstance({

--- a/packages/optimizely-sdk/rollup.config.js
+++ b/packages/optimizely-sdk/rollup.config.js
@@ -87,10 +87,27 @@ const umdconfig = {
   ],
 };
 
+// A separate bundle for json schema validator.
+const jsonSchemaValidatorConfig = {
+  plugins: [
+    resolve(),
+    commonjs(),
+  ],
+  external: ['json-schema', '@optimizely/js-sdk-utils'],
+  input: 'lib/utils/json_schema_validator/index.js',
+  output: {
+    exports: 'named',
+    format: 'cjs',
+    file: 'dist/optimizely.json_schema_validator.min.js',
+    plugins: [ terser() ],
+  }
+};
+
 export default [
   BUILD_ALL && getCjsConfigForPlatform('node'),
   BUILD_ALL && getCjsConfigForPlatform('browser'),
   BUILD_ALL && getCjsConfigForPlatform('react_native'),
   BUILD_ALL && esModuleConfig,
+  BUILD_ALL && jsonSchemaValidatorConfig,
   (BUILD_ALL || BUILD_UMD_BUNDLE) && umdconfig,
 ].filter(config => config);


### PR DESCRIPTION
## Summary
Since all the code was common JS earlier, json schema validator could be imported directly from source code. Now its no longer possible because its converted to Es module. Created a separate Cjs bundle for json schema validator to serve the same purpose.

## Test plan
Manually tested thoroughly