### PR TITLE
fix: Add type definition for getFeatureVariable, fix type definition for getAllFeatureVariables

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Bug fixes
+- Added definition of `getFeatureVariable` method in TypeScript type definitions
+- Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions
+
 ## [4.0.0] - April 30, 2020
 
 ### New Features

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -65,6 +65,7 @@ declare module '@optimizely/optimizely-sdk' {
     getForcedVariation(experimentKey: string, userId: string): string | null;
     isFeatureEnabled(featureKey: string, userId: string, attributes?: UserAttributes): boolean;
     getEnabledFeatures(userId: string, attributes?: UserAttributes): string[];
+    getFeatureVariable(featureKey: string, variableKey: string, userId: string, attributes?: UserAttributes): unknown
     getFeatureVariableBoolean(
       featureKey: string,
       variableKey: string,
@@ -99,7 +100,7 @@ declare module '@optimizely/optimizely-sdk' {
       featureKey: string,
       userId: string,
       attributes?: UserAttributes
-    ): unknown;
+    ): { [variableKey: string]: unknown };
     getOptimizelyConfig(): OptimizelyConfig | null;
     onReady(options?: { timeout?: number }): Promise<{ success: boolean; reason?: string }>;
     close(): Promise<{ success: boolean; reason?: string }>;


### PR DESCRIPTION
## Summary
- Add missing definition for `getFeatureVariable`
- Fix return type for `getAllFeatureVariables`

## Test plan
Manually tested
