### PR TITLE
fix: Change to optimizely-sdk directory prior to running Source Clear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
       if: type = cron
       addons:
         srcclr: true
-      before_install: skip
+      before_install: cd packages/optimizely-sdk
       install: skip
       before_script: skip
       script: skip


### PR DESCRIPTION
## Summary

Prior to running Source Clear build step, change into optimizely-sdk directory

## Test plan

N/A