### PR TITLE
fix: Changed getFeatureVariableJson to getFeatureVariableJSON

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [4.1.0-beta] - June 16, 2020
 
 ### New Features
-- Added support for JSON feature variables: new methods `getFeatureVariableJson` and `getAllFeatureVariables` ([#467](https://github.com/optimizely/javascript-sdk/pull/467), [#470](https://github.com/optimizely/javascript-sdk/pull/470))
+- Added support for JSON feature variables: new methods `getFeatureVariableJSON` and `getAllFeatureVariables` ([#467](https://github.com/optimizely/javascript-sdk/pull/467), [#470](https://github.com/optimizely/javascript-sdk/pull/470))
 - Added support for authenticated datafiles when running in Node.js. Pass `datafileAccessToken` within `datafileOptions` to request an authenticated datafile using the token ([#498](https://github.com/optimizely/javascript-sdk/pull/498), [#502](https://github.com/optimizely/javascript-sdk/pull/502)):
   ```js
   const optimizelySDK = require('@optimizely/optimizely-sdk');

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -91,7 +91,7 @@ declare module '@optimizely/optimizely-sdk' {
       userId: string,
       attributes?: UserAttributes
     ): string | null;
-    getFeatureVariableJson(
+    getFeatureVariableJSON(
       featureKey: string,
       variableKey: string,
       userId: string,

--- a/packages/optimizely-sdk/lib/optimizely/index.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.js
@@ -686,6 +686,10 @@ Optimizely.prototype.getEnabledFeatures = function(userId, attributes) {
 
 Optimizely.prototype.getFeatureVariable = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariable'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, null, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
@@ -717,14 +721,6 @@ Optimizely.prototype.getFeatureVariable = function(featureKey, variableKey, user
  *                                      with the type of the variable
  */
 Optimizely.prototype._getFeatureVariableForType = function(featureKey, variableKey, variableType, userId, attributes) {
-  if (!this.__isValidInstance()) {
-    var apiName = variableType
-      ? 'getFeatureVariable' + variableType.charAt(0).toUpperCase() + variableType.slice(1)
-      : 'getFeatureVariable';
-    this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, apiName));
-    return null;
-  }
-
   if (!this.__validateInputs({ feature_key: featureKey, variable_key: variableKey, user_id: userId }, attributes)) {
     return null;
   }
@@ -875,6 +871,10 @@ Optimizely.prototype._getFeatureVariableValueFromVariation = function(featureKey
  */
 Optimizely.prototype.getFeatureVariableBoolean = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariableBoolean'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, FEATURE_VARIABLE_TYPES.BOOLEAN, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
@@ -899,6 +899,10 @@ Optimizely.prototype.getFeatureVariableBoolean = function(featureKey, variableKe
  */
 Optimizely.prototype.getFeatureVariableDouble = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariableDouble'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, FEATURE_VARIABLE_TYPES.DOUBLE, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
@@ -923,6 +927,10 @@ Optimizely.prototype.getFeatureVariableDouble = function(featureKey, variableKey
  */
 Optimizely.prototype.getFeatureVariableInteger = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariableInteger'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, FEATURE_VARIABLE_TYPES.INTEGER, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
@@ -947,6 +955,10 @@ Optimizely.prototype.getFeatureVariableInteger = function(featureKey, variableKe
  */
 Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariableString'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, FEATURE_VARIABLE_TYPES.STRING, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);
@@ -969,8 +981,12 @@ Optimizely.prototype.getFeatureVariableString = function(featureKey, variableKey
  *                              invalid, or there is a mismatch with the type
  *                              of the variable
  */
-Optimizely.prototype.getFeatureVariableJson = function(featureKey, variableKey, userId, attributes) {
+Optimizely.prototype.getFeatureVariableJSON = function(featureKey, variableKey, userId, attributes) {
   try {
+    if (!this.__isValidInstance()) {
+      this.logger.log(LOG_LEVEL.ERROR, sprintf(LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'getFeatureVariableJSON'));
+      return null;
+    }
     return this._getFeatureVariableForType(featureKey, variableKey, FEATURE_VARIABLE_TYPES.JSON, userId, attributes);
   } catch (e) {
     this.logger.log(LOG_LEVEL.ERROR, e.message);

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -3136,8 +3136,8 @@ describe('lib/optimizely', function() {
                   });
                 });
 
-                it('returns the right value from getFeatureVariableJson and send notification with featureEnabled true', function() {
-                  var result = optlyInstance.getFeatureVariableJson(
+                it('returns the right value from getFeatureVariableJSON and send notification with featureEnabled true', function() {
+                  var result = optlyInstance.getFeatureVariableJSON(
                     'test_feature_for_experiment',
                     'button_info',
                     'user1',
@@ -3334,8 +3334,8 @@ describe('lib/optimizely', function() {
                   });
                 });
 
-                it('returns the default value from getFeatureVariableJson and send notification with featureEnabled false', function() {
-                  var result = optlyInstance.getFeatureVariableJson(
+                it('returns the default value from getFeatureVariableJSON and send notification with featureEnabled false', function() {
+                  var result = optlyInstance.getFeatureVariableJSON(
                     'test_feature_for_experiment',
                     'button_info',
                     'user1',
@@ -3621,8 +3621,8 @@ describe('lib/optimizely', function() {
                   });
                 });
 
-                it('should return the right value from getFeatureVariableJson and send notification with featureEnabled true', function() {
-                  var result = optlyInstance.getFeatureVariableJson('test_feature', 'message_info', 'user1', {
+                it('should return the right value from getFeatureVariableJSON and send notification with featureEnabled true', function() {
+                  var result = optlyInstance.getFeatureVariableJSON('test_feature', 'message_info', 'user1', {
                     test_attribute: 'test_value',
                   });
                   assert.deepEqual(result, {
@@ -3894,8 +3894,8 @@ describe('lib/optimizely', function() {
                   });
                 });
 
-                it('should return the default value from getFeatureVariableJson and send notification with featureEnabled false', function() {
-                  var result = optlyInstance.getFeatureVariableJson('test_feature', 'message_info', 'user1', {
+                it('should return the default value from getFeatureVariableJSON and send notification with featureEnabled false', function() {
+                  var result = optlyInstance.getFeatureVariableJSON('test_feature', 'message_info', 'user1', {
                     test_attribute: 'test_value',
                   });
                   assert.deepEqual(result, {
@@ -4181,8 +4181,8 @@ describe('lib/optimizely', function() {
                 });
               });
 
-              it('returns the variable default value from getFeatureVariableJson and send notification with featureEnabled false', function() {
-                var result = optlyInstance.getFeatureVariableJson(
+              it('returns the variable default value from getFeatureVariableJSON and send notification with featureEnabled false', function() {
+                var result = optlyInstance.getFeatureVariableJSON(
                   'test_feature_for_experiment',
                   'button_info',
                   'user1',
@@ -5065,8 +5065,8 @@ describe('lib/optimizely', function() {
             );
           });
 
-          it('returns the right value from getFeatureVariableJson', function() {
-            var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', 'user1', {
+          it('returns the right value from getFeatureVariableJSON', function() {
+            var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', 'user1', {
               test_attribute: 'test_value',
             });
             assert.deepEqual(result, {
@@ -5252,8 +5252,8 @@ describe('lib/optimizely', function() {
               );
             });
 
-            it('returns the variable default value from getFeatureVariableJson', function() {
-              var result = optlyInstance.getFeatureVariableJson(
+            it('returns the variable default value from getFeatureVariableJSON', function() {
+              var result = optlyInstance.getFeatureVariableJSON(
                 'test_feature_for_experiment',
                 'button_info',
                 'user1',
@@ -5450,8 +5450,8 @@ describe('lib/optimizely', function() {
             );
           });
 
-          it('returns the variable default value from getFeatureVariableJson', function() {
-            var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', 'user1', {
+          it('returns the variable default value from getFeatureVariableJSON', function() {
+            var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', 'user1', {
               test_attribute: 'test_value',
             });
             assert.deepEqual(result, {
@@ -5634,8 +5634,8 @@ describe('lib/optimizely', function() {
             );
           });
 
-          it('returns the right value from getFeatureVariableJson', function() {
-            var result = optlyInstance.getFeatureVariableJson('test_feature', 'message_info', 'user1', {
+          it('returns the right value from getFeatureVariableJSON', function() {
+            var result = optlyInstance.getFeatureVariableJSON('test_feature', 'message_info', 'user1', {
               test_attribute: 'test_value',
             });
             assert.deepEqual(result, {
@@ -5806,8 +5806,8 @@ describe('lib/optimizely', function() {
               );
             });
 
-            it('returns the variable default value from getFeatureVariableJson', function() {
-              var result = optlyInstance.getFeatureVariableJson('test_feature', 'message_info', 'user1', {
+            it('returns the variable default value from getFeatureVariableJSON', function() {
+              var result = optlyInstance.getFeatureVariableJSON('test_feature', 'message_info', 'user1', {
                 test_attribute: 'test_value',
               });
               assert.deepEqual(result, {
@@ -5989,8 +5989,8 @@ describe('lib/optimizely', function() {
             );
           });
 
-          it('returns the variable default value from getFeatureVariableJson', function() {
-            var result = optlyInstance.getFeatureVariableJson('test_feature', 'message_info', 'user1', {
+          it('returns the variable default value from getFeatureVariableJSON', function() {
+            var result = optlyInstance.getFeatureVariableJSON('test_feature', 'message_info', 'user1', {
               test_attribute: 'test_value',
             });
             assert.deepEqual(result, {
@@ -6170,8 +6170,8 @@ describe('lib/optimizely', function() {
           );
         });
 
-        it('returns the variable default value from getFeatureVariableJson', function() {
-          var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', 'user1', {
+        it('returns the variable default value from getFeatureVariableJSON', function() {
+          var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', 'user1', {
             test_attribute: 'test_value',
           });
           assert.deepEqual(result, {
@@ -6441,8 +6441,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson when called with a non-json variable', function() {
-        var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_txt', 'user1');
+      it('returns null from getFeatureVariableJSON when called with a non-json variable', function() {
+        var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_txt', 'user1');
         assert.strictEqual(result, null);
         sinon.assert.calledWith(
           createdLogger.log,
@@ -6593,8 +6593,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson if user id is null', function() {
-        var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', null, {
+      it('returns null from getFeatureVariableJSON if user id is null', function() {
+        var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', null, {
           test_attribute: 'test_value',
         });
         assert.strictEqual(result, null);
@@ -6605,8 +6605,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson if user id is undefined', function() {
-        var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', undefined, {
+      it('returns null from getFeatureVariableJSON if user id is undefined', function() {
+        var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', undefined, {
           test_attribute: 'test_value',
         });
         assert.strictEqual(result, null);
@@ -6617,8 +6617,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson if user id is not provided', function() {
-        var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info');
+      it('returns null from getFeatureVariableJSON if user id is not provided', function() {
+        var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info');
         assert.strictEqual(result, null);
         sinon.assert.calledWith(
           createdLogger.log,
@@ -6686,7 +6686,7 @@ describe('lib/optimizely', function() {
           });
 
           it('should return null and log an error', function() {
-            var result = optlyInstance.getFeatureVariableJson('test_feature_for_experiment', 'button_info', 'user1');
+            var result = optlyInstance.getFeatureVariableJSON('test_feature_for_experiment', 'button_info', 'user1');
             assert.strictEqual(result, null);
             sinon.assert.calledWith(
               createdLogger.log,
@@ -6801,8 +6801,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson if the argument feature key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableJson('thisIsNotAValidKey<><><>', 'button_info', 'user1');
+      it('returns null from getFeatureVariableJSON if the argument feature key is invalid', function() {
+        var result = optlyInstance.getFeatureVariableJSON('thisIsNotAValidKey<><><>', 'button_info', 'user1');
         assert.strictEqual(result, null);
         sinon.assert.calledWith(
           createdLogger.log,
@@ -6867,8 +6867,8 @@ describe('lib/optimizely', function() {
         );
       });
 
-      it('returns null from getFeatureVariableJson if the argument variable key is invalid', function() {
-        var result = optlyInstance.getFeatureVariableJson(
+      it('returns null from getFeatureVariableJSON if the argument variable key is invalid', function() {
+        var result = optlyInstance.getFeatureVariableJSON(
           'test_feature_for_experiment',
           'thisIsNotAVariableKey****',
           'user1'
@@ -6966,7 +6966,7 @@ describe('lib/optimizely', function() {
         assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableString'));
       });
 
-      it('returns null from getFeatureVariableJson when optimizely object is not a valid instance', function() {
+      it('returns null from getFeatureVariableJSON when optimizely object is not a valid instance', function() {
         var instance = new Optimizely({
           datafile: {},
           errorHandler: errorHandler,
@@ -6976,11 +6976,11 @@ describe('lib/optimizely', function() {
 
         createdLogger.log.reset();
 
-        instance.getFeatureVariableJson('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
+        instance.getFeatureVariableJSON('test_feature_for_experiment', 'thisIsNotAVariableKey****', 'user1');
 
         sinon.assert.calledOnce(createdLogger.log);
         var logMessage = createdLogger.log.args[0][1];
-        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableJson'));
+        assert.strictEqual(logMessage, sprintf(LOG_MESSAGES.INVALID_OBJECT, 'OPTIMIZELY', 'getFeatureVariableJSON'));
       });
     });
   });


### PR DESCRIPTION
## Summary
- fixed case for getFeatureVariableJSON api
- Instead of adding another check for apiName to the generic `_getFeatureVariableForType` function, Moved invalid instance check and log message to their own functions. 

## Test plan
All unit tests FSC tests should pass