### PR TITLE
docs(readme): Restore uuid in Additional code section

### DIFF
--- a/packages/optimizely-sdk/README.md
+++ b/packages/optimizely-sdk/README.md
@@ -100,6 +100,10 @@ Prod dependencies are as follows:
     "licenses": "MIT*",
     "repository": "https://github.com/perezd/node-murmurhash"
   },
+  "uuid@3.3.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/kelektiv/node-uuid"
+  },
   "decompress-response@4.2.1": {
     "licenses": "MIT",
     "repository": "https://github.com/sindresorhus/decompress-response"


### PR DESCRIPTION
## Summary

This was removed along with the change to use the uuid function exported by the utils package. But, we are listing all additional code from transitive dependencies here (for example, decompress-response), not just direct dependencies.

## Test plan

None. Docs-only change.