### PR TITLE
fix(log-level) change single audience result to debug

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.0.0] - April 30, 2020
 
+### Bug fixes
+Revisited audience evaluation log level to debug
+
 ### New Features
 
 - Removed lodash dependency

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -10,11 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug fixes
 - Added definition of `getFeatureVariable` method in TypeScript type definitions
 - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions
+- Revisited audience evaluation log level to debug
 
 ## [4.0.0] - April 30, 2020
-
-### Bug fixes
-Revisited audience evaluation log level to debug
 
 ### New Features
 

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.js
@@ -19,7 +19,7 @@ import { getLogger } from '@optimizely/js-sdk-logging';
 import fns from '../../utils/fns';
 import {
   LOG_LEVEL,
-  LOG_MESSAGES, 
+  LOG_MESSAGES,
   ERROR_MESSAGES,
 } from '../../utils/enums';
 import conditionTreeEvaluator from '../condition_tree_evaluator';
@@ -76,7 +76,7 @@ AudienceEvaluator.prototype.evaluate = function(audienceConditions, audiencesByI
         this.evaluateConditionWithUserAttributes.bind(this, userAttributes)
       );
       var resultText = result === null ? 'UNKNOWN' : result.toString().toUpperCase();
-      logger.log(LOG_LEVEL.INFO, sprintf(LOG_MESSAGES.AUDIENCE_EVALUATION_RESULT, MODULE_NAME, audienceId, resultText));
+      logger.log(LOG_LEVEL.DEBUG, sprintf(LOG_MESSAGES.AUDIENCE_EVALUATION_RESULT, MODULE_NAME, audienceId, resultText));
       return result;
     }
 


### PR DESCRIPTION
## Summary
Updating audience evaluation log level to be debug. The only info level log will be the one corresponding to the result of overall evaluation of an audience.

## Test plan
All checks pass.
