### PR TITLE
chore: Add source maps to build output

### DIFF
--- a/packages/optimizely-sdk/rollup.config.js
+++ b/packages/optimizely-sdk/rollup.config.js
@@ -33,7 +33,8 @@ const getCjsConfigForPlatform = (platform) => {
       exports: 'named',
       format: 'cjs',
       file: `dist/optimizely.${platform}.min.js`,
-      plugins: [ terser() ]
+      plugins: [ terser() ],
+      sourcemap: true,
     }
   };
 };
@@ -44,7 +45,8 @@ const esModuleConfig = {
     exports: 'named',
     format: 'es',
     file: 'dist/optimizely.browser.es.min.js',
-    plugins: [ terser() ]
+    plugins: [ terser() ],
+    sourcemap: true,
   }
 }
 
@@ -83,6 +85,7 @@ const umdconfig = {
       file: 'dist/optimizely.browser.umd.min.js',
       exports: 'named',
       plugins: [ terser() ],
+      sourcemap: true,
     },
   ],
 };
@@ -100,6 +103,7 @@ const jsonSchemaValidatorConfig = {
     format: 'cjs',
     file: 'dist/optimizely.json_schema_validator.min.js',
     plugins: [ terser() ],
+    sourcemap: true,
   }
 };
 


### PR DESCRIPTION
## Summary

Update Rollup build configuration to produce source maps for the minified .js files. This helps with debugging any SDK issues or usage.

## Test plan

Manually tested in Node, using [built-in debugger](https://nodejs.org/en/docs/guides/debugging-getting-started/) with Chrome dev tools