### PR TITLE
fix(project config manager): Don't log an error when not initialized with datafile

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bug fixes
 
 - Fixed return type of `getAllFeatureVariables` method and `dispatchEvent ` method signature of `EventDispatcher` interface in TypeScript type definitions ([#576](https://github.com/optimizely/javascript-sdk/pull/576))
+- Don't log an error message when initialized with `sdkKey`, but no `datafile` ([#589](https://github.com/optimizely/javascript-sdk/pull/589))
 
 ## [4.3.1] - October 5, 2020
 

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.js
@@ -91,8 +91,13 @@ ProjectConfigManager.prototype.__initialize = function(config) {
     return;
   }
 
-  var handleNewDatafileException = this.__handleNewDatafile(config.datafile);
-  if (handleNewDatafileException) {
+  let handleNewDatafileException;
+  if (config.datafile) {
+    handleNewDatafileException = this.__handleNewDatafile(config.datafile);
+    if (handleNewDatafileException) {
+      this.__configObj = null;
+    }
+  } else {
     this.__configObj = null;
   }
 

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
@@ -347,6 +347,13 @@ describe('lib/core/project_config/project_config_manager', function() {
         manager.stop();
         sinon.assert.calledOnce(datafileManager.HttpPollingDatafileManager.getCall(0).returnValue.stop);
       });
+
+      it('does not log an error message', function() {
+        projectConfigManager.createProjectConfigManager({
+          sdkKey: '12345',
+        });
+        sinon.assert.notCalled(stubLogHandler.log);
+      });
     });
 
     describe('when constructed with sdkKey and with a valid datafile object', function() {


### PR DESCRIPTION
## Summary
Fixes a regression introduced during refactoring for datafile accessor - any time the `datafile` property of the object passed to `createInstance` is missing or falsy, the logger will output (for example):

```
[OPTIMIZELY] - ERROR 2020-10-05T23:38:15.224Z CONFIG_VALIDATOR: No datafile specified. Cannot start optimizely
```

Passing in an `sdkKey`, but no `datafile`, is valid and supported when calling `createInstance`, but this message leads the user to believe otherwise. In this situation, nothing is actually wrong, but the message says "Cannot start optimizely".

To fix, in `ProjectConfigManager` `__initialize`, when `config.datafile` is falsy, we do not call `__handleNewDatafile`, avoiding the code path that eventually would log the error message.

## Test plan

- Added new unit test
- Manually tested
