### PR TITLE
Updates engines.node stanza to reflect actual requirements

### DIFF
--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -4,7 +4,7 @@
   "description": "Optimizely Full Stack Datafile Manager",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "optimizely"


### PR DESCRIPTION
## Summary
The version spec in package.json#engines.node is out of date from what is specified in the corresponding READMEs. This updates the package to declare the correct minimum version of node.

While it may seem unimportant, the package.json#engines.node spec is respected by some tools, like nodenv, for node version selection. So this being incorrect can potentially activate the wrong version of node for someone developing locally.