### PR TITLE
feat: Bump Datafile Manager version

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### New Features
+- upgrade js-sdk-datafile-manager to 0.6.0 which adds support for `datafileAccessToken` within `datafileOptions` for private datafiles.
+
 ### Bug fixes
 - Added definition of `getFeatureVariable` method in TypeScript type definitions
 - Fixed return type of `getAllFeatureVariables` method in TypeScript type definitions

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -34,6 +34,7 @@ declare module '@optimizely/optimizely-sdk' {
     autoUpdate?: boolean;
     updateInterval?: number;
     urlTemplate?: string;
+    datafileAccessToken?: string;
   }
 
   // The options object given to Optimizely.createInstance.

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -381,9 +381,9 @@
       "dev": true
     },
     "@optimizely/js-sdk-datafile-manager": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.5.0.tgz",
-      "integrity": "sha512-ZDov8jphA+Ez+fA0anioA8ooJrraCFbeGm7GejzPTCZPMisNGtchrpdHr9TMd+hld+TOMBZ5NbqfMvvYhbB34A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.6.0.tgz",
+      "integrity": "sha512-eqUZZZ1M6MYF2vttdjhV2GEd+C8/A94hS3fnGm1ScTMzWeoCcvlrdg3gO0WoXOVh2t7JfkvY9nNdkRJTan3uKg==",
       "requires": {
         "@optimizely/js-sdk-logging": "^0.1.0",
         "@optimizely/js-sdk-utils": "^0.2.0",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/optimizely-sdk",
   "dependencies": {
-    "@optimizely/js-sdk-datafile-manager": "^0.5.0",
+    "@optimizely/js-sdk-datafile-manager": "^0.6.0",
     "@optimizely/js-sdk-event-processor": "^0.4.0",
     "@optimizely/js-sdk-logging": "^0.1.0",
     "@optimizely/js-sdk-utils": "^0.2.0",


### PR DESCRIPTION
## Summary
Bump `datafile-manager` version to `0.6.0`. This adds support for private datafiles for Node.

## Test Plan
- Unit tests added in the `datafile-manager` package along with the implementation.
- Full Stack Compat Suite tests will be added to explicitly test this feature.