### PR TITLE
chore: Prepare for js-sdk-datafile-manager 0.5.0 release

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.5.0] - April 17, 2020
+
 ### Breaking Changes
 - Removed `StaticDatafileManager` from all top level exports
 - Dropped support for Node.js version <8

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Optimizely Full Stack Datafile Manager",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Prepare for js-sdk-datafile-manager 0.5.0 release