### PR TITLE
Removes direct UUID dep

### DIFF
--- a/packages/optimizely-sdk/README.md
+++ b/packages/optimizely-sdk/README.md
@@ -100,10 +100,6 @@ Prod dependencies are as follows:
     "licenses": "MIT*",
     "repository": "https://github.com/perezd/node-murmurhash"
   },
-  "uuid@3.3.2": {
-    "licenses": "MIT",
-    "repository": "https://github.com/kelektiv/node-uuid"
-  },
   "decompress-response@4.2.1": {
     "licenses": "MIT",
     "repository": "https://github.com/sindresorhus/decompress-response"

--- a/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/event_builder/index.tests.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import uuid from 'uuid';
 import sinon from 'sinon';
 import { assert } from 'chai';
 
+import fns from '../../utils/fns';
 import testData from '../../tests/test_data';
 import projectConfig from '../project_config';
 import packageJSON from '../../../package.json';
@@ -31,7 +31,7 @@ describe('lib/core/event_builder', function() {
     beforeEach(function() {
       configObj = projectConfig.createProjectConfig(testData.getTestProjectConfig());
       clock = sinon.useFakeTimers(new Date().getTime());
-      sinon.stub(uuid, 'v4').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
+      sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
       mockLogger = {
         log: sinon.stub(),
       };
@@ -39,7 +39,7 @@ describe('lib/core/event_builder', function() {
 
     afterEach(function() {
       clock.restore();
-      uuid.v4.restore();
+      fns.uuid.restore();
     });
 
     describe('getImpressionEvent', function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -15,7 +15,6 @@
  ***************************************************************************/
 import { assert } from 'chai';
 import sinon from 'sinon';
-import uuid from 'uuid';
 import { sprintf } from '@optimizely/js-sdk-utils';
 import * as eventProcessor from '@optimizely/js-sdk-event-processor';
 import * as logging from '@optimizely/js-sdk-logging';
@@ -294,7 +293,7 @@ describe('lib/optimizely', function() {
       sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
-      sinon.stub(uuid, 'v4').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
+      sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
 
       clock = sinon.useFakeTimers(new Date().getTime());
     });
@@ -305,7 +304,7 @@ describe('lib/optimizely', function() {
       errorHandler.handleError.restore();
       createdLogger.log.restore();
       clock.restore();
-      uuid.v4.restore();
+      fns.uuid.restore();
     });
 
     describe('#activate', function() {
@@ -4337,7 +4336,7 @@ describe('lib/optimizely', function() {
       sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
-      sandbox.stub(uuid, 'v4').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
+      sandbox.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
       sandbox.stub(fns, 'currentTimestamp').returns(1509489766569);
       clock = sinon.useFakeTimers(new Date().getTime());
     });
@@ -7311,7 +7310,7 @@ describe('lib/optimizely', function() {
       sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
-      sinon.stub(uuid, 'v4').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
+      sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
 
       clock = sinon.useFakeTimers(new Date().getTime());
     });
@@ -7322,7 +7321,7 @@ describe('lib/optimizely', function() {
       errorHandler.handleError.restore();
       createdLogger.log.restore();
       clock.restore();
-      uuid.v4.restore();
+      fns.uuid.restore();
     });
 
     describe('when eventBatchSize = 3 and eventFlushInterval = 100', function() {

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -17,7 +17,7 @@ import { generateUUID as uuid, keyBy as keyByUtil } from '@optimizely/js-sdk-uti
 
 var MAX_SAFE_INTEGER_LIMIT = Math.pow(2, 53);
 
-export var assign = function(target) {
+export var assign = function (target) {
   if (!target) {
     return {};
   }
@@ -40,24 +40,24 @@ export var assign = function(target) {
   }
 };
 
-export var currentTimestamp = function() {
+export var currentTimestamp = function () {
   return Math.round(new Date().getTime());
 };
 
-export var isSafeInteger = function(number) {
+export var isSafeInteger = function (number) {
   return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
 };
 
-export var keyBy = function(arr, key) {
+export var keyBy = function (arr, key) {
   if (!arr) return {};
-  return keyByUtil(arr, function(item) {
+  return keyByUtil(arr, function (item) {
     return item[key];
   });
 };
 
-export { uuid }
+export { uuid };
 
-export var isNumber = function(value) {
+export var isNumber = function (value) {
   return typeof value === 'number';
 };
 

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -62,10 +62,10 @@ export var isNumber = function (value) {
 };
 
 export default {
-  assign,
-  currentTimestamp,
-  isSafeInteger,
-  keyBy,
-  uuid,
-  isNumber,
+  assign: assign,
+  currentTimestamp: currentTimestamp,
+  isSafeInteger: isSafeInteger,
+  keyBy: keyBy,
+  uuid: uuid,
+  isNumber: isNumber,
 };

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { generateUUID, keyBy as keyByUtil } from '@optimizely/js-sdk-utils';
+import { generateUUID as uuid, keyBy as keyByUtil } from '@optimizely/js-sdk-utils';
 
 var MAX_SAFE_INTEGER_LIMIT = Math.pow(2, 53);
 
@@ -55,17 +55,17 @@ export var keyBy = function(arr, key) {
   });
 };
 
-export var uuid = generateUUID
+export { uuid }
 
 export var isNumber = function(value) {
   return typeof value === 'number';
 };
 
 export default {
-  assign: assign,
-  currentTimestamp: currentTimestamp,
-  isSafeInteger: isSafeInteger,
-  keyBy: keyBy,
-  uuid: uuid,
-  isNumber: isNumber,
+  assign,
+  currentTimestamp,
+  isSafeInteger,
+  keyBy,
+  uuid,
+  isNumber,
 };

--- a/packages/optimizely-sdk/lib/utils/fns/index.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.js
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import uuidLib from 'uuid';
-import { keyBy as keyByUtil } from '@optimizely/js-sdk-utils';
+import { generateUUID, keyBy as keyByUtil } from '@optimizely/js-sdk-utils';
 
 var MAX_SAFE_INTEGER_LIMIT = Math.pow(2, 53);
 
@@ -56,9 +55,7 @@ export var keyBy = function(arr, key) {
   });
 };
 
-export var uuid = function() {
-  return uuidLib.v4();
-};
+export var uuid = generateUUID
 
 export var isNumber = function(value) {
   return typeof value === 'number';

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -40,8 +40,7 @@
     "@optimizely/js-sdk-logging": "^0.1.0",
     "@optimizely/js-sdk-utils": "^0.2.0",
     "json-schema": "^0.2.3",
-    "murmurhash": "0.0.2",
-    "uuid": "^3.3.2"
+    "murmurhash": "0.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { v4 } from 'uuid'
+export { v4 as generateUUID } from 'uuid'
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export function getTimestamp(): number {
   return new Date().getTime()
-}
-
-export function generateUUID(): string {
-  return v4()
 }
 
 /**


### PR DESCRIPTION
## Summary

UUID is already exposed in the js-sdk-utils package, so we should use it directly.
That will ensure de-duping, as well as automatic tree shaking of the uuid dep (because the utils package imports UUID via ESM).

**Before**
![image](https://user-images.githubusercontent.com/119972/81292998-91646480-903a-11ea-95b4-037e52c82096.png)

**After**
![image](https://user-images.githubusercontent.com/119972/81293265-046ddb00-903b-11ea-9ef3-b7171e7c3900.png)

closes #479 
