### PR TITLE
fix(TS type defs): Restore missing types

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -35,6 +35,14 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type OptimizelyConfig = import('./shared_types').OptimizelyConfig;
 
+  export type OptimizelyVariable = import('./shared_types').OptimizelyVariable;
+
+  export type OptimizelyVariation = import('./shared_types').OptimizelyVariation;
+
+  export type OptimizelyExperiment = import('./shared_types').OptimizelyExperiment;
+
+  export type OptimizelyFeature = import('./shared_types').OptimizelyFeature;
+
   export type EventTags = import ('./shared_types').EventTags;
 
   export type Event = import ('./shared_types').Event;
@@ -44,6 +52,8 @@ declare module '@optimizely/optimizely-sdk' {
   export type DatafileOptions = import ('./shared_types').DatafileOptions;
 
   export type UserProfileService = import('./shared_types').UserProfileService;
+
+  export type UserProfile = import('./shared_types').UserProfile;
 
   // The options object given to Optimizely.createInstance.
   export interface Config {

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -43,6 +43,8 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type DatafileOptions = import ('./shared_types').DatafileOptions;
 
+  export type UserProfileService = import('./shared_types').UserProfileService;
+
   // The options object given to Optimizely.createInstance.
   export interface Config {
     // TODO[OASIS-6649]: Don't use object type
@@ -61,7 +63,7 @@ declare module '@optimizely/optimizely-sdk' {
     // TODO[OASIS-6649]: Don't use object type
     // eslint-disable-next-line  @typescript-eslint/ban-types
     jsonSchemaValidator?: object;
-    userProfileService?: import('./shared_types').UserProfileService | null;
+    userProfileService?: UserProfileService | null;
     eventBatchSize?: number;
     eventFlushInterval?: number;
     sdkKey?: string;


### PR DESCRIPTION
## Summary

`UserProfileService` and several other types were removed by mistake from lib/index.d.ts. 

## Test plan

Manual testing

## Issues

https://github.com/optimizely/javascript-sdk/issues/593