### PR TITLE
Fix test stubbings of global XHR object

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -61,7 +61,6 @@ describe('javascript-sdk', function() {
         optimizelyFactory.__internalResetRetryState();
         console.error.restore();
         configValidator.validate.restore();
-        XMLHttpRequest.restore();
         delete global.XMLHttpRequest
       });
 

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -29,7 +29,6 @@ var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEven
 
 describe('javascript-sdk', function() {
   describe('APIs', function() {
-    var xhr;
     var requests;
 
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
@@ -54,10 +53,9 @@ describe('javascript-sdk', function() {
         sinon.spy(console, 'error');
         sinon.stub(configValidator, 'validate');
 
-        xhr = sinon.useFakeXMLHttpRequest();
-        global.XMLHttpRequest = xhr;
         requests = [];
-        xhr.onCreate = function(req) {
+        global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+        XMLHttpRequest.onCreate = function(req) {
           requests.push(req);
         };
 
@@ -69,7 +67,8 @@ describe('javascript-sdk', function() {
         optimizelyFactory.__internalResetRetryState();
         console.error.restore();
         configValidator.validate.restore();
-        xhr.restore();
+        XMLHttpRequest.restore();
+        delete global.XMLHttpRequest
       });
 
       describe('when an eventDispatcher is not passed in', function() {

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -29,8 +29,6 @@ var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEven
 
 describe('javascript-sdk', function() {
   describe('APIs', function() {
-    var requests;
-
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
       assert.isDefined(optimizelyFactory.logging);
       assert.isDefined(optimizelyFactory.logging.createLogger);
@@ -53,11 +51,7 @@ describe('javascript-sdk', function() {
         sinon.spy(console, 'error');
         sinon.stub(configValidator, 'validate');
 
-        requests = [];
         global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
-        XMLHttpRequest.onCreate = function(req) {
-          requests.push(req);
-        };
 
         sinon.stub(LocalStoragePendingEventsDispatcher.prototype, 'sendPendingEvents');
       });

--- a/packages/optimizely-sdk/lib/index.browser.umdtests.js
+++ b/packages/optimizely-sdk/lib/index.browser.umdtests.js
@@ -26,8 +26,6 @@ import eventDispatcher from './plugins/event_dispatcher/index.browser';
 
 describe('javascript-sdk', function() {
   describe('APIs', function() {
-    var xhr;
-    var requests;
     describe('createInstance', function() {
       var fakeErrorHandler = { handleError: function() {} };
       var fakeEventDispatcher = { dispatchEvent: function() {} };
@@ -41,12 +39,7 @@ describe('javascript-sdk', function() {
         sinon.stub(configValidator, 'validate');
         sinon.stub(Optimizely.prototype, 'close');
 
-        xhr = sinon.useFakeXMLHttpRequest();
-        global.XMLHttpRequest = xhr;
-        requests = [];
-        xhr.onCreate = function(req) {
-          requests.push(req);
-        };
+        global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
 
         sinon.spy(console, 'log');
         sinon.spy(console, 'info');
@@ -64,7 +57,7 @@ describe('javascript-sdk', function() {
         window.addEventListener.restore();
         configValidator.validate.restore();
         Optimizely.prototype.close.restore();
-        xhr.restore();
+        delete global.XMLHttpRequest
       });
 
       // this test has to come first due to local state of the logLevel

--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -28,9 +28,6 @@ import eventProcessorConfigValidator from './utils/event_processor_config_valida
 
 describe('javascript-sdk/react-native', function() {
   describe('APIs', function() {
-    var xhr;
-    var requests;
-
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
       assert.isDefined(optimizelyFactory.logging);
       assert.isDefined(optimizelyFactory.logging.createLogger);
@@ -52,18 +49,11 @@ describe('javascript-sdk/react-native', function() {
         });
         sinon.spy(console, 'error');
         sinon.stub(configValidator, 'validate');
-
-        xhr = sinon.useFakeXMLHttpRequest();
-        requests = [];
-        xhr.onCreate = function(req) {
-          requests.push(req);
-        };
       });
 
       afterEach(function() {
         console.error.restore();
         configValidator.validate.restore();
-        xhr.restore();
       });
 
       it('should not throw if the provided config is not valid', function() {

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -24,11 +24,10 @@ describe('lib/plugins/event_dispatcher/browser', function() {
       beforeEach(function() {
         this.requests = [];
         global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
-        XMLHttpRequest.onCreate = (req) => { this.requests.push(req); };
+        global.XMLHttpRequest.onCreate = (req) => { this.requests.push(req); };
       });
 
       afterEach(function() {
-        XMLHttpRequest.restore();
         delete global.XMLHttpRequest
       });
 

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -21,19 +21,18 @@ import { dispatchEvent } from './index.browser';
 describe('lib/plugins/event_dispatcher/browser', function() {
   describe('APIs', function() {
     describe('dispatchEvent', function() {
-      var xhr;
       var requests;
       beforeEach(function() {
-        xhr = sinon.useFakeXMLHttpRequest();
-        global.XMLHttpRequest = xhr;
         requests = [];
-        xhr.onCreate = function(req) {
+        global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+        XMLHttpRequest.onCreate = function(req) {
           requests.push(req);
         };
       });
 
       afterEach(function() {
-        xhr.restore();
+        XMLHttpRequest.restore();
+        delete global.XMLHttpRequest
       });
 
       it('should send a POST request with the specified params', function(done) {

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -21,13 +21,10 @@ import { dispatchEvent } from './index.browser';
 describe('lib/plugins/event_dispatcher/browser', function() {
   describe('APIs', function() {
     describe('dispatchEvent', function() {
-      var requests;
       beforeEach(function() {
-        requests = [];
+        this.requests = [];
         global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
-        XMLHttpRequest.onCreate = function(req) {
-          requests.push(req);
-        };
+        XMLHttpRequest.onCreate = (req) => { this.requests.push(req); };
       });
 
       afterEach(function() {
@@ -48,9 +45,9 @@ describe('lib/plugins/event_dispatcher/browser', function() {
 
         var callback = sinon.spy();
         dispatchEvent(eventObj, callback);
-        assert.strictEqual(1, requests.length);
-        assert.strictEqual(requests[0].method, 'POST');
-        assert.strictEqual(requests[0].requestBody, JSON.stringify(eventParams));
+        assert.strictEqual(1, this.requests.length);
+        assert.strictEqual(this.requests[0].method, 'POST');
+        assert.strictEqual(this.requests[0].requestBody, JSON.stringify(eventParams));
         done();
       });
 
@@ -67,7 +64,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
 
         var callback = sinon.spy();
         dispatchEvent(eventObj, callback);
-        requests[0].respond([
+        this.requests[0].respond([
           200,
           {},
           '{"url":"https://cdn.com/event","body":{"id":123},"httpVerb":"POST","params":{"testParam":"testParamValue"}}',
@@ -84,7 +81,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
 
         var callback = sinon.spy();
         dispatchEvent(eventObj, callback);
-        requests[0].respond([200, {}, '{"url":"https://cdn.com/event","httpVerb":"GET"']);
+        this.requests[0].respond([200, {}, '{"url":"https://cdn.com/event","httpVerb":"GET"']);
         sinon.assert.calledOnce(callback);
         done();
       });

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.browser.tests.js
@@ -25,6 +25,7 @@ describe('lib/plugins/event_dispatcher/browser', function() {
       var requests;
       beforeEach(function() {
         xhr = sinon.useFakeXMLHttpRequest();
+        global.XMLHttpRequest = xhr;
         requests = [];
         xhr.onCreate = function(req) {
           requests.push(req);


### PR DESCRIPTION
## Summary

Fixes cross-test pollution of global XHR object.

The global XHR object was being stubbed in some tests but not others. But the tests that didn't stub weren't failing because the tests that _were_ stubbing weren't being cleaned up! So some test suites were depending (implicitly) on side effects from other test files.



## Issues
partially fixes #488 
