### PR TITLE
fix: Event Processor - Reverted back the typescript version to fix stubbing issue

### DIFF
--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -5072,9 +5072,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "uglify-js": {

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -49,7 +49,7 @@
     "jest": "^23.6.0",
     "jest-localstorage-mock": "^2.4.0",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.3.3333"
+    "typescript": "3.3.3333"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "5.9.4",


### PR DESCRIPTION
## Summary
Typescript version was updated which resulted in some problems with stubbing event processor. Reverted back to the version which was being used earlier.

## Test plan
Tested by locally linking this version of event processor with optimizely sdk and verified that stubbing works correctly after this fix.

