### PR TITLE
chore(datafile manager): Remove react native entry point from package.json

### DIFF
--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -8,7 +8,6 @@
   },
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
-  "react-native": "lib/index.react_native.js",
   "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
## Summary

Remove entry point for RN datafile manager.

## Test plan

Existing tests