### PR TITLE
chore: Removed unwanted step from datafile manager docs

### DIFF
--- a/packages/datafile-manager/README.md
+++ b/packages/datafile-manager/README.md
@@ -36,11 +36,6 @@ manager.on('update', ({ datafile }) => {
 ```
 
 ## Development
-For development, installation of peer dependency `@react-native-community/async-storage` is also required:
-```sh
-npm i --no-save @react-native-community/async-storage
-```
-
 - The `lint` package.json script runs ESLint and Prettier. This applies formatting and lint fixes to all `.ts` files in the `src/` directory.
 - The `test` package.json script runs our Jest-based test suite.
 - The `tsc` package.json script runs the TypeScript compiler to build the final scripts for publishing (into the `lib/` directory).


### PR DESCRIPTION
## Summary
Datafile Manager does not require manual installation of `@react-native-community/async-storage` dependency as this is now added as a dev dependency and will automatically be installed

## Test plan
Documentation change. Not testing needed.