### PR TITLE
ci: add source clear as a separate stage;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ stages:
   - 'Cross-browser and umd unit tests'
   - 'Test'
   - 'Test sub packages'
+  - 'Source Clear'
 
 jobs:
   include:
@@ -59,8 +60,6 @@ jobs:
       script: npm run lint
     - &integrationtest
       stage: 'Integration tests'
-      addons:
-        srcclr: true
       merge_mode: replace
       cache: false
       language: minimal
@@ -86,3 +85,14 @@ jobs:
     - <<: *packagetest
       before_script: npm install "@react-native-community/async-storage"
       before_install: cd packages/datafile-manager
+
+    - stage: 'Source Clear'
+      if: type = cron
+      addons:
+        srcclr: true
+      before_install: skip
+      install: skip
+      before_script: skip
+      script: skip
+      after_script: skip
+      after_success: skip


### PR DESCRIPTION
## Summary
Adds a separate stage for Source Clear, to only run on cron builds.

## Testplan
Manually need to see when cron is running this stage.

## Issues
OASIS-6817
