### PR TITLE
Configure repository.directory for monorepo packages

### DIFF
--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -2,6 +2,11 @@
   "name": "@optimizely/js-sdk-datafile-manager",
   "version": "0.5.0",
   "description": "Optimizely Full Stack Datafile Manager",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/optimizely/javascript-sdk.git",
+    "directory": "packages/datafile-manager"
+  },
   "license": "Apache-2.0",
   "engines": {
     "node": ">=6.0.0"

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/optimizely/javascript-sdk.git"
+    "url": "git+https://github.com/optimizely/javascript-sdk.git",
+    "directory": "packages/event-processor"
   },
   "keywords": [
     "optimizely"

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/optimizely/javascript-sdk.git"
+    "url": "git+https://github.com/optimizely/javascript-sdk.git",
+    "directory": "packages/logging"
   },
   "keywords": [
     "optimizely"

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/optimizely/javascript-sdk.git"
+    "url": "git+https://github.com/optimizely/javascript-sdk.git",
+    "directory": "packages/optimizely-sdk"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/optimizely/javascript-sdk.git"
+    "url": "git+https://github.com/optimizely/javascript-sdk.git",
+    "directory": "packages/utils"
   },
   "keywords": [
     "optimizely"


### PR DESCRIPTION
## Summary 

Configure each package's `package.json#repository.directory` 
property to properly reflect the location of the package within 
the repository.

This is the standard configuration value for deep-linking into a
package's directory within a monorepo.

npm RFC: https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md

This will ensure the packages' pages on npmjs.org will link to the
correct directory.

Also, _eventually_, it will ensure the `npm repo` command opens to the
correct location: https://github.com/npm/cli/pull/163

Lastly, this is _required_ for monorepo packages to be successfully
published to the GitHub Package Registry (if that is ever considered in
the future).
https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#publishing-multiple-packages-to-the-same-repository

## Test plan
n/a

## Issues

