### PR TITLE
fix(utils): Wrap uuid.v4 to disallow passing extra arguments and prevent dependency on uuid package types

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,7 +15,9 @@
  */
 import { v4 } from 'uuid';
 
-export const generateUUID: () => string = v4;
+export function generateUUID(): string {
+  return v4()
+}
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { v4 as generateUUID } from 'uuid'
+import { v4 } from 'uuid';
+
+export const generateUUID: () => string = v4;
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 


### PR DESCRIPTION
## Summary

Reverts part of a prior change in the utils package for two reasons:
- `uuid.v4` has different behavior when passed arguments. We have no use for this behavior, thus it is better to ensure no arguments are accidentally passed.
- We don't want our type definitions to be dependent on `'uuid'`'s type definitions

## Test plan

Existing tests