### PR TITLE
fix: Stub event dispatcher and mock timers in tests

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -414,7 +414,6 @@ describe('javascript-sdk', function() {
             eventDispatcher: fakeEventDispatcher,
             logger: silentLogger,
           });
-
           sinon.assert.calledWithExactly(
             eventProcessorSpy,
             sinon.match({

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -28,24 +28,15 @@ import eventProcessorConfigValidator from './utils/event_processor_config_valida
 var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEventsDispatcher;
 
 describe('javascript-sdk', function() {
+  var clock;
   beforeEach(function() {
-    sinon.spy(optimizelyFactory, 'createInstance');
-    sinon.stub(optimizelyFactory.eventDispatcher, 'dispatchEvent').callsFake(function(eventObj, cb) {
-      setTimeout(function() {
-        cb();
-      }, 0);
-    });
+    sinon.stub(optimizelyFactory.eventDispatcher, 'dispatchEvent');
+    clock = sinon.useFakeTimers(new Date());
   });
 
   afterEach(function() {
     optimizelyFactory.eventDispatcher.dispatchEvent.restore();
-    var instances = optimizelyFactory.createInstance.getCalls().map(function(call) {
-      return call.returnValue;
-    })
-    optimizelyFactory.createInstance.restore();
-    return Promise.all(instances.map(function(instance) {
-      return instance.close();
-    }));
+    clock.restore();
   });
 
   describe('APIs', function() {

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -28,6 +28,26 @@ import eventProcessorConfigValidator from './utils/event_processor_config_valida
 var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEventsDispatcher;
 
 describe('javascript-sdk', function() {
+  beforeEach(function() {
+    sinon.spy(optimizelyFactory, 'createInstance');
+    sinon.stub(optimizelyFactory.eventDispatcher, 'dispatchEvent').callsFake(function(eventObj, cb) {
+      setTimeout(function() {
+        cb();
+      }, 0);
+    });
+  });
+
+  afterEach(function() {
+    optimizelyFactory.eventDispatcher.dispatchEvent.restore();
+    var instances = optimizelyFactory.createInstance.getCalls().map(function(call) {
+      return call.returnValue;
+    })
+    optimizelyFactory.createInstance.restore();
+    return Promise.all(instances.map(function(instance) {
+      return instance.close();
+    }));
+  });
+
   describe('APIs', function() {
     it('should expose logger, errorHandler, eventDispatcher and enums', function() {
       assert.isDefined(optimizelyFactory.logging);
@@ -151,19 +171,6 @@ describe('javascript-sdk', function() {
         optlyInstance.onReady().catch(function() {});
         assert.equal('javascript-sdk', optlyInstance.clientEngine);
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
-      });
-
-      it('should allow passing of "react-sdk" as the clientEngine', function() {
-        var optlyInstance = optimizelyFactory.createInstance({
-          clientEngine: 'react-sdk',
-          datafile: {},
-          errorHandler: fakeErrorHandler,
-          eventDispatcher: fakeEventDispatcher,
-          logger: silentLogger,
-        });
-        // Invalid datafile causes onReady Promise rejection - catch this error
-        optlyInstance.onReady().catch(function() {});
-        assert.equal('react-sdk', optlyInstance.clientEngine);
       });
 
       it('should allow passing of "react-sdk" as the clientEngine', function() {
@@ -393,7 +400,7 @@ describe('javascript-sdk', function() {
       describe('event processor configuration', function() {
         var eventProcessorSpy;
         beforeEach(function() {
-          eventProcessorSpy = sinon.stub(eventProcessor, 'LogTierV1EventProcessor').callThrough();
+          eventProcessorSpy = sinon.spy(eventProcessor, 'LogTierV1EventProcessor');
         });
 
         afterEach(function() {
@@ -407,6 +414,7 @@ describe('javascript-sdk', function() {
             eventDispatcher: fakeEventDispatcher,
             logger: silentLogger,
           });
+
           sinon.assert.calledWithExactly(
             eventProcessorSpy,
             sinon.match({

--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -26,24 +26,15 @@ import configValidator from './utils/config_validator';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
 
 describe('javascript-sdk/react-native', function() {
+  var clock;
   beforeEach(function() {
-    sinon.spy(optimizelyFactory, 'createInstance');
-    sinon.stub(optimizelyFactory.eventDispatcher, 'dispatchEvent').callsFake(function(eventObj, cb) {
-      setTimeout(function() {
-        cb();
-      }, 0);
-    });
+    sinon.stub(optimizelyFactory.eventDispatcher, 'dispatchEvent');
+    clock = sinon.useFakeTimers(new Date());
   });
 
   afterEach(function() {
     optimizelyFactory.eventDispatcher.dispatchEvent.restore();
-    var instances = optimizelyFactory.createInstance.getCalls().map(function(call) {
-      return call.returnValue;
-    })
-    optimizelyFactory.createInstance.restore();
-    return Promise.all(instances.map(function(instance) {
-      return instance.close();
-    }));
+    clock.restore();
   });
 
   describe('APIs', function() {
@@ -146,9 +137,8 @@ describe('javascript-sdk/react-native', function() {
             logger: silentLogger,
           });
           optlyInstance.activate('testExperiment', 'testUser');
-          return optlyInstance.close().then(function() {
-            sinon.assert.calledOnce(optimizelyFactory.eventDispatcher.dispatchEvent);
-          });
+          clock.tick(30001)
+          sinon.assert.calledOnce(optimizelyFactory.eventDispatcher.dispatchEvent);
         });
       });
 

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -46,6 +46,7 @@ describe('lib/optimizely', function() {
   var ProjectConfigManagerStub;
   var globalStubErrorHandler;
   var stubLogHandler;
+  var clock;
   beforeEach(function() {
     logging.setLogLevel('notset');
     stubLogHandler = {
@@ -65,11 +66,8 @@ describe('lib/optimizely', function() {
         onReady: sinon.stub().returns({ then: function() {} }),
       };
     });
-    sinon.stub(eventDispatcher, 'dispatchEvent').callsFake(function(eventObj, cb) {
-      setTimeout(function() {
-        cb();
-      }, 0);
-    });
+    sinon.stub(eventDispatcher, 'dispatchEvent');
+    clock = sinon.useFakeTimers(new Date());
   });
 
   afterEach(function() {
@@ -77,6 +75,7 @@ describe('lib/optimizely', function() {
     logging.resetErrorHandler();
     logging.resetLogger();
     eventDispatcher.dispatchEvent.restore();
+    clock.restore();
   });
 
   describe('constructor', function() {
@@ -278,7 +277,6 @@ describe('lib/optimizely', function() {
   describe('APIs', function() {
     var optlyInstance;
     var bucketStub;
-    var clock;
     var createdLogger = logger.createLogger({
       logLevel: LOG_LEVEL.INFO,
       logToConsole: false,
@@ -299,15 +297,12 @@ describe('lib/optimizely', function() {
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
       sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
-
-      clock = sinon.useFakeTimers(new Date().getTime());
     });
 
     afterEach(function() {
       bucketer.bucket.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
-      clock.restore();
       fns.uuid.restore();
     });
 
@@ -3176,7 +3171,7 @@ describe('lib/optimizely', function() {
 
                 it('returns the right value from getAllFeatureVariables and send notification with featureEnabled true', function() {
                   var result = optlyInstance.getAllFeatureVariables(
-                    'test_feature_for_experiment',                  
+                    'test_feature_for_experiment',
                     'user1',
                     { test_attribute: 'test_value' }
                   );
@@ -3196,7 +3191,7 @@ describe('lib/optimizely', function() {
                     attributes: { test_attribute: 'test_value' },
                     decisionInfo: {
                       featureKey: 'test_feature_for_experiment',
-                      featureEnabled: true,                      
+                      featureEnabled: true,
                       variableValues: {
                         is_button_animated: true,
                         button_width: 20.25,
@@ -3213,9 +3208,9 @@ describe('lib/optimizely', function() {
                         variationKey: 'variation',
                       },
                     },
-                  });                  
+                  });
                 });
-              });              
+              });
 
               describe('when the variation is toggled OFF', function() {
                 beforeEach(function() {
@@ -3374,7 +3369,7 @@ describe('lib/optimizely', function() {
 
                 it('returns the right value from getAllFeatureVariables and send notification with featureEnabled false', function() {
                   var result = optlyInstance.getAllFeatureVariables(
-                    'test_feature_for_experiment',                  
+                    'test_feature_for_experiment',
                     'user1',
                     { test_attribute: 'test_value' }
                   );
@@ -3394,7 +3389,7 @@ describe('lib/optimizely', function() {
                     attributes: { test_attribute: 'test_value' },
                     decisionInfo: {
                       featureKey: 'test_feature_for_experiment',
-                      featureEnabled: false,                      
+                      featureEnabled: false,
                       variableValues: {
                         is_button_animated: false,
                         button_width: 50.55,
@@ -3411,7 +3406,7 @@ describe('lib/optimizely', function() {
                         variationKey: 'variation2',
                       },
                     },
-                  });              
+                  });
                 });
               });
             });
@@ -3675,7 +3670,7 @@ describe('lib/optimizely', function() {
                     attributes: { test_attribute: 'test_value' },
                     decisionInfo: {
                       featureKey: 'test_feature',
-                      featureEnabled: true,                      
+                      featureEnabled: true,
                       variableValues: {
                         new_content: true,
                         price: 4.99,
@@ -3685,7 +3680,7 @@ describe('lib/optimizely', function() {
                           count: 2,
                           message: 'Hello audience',
                         },
-                      },                      
+                      },
                       source: DECISION_SOURCES.ROLLOUT,
                       sourceInfo: {},
                     },
@@ -4238,7 +4233,7 @@ describe('lib/optimizely', function() {
                   attributes: { test_attribute: 'test_value' },
                   decisionInfo: {
                     featureKey: 'test_feature_for_experiment',
-                    featureEnabled: false,                    
+                    featureEnabled: false,
                     variableValues: {
                       is_button_animated: false,
                       button_width: 50.55,
@@ -4248,7 +4243,7 @@ describe('lib/optimizely', function() {
                         num_buttons: 0,
                         text: 'default value',
                       }
-                    },                    
+                    },
                     source: DECISION_SOURCES.ROLLOUT,
                     sourceInfo: {},
                   },
@@ -4322,7 +4317,6 @@ describe('lib/optimizely', function() {
       logToConsole: false,
     });
     var optlyInstance;
-    var clock;
 
     beforeEach(function() {
       optlyInstance = new Optimizely({
@@ -4341,12 +4335,10 @@ describe('lib/optimizely', function() {
       sandbox.stub(createdLogger, 'log');
       sandbox.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
       sandbox.stub(fns, 'currentTimestamp').returns(1509489766569);
-      clock = sinon.useFakeTimers(new Date().getTime());
     });
 
     afterEach(function() {
       sandbox.restore();
-      clock.restore();
     });
 
     describe('#isFeatureEnabled', function() {
@@ -5867,7 +5859,7 @@ describe('lib/optimizely', function() {
                 createdLogger.log,
                 LOG_LEVEL.INFO,
                 'OPTIMIZELY: Variable "message_info" is not used in variation "594032". Returning default value.'
-              );              
+              );
             });
           });
         });
@@ -6118,7 +6110,7 @@ describe('lib/optimizely', function() {
           });
           assert.deepEqual(result, {
             num_buttons: 0,
-            text: 'default value',            
+            text: 'default value',
           });
           sinon.assert.calledWith(
             createdLogger.log,
@@ -6232,7 +6224,7 @@ describe('lib/optimizely', function() {
             LOG_LEVEL.INFO,
             'OPTIMIZELY: User "user1" is not in any variation or rollout rule. Returning default value for variable "button_info" of feature flag "test_feature_for_experiment".'
           );
-        });        
+        });
       });
 
       it('returns null from getFeatureVariable if user id is null when variable type is boolean', function() {
@@ -7299,7 +7291,6 @@ describe('lib/optimizely', function() {
 
   describe('event batching', function() {
     var bucketStub;
-    var clock;
 
     var createdLogger = logger.createLogger({
       logLevel: LOG_LEVEL.INFO,
@@ -7312,14 +7303,12 @@ describe('lib/optimizely', function() {
       sinon.stub(createdLogger, 'log');
       sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
 
-      clock = sinon.useFakeTimers(new Date().getTime());
     });
 
     afterEach(function() {
       bucketer.bucket.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
-      clock.restore();
       fns.uuid.restore();
     });
 
@@ -7769,11 +7758,9 @@ describe('lib/optimizely', function() {
     });
 
     describe('onReady method', function() {
-      var clock;
       var setTimeoutSpy;
       var clearTimeoutSpy;
       beforeEach(function() {
-        clock = sinon.useFakeTimers(new Date().getTime());
         setTimeoutSpy = sinon.spy(clock, 'setTimeout');
         clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
       });
@@ -7781,7 +7768,6 @@ describe('lib/optimizely', function() {
       afterEach(function() {
         setTimeoutSpy.restore();
         clearTimeoutSpy.restore();
-        clock.restore();
       });
 
       it('fulfills the promise with the value from the project config manager ready promise after the project config manager ready promise is fulfilled', function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -65,12 +65,18 @@ describe('lib/optimizely', function() {
         onReady: sinon.stub().returns({ then: function() {} }),
       };
     });
+    sinon.stub(eventDispatcher, 'dispatchEvent').callsFake(function(eventObj, cb) {
+      setTimeout(function() {
+        cb();
+      }, 0);
+    });
   });
 
   afterEach(function() {
     ProjectConfigManagerStub.restore();
     logging.resetErrorHandler();
     logging.resetLogger();
+    eventDispatcher.dispatchEvent.restore();
   });
 
   describe('constructor', function() {
@@ -290,7 +296,6 @@ describe('lib/optimizely', function() {
       });
 
       bucketStub = sinon.stub(bucketer, 'bucket');
-      sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
       sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
@@ -300,7 +305,6 @@ describe('lib/optimizely', function() {
 
     afterEach(function() {
       bucketer.bucket.restore();
-      eventDispatcher.dispatchEvent.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
       clock.restore();
@@ -4333,7 +4337,6 @@ describe('lib/optimizely', function() {
         eventBatchSize: 1,
       });
 
-      sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
       sandbox.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
@@ -7010,7 +7013,6 @@ describe('lib/optimizely', function() {
         eventBatchSize: 1,
       });
 
-      sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
     });
@@ -7144,7 +7146,6 @@ describe('lib/optimizely', function() {
       });
       audienceEvaluator = AudienceEvaluator.prototype;
 
-      sandbox.stub(eventDispatcher, 'dispatchEvent');
       sandbox.stub(errorHandler, 'handleError');
       sandbox.stub(createdLogger, 'log');
       sandbox.spy(audienceEvaluator, 'evaluate');
@@ -7307,7 +7308,6 @@ describe('lib/optimizely', function() {
 
     beforeEach(function() {
       bucketStub = sinon.stub(bucketer, 'bucket');
-      sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
       sinon.stub(fns, 'uuid').returns('a68cf1ad-0393-4e18-af87-efe8f01a7c9c');
@@ -7317,7 +7317,6 @@ describe('lib/optimizely', function() {
 
     afterEach(function() {
       bucketer.bucket.restore();
-      eventDispatcher.dispatchEvent.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
       clock.restore();
@@ -7665,14 +7664,12 @@ describe('lib/optimizely', function() {
     });
 
     beforeEach(function() {
-      sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
       sinon.spy(eventProcessor, 'LogTierV1EventProcessor');
     });
 
     afterEach(function() {
-      eventDispatcher.dispatchEvent.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
       eventProcessor.LogTierV1EventProcessor.restore();
@@ -7709,13 +7706,11 @@ describe('lib/optimizely', function() {
     });
 
     beforeEach(function() {
-      sinon.stub(eventDispatcher, 'dispatchEvent');
       sinon.stub(errorHandler, 'handleError');
       sinon.stub(createdLogger, 'log');
     });
 
     afterEach(function() {
-      eventDispatcher.dispatchEvent.restore();
       errorHandler.handleError.restore();
       createdLogger.log.restore();
     });
@@ -7943,6 +7938,7 @@ describe('lib/optimizely', function() {
           logger: createdLogger,
           sdkKey: '12345',
           isValidInstance: true,
+          eventBatchSize: 1,
         });
       });
 

--- a/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/plugins/event_dispatcher/index.node.tests.js
@@ -87,18 +87,26 @@ describe('lib/plugins/event_dispatcher/node', function() {
         dispatchEvent(eventObj, callback);
         sinon.assert.notCalled(callback);
       });
-    });
 
-    it('does not throw in the event of an error', function() {
-      var eventObj = {
-        url: 'https://example',
-        params: {},
-        httpVerb: 'POST',
-      };
+      describe('in the event of an error', function() {
+        beforeEach(function() {
+          nock('https://example')
+            .post('/event')
+            .replyWithError('Connection error')
+        });
 
-      var callback = sinon.spy();
-      dispatchEvent(eventObj, callback);
-      sinon.assert.notCalled(callback);
+        it('does not throw', function() {
+          var eventObj = {
+            url: 'https://example/event',
+            params: {},
+            httpVerb: 'POST',
+          };
+
+          var callback = sinon.spy();
+          dispatchEvent(eventObj, callback);
+          sinon.assert.notCalled(callback);
+        });
+      });
     });
   });
 });

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint 'lib/**/*.js'",
-    "test": "mocha --exit -r esm -r lib/tests/exit_on_unhandled_rejection.js 'lib/**/*.tests.js'",
+    "test": "mocha -r esm -r lib/tests/exit_on_unhandled_rejection.js 'lib/**/*.tests.js'",
     "posttest": "npm run lint",
     "test-ci": "npm run test-xbrowser && npm run test-umdbrowser",
     "test-xbrowser": "karma start karma.bs.conf.js --single-run",


### PR DESCRIPTION
## Summary
- Several unit tests weren't properly stubbing the default event dispatcher - add these stubs
- The test suite wasn't exiting due to active timers not being cleaned up. Fixed this by mocking `setTimeout` using `sinon.useFakeTimers`
- One test for Node default event dispatcher was relying on a real connection error from attempting to request to an invalid domain. Added a `nock` mock for this to prevent the real request.

## Test plan
Run `npm test`. Should exit immediately, and not make any outgoing HTTP requests.

## Issues
https://github.com/optimizely/javascript-sdk/issues/487
