### PR TITLE
feat: modify datafile managers to use datafile strings instead of objects

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Changed
+
+- Modified datafile manager to accept, process, and return the datafile's string representation instead of the datafile object.
+- Remove JSON parsing of response received from datafile fetch request
+  - Responsibility of validating the datafile now solely belongs to the project config manager
+
 ## [0.7.0] - July 28, 2020
 
 ### Changed

--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes that have landed but are not yet released.
 - Modified datafile manager to accept, process, and return the datafile's string representation instead of the datafile object.
 - Remove JSON parsing of response received from datafile fetch request
   - Responsibility of validating the datafile now solely belongs to the project config manager
+- Modified React Native async storage cache and persistent value cache implementation to store strings instead of objects as values.
 
 ## [0.7.0] - July 28, 2020
 

--- a/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
+++ b/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
@@ -69,11 +69,11 @@ class TestDatafileManager extends HttpPollingDatafileManager {
 }
 
 const testCache: PersistentKeyValueCache = {
-  get(key: string): Promise<any | null> {
-    let val = null;
+  get(key: string): Promise<string> {
+    let val = '';
     switch (key) {
       case 'opt-datafile-keyThatExists':
-        val = { name: 'keyThatExists' };
+        val = JSON.stringify({ name: 'keyThatExists' });
         break;
     }
     return Promise.resolve(val);
@@ -640,9 +640,9 @@ describe('httpPollingDatafileManager', () => {
       manager.on('update', updateFn);
       manager.start();
       await manager.onReady();
-      expect(manager.get()).toEqual({ name: 'keyThatExists' });
+      expect(JSON.parse(manager.get())).toEqual({ name: 'keyThatExists' });
       await advanceTimersByTime(50);
-      expect(manager.get()).toEqual({ name: 'keyThatExists' });
+      expect(JSON.parse(manager.get())).toEqual({ name: 'keyThatExists' });
       expect(updateFn).toBeCalledTimes(0);
     });
 
@@ -657,7 +657,7 @@ describe('httpPollingDatafileManager', () => {
       manager.on('update', updateFn);
       manager.start();
       await manager.onReady();
-      expect(manager.get()).toEqual({ name: 'keyThatExists' });
+      expect(JSON.parse(manager.get())).toEqual({ name: 'keyThatExists' });
       expect(updateFn).toBeCalledTimes(0);
       await advanceTimersByTime(50);
       expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });

--- a/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
+++ b/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
@@ -109,7 +109,7 @@ describe('httpPollingDatafileManager', () => {
 
   describe('when constructed with sdkKey and datafile and autoUpdate: true,', () => {
     beforeEach(() => {
-      manager = new TestDatafileManager({ datafile: { foo: 'abcd' }, sdkKey: '123', autoUpdate: true });
+      manager = new TestDatafileManager({ datafile: JSON.stringify({ foo: 'abcd' }), sdkKey: '123', autoUpdate: true });
     });
 
     it('returns the passed datafile from get', () => {
@@ -149,11 +149,11 @@ describe('httpPollingDatafileManager', () => {
 
   describe('when constructed with sdkKey and datafile and autoUpdate: false,', () => {
     beforeEach(() => {
-      manager = new TestDatafileManager({ datafile: { foo: 'abcd' }, sdkKey: '123', autoUpdate: false });
+      manager = new TestDatafileManager({ datafile: JSON.stringify({ foo: 'abcd' }), sdkKey: '123', autoUpdate: false });
     });
 
     it('returns the passed datafile from get', () => {
-      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'abcd' });
     });
 
     it('after being started, fetches the datafile, updates itself once, but does not schedule a future update', async () => {

--- a/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
+++ b/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
@@ -113,7 +113,7 @@ describe('httpPollingDatafileManager', () => {
     });
 
     it('returns the passed datafile from get', () => {
-      expect(manager.get()).toEqual({ foo: 'abcd' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'abcd' });
     });
 
     it('after being started, fetches the datafile, updates itself, and updates itself again after a timeout', async () => {
@@ -134,7 +134,7 @@ describe('httpPollingDatafileManager', () => {
       manager.start();
       expect(manager.responsePromises.length).toBe(1);
       await manager.responsePromises[0];
-      expect(manager.get()).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
       updateFn.mockReset();
 
       await advanceTimersByTime(300000);
@@ -142,10 +142,8 @@ describe('httpPollingDatafileManager', () => {
       expect(manager.responsePromises.length).toBe(2);
       await manager.responsePromises[1];
       expect(updateFn).toBeCalledTimes(1);
-      expect(updateFn).toBeCalledWith({
-        datafile: { fooz: 'barz' },
-      });
-      expect(manager.get()).toEqual({ fooz: 'barz' });
+      expect(updateFn.mock.calls[0][0]).toEqual({ datafile: '{"fooz": "barz"}' });
+      expect(JSON.parse(manager.get())).toEqual({ fooz: 'barz' });
     });
   });
 
@@ -155,7 +153,7 @@ describe('httpPollingDatafileManager', () => {
     });
 
     it('returns the passed datafile from get', () => {
-      expect(manager.get()).toEqual({ foo: 'abcd' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
     });
 
     it('after being started, fetches the datafile, updates itself once, but does not schedule a future update', async () => {
@@ -167,7 +165,7 @@ describe('httpPollingDatafileManager', () => {
       manager.start();
       expect(manager.responsePromises.length).toBe(1);
       await manager.responsePromises[0];
-      expect(manager.get()).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
       expect(getTimerCount()).toBe(0);
     });
   });
@@ -179,7 +177,7 @@ describe('httpPollingDatafileManager', () => {
 
     describe('initial state', () => {
       it('returns null from get before becoming ready', () => {
-        expect(manager.get()).toBeNull();
+        expect(manager.get()).toEqual('');
       });
     });
 
@@ -205,28 +203,7 @@ describe('httpPollingDatafileManager', () => {
         });
         manager.start();
         await manager.onReady();
-        expect(manager.get()).toEqual({ foo: 'bar' });
-      });
-
-      it('does not update if the response body is not valid json', async () => {
-        manager.queuedResponses.push(
-          {
-            statusCode: 200,
-            body: '{"foo" "',
-            headers: {},
-          },
-          {
-            statusCode: 200,
-            body: '{"foo": "bar"}',
-            headers: {},
-          }
-        );
-        manager.start();
-        await manager.onReady();
-        await advanceTimersByTime(1000);
-        expect(manager.responsePromises.length).toBe(2);
-        await manager.responsePromises[1];
-        expect(manager.get()).toEqual({ foo: 'bar' });
+        expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
       });
 
       describe('live updates', () => {
@@ -275,22 +252,22 @@ describe('httpPollingDatafileManager', () => {
 
           manager.start();
           await manager.onReady();
-          expect(manager.get()).toEqual({ foo: 'bar' });
+          expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
           expect(updateFn).toBeCalledTimes(0);
 
           await advanceTimersByTime(1000);
           await manager.responsePromises[1];
           expect(updateFn).toBeCalledTimes(1);
-          expect(updateFn.mock.calls[0][0]).toEqual({ datafile: { foo2: 'bar2' } });
-          expect(manager.get()).toEqual({ foo2: 'bar2' });
+          expect(updateFn.mock.calls[0][0]).toEqual({ datafile: '{"foo2": "bar2"}' });
+          expect(JSON.parse(manager.get())).toEqual({ foo2: 'bar2' });
 
           updateFn.mockReset();
 
           await advanceTimersByTime(1000);
           await manager.responsePromises[2];
           expect(updateFn).toBeCalledTimes(1);
-          expect(updateFn.mock.calls[0][0]).toEqual({ datafile: { foo3: 'bar3' } });
-          expect(manager.get()).toEqual({ foo3: 'bar3' });
+          expect(updateFn.mock.calls[0][0]).toEqual({ datafile: '{"foo3": "bar3"}' });
+          expect(JSON.parse(manager.get())).toEqual({ foo3: 'bar3' });
         });
 
         describe('when the update interval time fires before the request is complete', () => {
@@ -351,7 +328,7 @@ describe('httpPollingDatafileManager', () => {
 
           manager.start();
           await manager.onReady();
-          expect(manager.get()).toEqual({ foo: 'bar' });
+          expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
 
           advanceTimersByTime(1000);
 
@@ -359,7 +336,7 @@ describe('httpPollingDatafileManager', () => {
           manager.stop();
           await manager.responsePromises[1];
           // Should not have updated datafile since manager was stopped
-          expect(manager.get()).toEqual({ foo: 'bar' });
+          expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
         });
 
         it('calls abort on the current request if there is a current request when stop is called', async () => {
@@ -399,7 +376,7 @@ describe('httpPollingDatafileManager', () => {
           // Trigger the update, should fetch the next response which should succeed, then we get ready
           advanceTimersByTime(1000);
           await manager.onReady();
-          expect(manager.get()).toEqual({ foo: 'bar' });
+          expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
         });
 
         describe('newness checking', () => {
@@ -424,7 +401,7 @@ describe('httpPollingDatafileManager', () => {
 
             manager.start();
             await manager.onReady();
-            expect(manager.get()).toEqual({ foo: 'bar' });
+            expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
             // First response promise was for the initial 200 response
             expect(manager.responsePromises.length).toBe(1);
             // Trigger the queued update
@@ -434,7 +411,7 @@ describe('httpPollingDatafileManager', () => {
             await manager.responsePromises[1];
             // Since the response was 304, updateFn should not have been called
             expect(updateFn).toBeCalledTimes(0);
-            expect(manager.get()).toEqual({ foo: 'bar' });
+            expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
           });
 
           it('sends if-modified-since using the last observed response last-modified', async () => {
@@ -559,7 +536,7 @@ describe('httpPollingDatafileManager', () => {
       });
       manager.start();
       await manager.onReady();
-      expect(manager.get()).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
     });
 
     it('does not schedule a live update after ready', async () => {
@@ -679,7 +656,7 @@ describe('httpPollingDatafileManager', () => {
       expect(manager.get()).toEqual({ name: 'keyThatExists' });
       expect(updateFn).toBeCalledTimes(0);
       await advanceTimersByTime(50);
-      expect(manager.get()).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
       expect(updateFn).toBeCalledTimes(1);
     });
 
@@ -693,8 +670,9 @@ describe('httpPollingDatafileManager', () => {
       manager.start();
       await manager.onReady();
       await advanceTimersByTime(50);
-      expect(manager.get()).toEqual({ foo: 'bar' });
-      expect(cacheSetSpy).toBeCalledWith('opt-datafile-keyThatExists', { foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
+      expect(cacheSetSpy.mock.calls[0][0]).toEqual('opt-datafile-keyThatExists');
+      expect(JSON.parse(cacheSetSpy.mock.calls[0][1])).toEqual({ foo: 'bar' });
     });
   });
 
@@ -721,7 +699,7 @@ describe('httpPollingDatafileManager', () => {
       manager.start();
       await advanceTimersByTime(50);
       await manager.onReady();
-      expect(manager.get()).toEqual({ foo: 'bar' });
+      expect(JSON.parse(manager.get())).toEqual({ foo: 'bar' });
       expect(updateFn).toBeCalledTimes(0);
     });
   });

--- a/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
+++ b/packages/datafile-manager/__test__/httpPollingDatafileManager.spec.ts
@@ -149,7 +149,11 @@ describe('httpPollingDatafileManager', () => {
 
   describe('when constructed with sdkKey and datafile and autoUpdate: false,', () => {
     beforeEach(() => {
-      manager = new TestDatafileManager({ datafile: JSON.stringify({ foo: 'abcd' }), sdkKey: '123', autoUpdate: false });
+      manager = new TestDatafileManager({
+        datafile: JSON.stringify({ foo: 'abcd' }),
+        sdkKey: '123',
+        autoUpdate: false,
+      });
     });
 
     it('returns the passed datafile from get', () => {

--- a/packages/datafile-manager/__test__/reactNativeAsyncStorageCache.spec.ts
+++ b/packages/datafile-manager/__test__/reactNativeAsyncStorageCache.spec.ts
@@ -24,46 +24,28 @@ describe('reactNativeAsyncStorageCache', () => {
   });
 
   describe('get', function() {
-    it('should return correct object when item is found in cache', function() {
-      return cacheInstance.get('keyThatExists').then(v => expect(v).toEqual({ name: 'Awesome Object' }));
+    it('should return correct string when item is found in cache', function() {
+      return cacheInstance.get('keyThatExists').then(v => expect(JSON.parse(v)).toEqual({ name: 'Awesome Object' }));
     });
 
-    it('should return null if item is not found in cache', function() {
-      return cacheInstance.get('keyThatDoesNotExist').then(v => expect(v).toBeNull());
-    });
-
-    it('should reject promise error if string has an incorrect JSON format', function() {
-      return cacheInstance
-        .get('keyWithInvalidJsonObject')
-        .catch(() => 'exception caught')
-        .then(v => {
-          expect(v).toEqual('exception caught');
-        });
+    it('should return empty string if item is not found in cache', function() {
+      return cacheInstance.get('keyThatDoesNotExist').then(v => expect(v).toEqual(''));
     });
   });
 
   describe('set', function() {
     it('should resolve promise if item was successfully set in the cache', function() {
       const testObj = { name: 'Awesome Object' };
-      return cacheInstance.set('testKey', testObj);
-    });
-
-    it('should reject promise if item was not set in the cache because of json stringifying error', function() {
-      const testObj: any = { name: 'Awesome Object' };
-      testObj.myOwnReference = testObj;
-      return cacheInstance
-        .set('testKey', testObj)
-        .catch(() => 'exception caught')
-        .then(v => expect(v).toEqual('exception caught'));
+      return cacheInstance.set('testKey', JSON.stringify(testObj));
     });
   });
 
   describe('contains', function() {
-    it('should return true if object with key exists', function() {
+    it('should return true if value with key exists', function() {
       return cacheInstance.contains('keyThatExists').then(v => expect(v).toBeTruthy());
     });
 
-    it('should return false if object with key does not exist', function() {
+    it('should return false if value with key does not exist', function() {
       return cacheInstance.contains('keyThatDoesNotExist').then(v => expect(v).toBeFalsy());
     });
   });

--- a/packages/datafile-manager/src/datafileManager.ts
+++ b/packages/datafile-manager/src/datafileManager.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import PersistentKeyValueCache from './persistentKeyValueCache';
+import { PersistentKeyValueCache } from '@optimizely/js-sdk-utils';
 
 export interface DatafileUpdate {
-  datafile: object;
+  datafile: string;
 }
 
 export interface DatafileUpdateListener {
@@ -31,14 +31,14 @@ interface Managed {
 }
 
 export interface DatafileManager extends Managed {
-  get: () => object | null;
+  get: () => string | null;
   on: (eventName: string, listener: DatafileUpdateListener) => () => void;
   onReady: () => Promise<void>;
 }
 
 export interface DatafileManagerConfig {
   autoUpdate?: boolean;
-  datafile?: object;
+  datafile?: string;
   sdkKey: string;
   updateInterval?: number;
   urlTemplate?: string;

--- a/packages/datafile-manager/src/datafileManager.ts
+++ b/packages/datafile-manager/src/datafileManager.ts
@@ -31,7 +31,7 @@ interface Managed {
 }
 
 export interface DatafileManager extends Managed {
-  get: () => string | null;
+  get: () => string;
   on: (eventName: string, listener: DatafileUpdateListener) => () => void;
   onReady: () => Promise<void>;
 }

--- a/packages/datafile-manager/src/datafileManager.ts
+++ b/packages/datafile-manager/src/datafileManager.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PersistentKeyValueCache } from '@optimizely/js-sdk-utils';
+import PersistentKeyValueCache from './persistentKeyValueCache';
 
 export interface DatafileUpdate {
   datafile: string;

--- a/packages/datafile-manager/src/httpPollingDatafileManager.ts
+++ b/packages/datafile-manager/src/httpPollingDatafileManager.ts
@@ -328,7 +328,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
   }
 
   setDatafileFromCacheIfAvailable(): void {
-    this.cache.get(this.cacheKey).then((datafile) => {
+    this.cache.get(this.cacheKey).then(datafile => {
       if (this.isStarted && !this.isReadyPromiseSettled && datafile) {
         logger.debug('Using datafile from cache');
         this.currentDatafile = datafile;

--- a/packages/datafile-manager/src/httpPollingDatafileManager.ts
+++ b/packages/datafile-manager/src/httpPollingDatafileManager.ts
@@ -15,12 +15,13 @@
  */
 
 import { getLogger } from '@optimizely/js-sdk-logging';
-import { sprintf, PersistentKeyValueCache } from '@optimizely/js-sdk-utils';
+import { sprintf } from '@optimizely/js-sdk-utils';
 import { DatafileManager, DatafileManagerConfig, DatafileUpdate } from './datafileManager';
 import EventEmitter, { Disposer } from './eventEmitter';
 import { AbortableRequest, Response, Headers } from './http';
 import { DEFAULT_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL, DEFAULT_URL_TEMPLATE } from './config';
 import BackoffController from './backoffController';
+import PersistentKeyValueCache from './persistentKeyValueCache';
 
 const logger = getLogger('DatafileManager');
 

--- a/packages/datafile-manager/src/httpPollingDatafileManager.ts
+++ b/packages/datafile-manager/src/httpPollingDatafileManager.ts
@@ -63,7 +63,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
   // Return any default configuration options that should be applied
   protected abstract getConfigDefaults(): Partial<DatafileManagerConfig>;
 
-  private currentDatafile: string | null;
+  private currentDatafile: string;
 
   private readonly readyPromise: Promise<void>;
 
@@ -131,7 +131,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
         this.resolveReadyPromise();
       }
     } else {
-      this.currentDatafile = null;
+      this.currentDatafile = '';
     }
 
     this.isStarted = false;
@@ -152,7 +152,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
     this.syncOnCurrentRequestComplete = false;
   }
 
-  get(): string | null {
+  get(): string {
     return this.currentDatafile;
   }
 
@@ -222,7 +222,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
     this.trySavingLastModified(response.headers);
 
     const datafile = this.getNextDatafileFromResponse(response);
-    if (datafile !== null) {
+    if (datafile !== '') {
       logger.info('Updating datafile from response');
       this.currentDatafile = datafile;
       this.cache.set(this.cacheKey, datafile);
@@ -305,18 +305,18 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
     }, nextUpdateDelay);
   }
 
-  private getNextDatafileFromResponse(response: Response): string | null {
+  private getNextDatafileFromResponse(response: Response): string {
     logger.debug('Response status code: %s', response.statusCode);
     if (typeof response.statusCode === 'undefined') {
-      return null;
+      return '';
     }
     if (response.statusCode === 304) {
-      return null;
+      return '';
     }
     if (isSuccessStatusCode(response.statusCode)) {
       return response.body;
     }
-    return null;
+    return '';
   }
 
   private trySavingLastModified(headers: Headers): void {

--- a/packages/datafile-manager/src/httpPollingDatafileManager.ts
+++ b/packages/datafile-manager/src/httpPollingDatafileManager.ts
@@ -36,8 +36,8 @@ function isSuccessStatusCode(statusCode: number): boolean {
 }
 
 const noOpKeyValueCache: PersistentKeyValueCache = {
-  get(): Promise<any | null> {
-    return Promise.resolve(null);
+  get(): Promise<string> {
+    return Promise.resolve('');
   },
 
   set(): Promise<void> {
@@ -329,7 +329,7 @@ export default abstract class HttpPollingDatafileManager implements DatafileMana
 
   setDatafileFromCacheIfAvailable(): void {
     this.cache.get(this.cacheKey).then(datafile => {
-      if (this.isStarted && !this.isReadyPromiseSettled && datafile) {
+      if (this.isStarted && !this.isReadyPromiseSettled && datafile !== '') {
         logger.debug('Using datafile from cache');
         this.currentDatafile = datafile;
         this.resolveReadyPromise();

--- a/packages/datafile-manager/src/persistentKeyValueCache.ts
+++ b/packages/datafile-manager/src/persistentKeyValueCache.ts
@@ -15,8 +15,7 @@
  */
 
 /**
- * An Interface to implement a persistent key value cache which supports strings as keys
- * and JSON Object as value.
+ * An Interface to implement a persistent key value cache which supports strings as keys and values.
  */
 export default interface PersistentKeyValueCache {
   /**
@@ -24,21 +23,21 @@ export default interface PersistentKeyValueCache {
    * @param key
    * @returns
    * Resolves promise with
-   * 1. Object if value found was stored as a JSON Object.
+   * 1. string if value found was stored as a string.
    * 2. null if the key does not exist in the cache.
    * Rejects the promise in case of an error
    */
-  get(key: string): Promise<any | null>;
+  get(key: string): Promise<string>;
 
   /**
-   * Stores Object in the persistent cache against a key
+   * Stores string in the persistent cache against a key
    * @param key
    * @param val
    * @returns
    * Resolves promise without a value if successful
    * Rejects the promise in case of an error
    */
-  set(key: string, val: any): Promise<void>;
+  set(key: string, val: string): Promise<void>;
 
   /**
    * Checks if a key exists in the cache

--- a/packages/datafile-manager/src/reactNativeAsyncStorageCache.ts
+++ b/packages/datafile-manager/src/reactNativeAsyncStorageCache.ts
@@ -14,35 +14,22 @@
  * limitations under the License.
  */
 
-import { getLogger } from '@optimizely/js-sdk-logging';
 import AsyncStorage from '@react-native-community/async-storage';
 
 import PersistentKeyValueCache from './persistentKeyValueCache';
 
-const logger = getLogger('DatafileManager');
-
 export default class ReactNativeAsyncStorageCache implements PersistentKeyValueCache {
-  get(key: string): Promise<any | null> {
+  get(key: string): Promise<string> {
     return AsyncStorage.getItem(key).then((val: string | null) => {
       if (!val) {
-        return null;
+        return '';
       }
-      try {
-        return JSON.parse(val);
-      } catch (ex) {
-        logger.error('Error Parsing Object from cache - %s', ex);
-        throw ex;
-      }
+      return val;
     });
   }
 
-  set(key: string, val: any): Promise<void> {
-    try {
-      return AsyncStorage.setItem(key, JSON.stringify(val));
-    } catch (ex) {
-      logger.error('Error stringifying Object to Json - %s', ex);
-      return Promise.reject(ex);
-    }
+  set(key: string, val: string): Promise<void> {
+    return AsyncStorage.setItem(key, val);
   }
 
   contains(key: string): Promise<boolean> {

--- a/packages/datafile-manager/src/reactNativeDatafileManager.ts
+++ b/packages/datafile-manager/src/reactNativeDatafileManager.ts
@@ -18,7 +18,7 @@ import { makeGetRequest } from './browserRequest';
 import HttpPollingDatafileManager from './httpPollingDatafileManager';
 import { Headers, AbortableRequest } from './http';
 import { DatafileManagerConfig } from './datafileManager';
-import ReactNativeAsyncStorageCache from './reactNativeAsyncStorageCache';
+import { ReactNativeAsyncStorageCache } from '@optimizely/js-sdk-utils';
 
 export default class ReactNativeDatafileManager extends HttpPollingDatafileManager {
   protected makeGetRequest(reqUrl: string, headers: Headers): AbortableRequest {

--- a/packages/datafile-manager/src/reactNativeDatafileManager.ts
+++ b/packages/datafile-manager/src/reactNativeDatafileManager.ts
@@ -18,7 +18,7 @@ import { makeGetRequest } from './browserRequest';
 import HttpPollingDatafileManager from './httpPollingDatafileManager';
 import { Headers, AbortableRequest } from './http';
 import { DatafileManagerConfig } from './datafileManager';
-import { ReactNativeAsyncStorageCache } from '@optimizely/js-sdk-utils';
+import ReactNativeAsyncStorageCache from './reactNativeAsyncStorageCache';
 
 export default class ReactNativeDatafileManager extends HttpPollingDatafileManager {
   protected makeGetRequest(reqUrl: string, headers: Headers): AbortableRequest {


### PR DESCRIPTION
Summary
----------
- Modified datafileManager and httpPollingDatafileManager to use datafile strings
- Removed unneeded JSON parsing of response body

Test Plan
----------
- Modified existing datafile manager tests to account for new changes to datafile variable type