### PR TITLE
refactor: Added a dev dependency to datafile manager

### DIFF
--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -410,6 +410,15 @@
         "uuid": "^3.3.2"
       }
     },
+    "@react-native-community/async-storage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.9.0.tgz",
+      "integrity": "sha512-TlGMr02JcmY4huH1P7Mt7p6wJecosPpW+09+CwCFLn875IhpRqU2XiVA+BQppZOYfQdHUfUzIKyCBeXOlCEbEg==",
+      "dev": true,
+      "requires": {
+        "deep-assign": "^3.0.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -1347,6 +1356,15 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -3168,6 +3186,12 @@
           }
         }
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -39,7 +39,8 @@
     "nock": "^10.0.6",
     "prettier": "^1.19.1",
     "ts-jest": "^24.0.0",
-    "typescript": "3.3.3333"
+    "typescript": "3.3.3333",
+    "@react-native-community/async-storage": "^1.2.0"
   },
   "dependencies": {
     "@optimizely/js-sdk-logging": "^0.1.0",


### PR DESCRIPTION
## Summary
Datafile Manager declares `@react-native-community/async-storage` as a peer dependency. This is required to be in `node_modules` when typescript is transpiled before publishing or during development. Adding it as a dev dependency in addition to the peer dependency.

## Test plan
All the existing test pass