### PR TITLE
feat: Upgrade TypeScript to v4.0.3 in event-processor

### DIFF
--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -5072,9 +5072,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "uglify-js": {

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -43,13 +43,13 @@
     "@optimizely/js-sdk-utils": "^0.4.0"
   },
   "devDependencies": {
-    "@react-native-community/netinfo": "^5.9.4",
     "@react-native-community/async-storage": "^1.2.0",
+    "@react-native-community/netinfo": "^5.9.4",
     "@types/jest": "^24.0.9",
     "jest": "^23.6.0",
     "jest-localstorage-mock": "^2.4.0",
     "ts-jest": "^23.10.5",
-    "typescript": "3.3.3333"
+    "typescript": "^4.0.3"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "5.9.4",


### PR DESCRIPTION
## Summary
- Upgrade TypeScript in `event-processor` package to v4.0.3

## Test plan
 - Existing unit tests
