### PR TITLE
feat(flag_decisions): update decisionSnapshot in event-processor to include metadata object 

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 Changes that have landed but are not yet released.
+- Update `Visitor.Snapshot` to include metadata object to support sending flag decisions.
 
 ## [0.6.0] - July 28, 2020
 

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -24,7 +24,7 @@ import { ImpressionEvent, ConversionEvent } from '../src/events'
 
 describe('buildEventV1', () => {
   describe('buildImpressionEventV1', () => {
-    it('should build an build an ImpressionEventV1', () => {
+    it('should build an ImpressionEventV1 when experiment and variation are defined', () => {
       const impressionEvent: ImpressionEvent = {
         type: 'impression',
         timestamp: 69,
@@ -58,6 +58,10 @@ describe('buildEventV1', () => {
           id: 'varId',
           key: 'varKey',
         },
+
+        ruleKey: 'expKey',
+        flagKey: 'flagKey1',
+        ruleType: 'experiment',
       }
 
       const result = buildImpressionEventV1(impressionEvent)
@@ -79,11 +83,114 @@ describe('buildEventV1', () => {
                     campaign_id: 'layerId',
                     experiment_id: 'expId',
                     variation_id: 'varId',
+                    metadata: {
+                      flag_key: 'flagKey1',
+                      rule_key: 'expKey',
+                      rule_type: 'experiment',
+                      variation_key: 'varKey',
+                    },
                   },
                 ],
                 events: [
                   {
                     entity_id: 'layerId',
+                    timestamp: 69,
+                    key: 'campaign_activated',
+                    uuid: 'uuid',
+                  },
+                ],
+              },
+            ],
+            visitor_id: 'userId',
+            attributes: [
+              {
+                entity_id: 'attr1-id',
+                key: 'attr1-key',
+                type: 'custom',
+                value: 'attr1-value',
+              },
+              {
+                entity_id: '$opt_bot_filtering',
+                key: '$opt_bot_filtering',
+                type: 'custom',
+                value: true,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should build an ImpressionEventV1 when experiment and variation are not defined', () => {
+      const impressionEvent: ImpressionEvent = {
+        type: 'impression',
+        timestamp: 69,
+        uuid: 'uuid',
+
+        context: {
+          accountId: 'accountId',
+          projectId: 'projectId',
+          clientName: 'node-sdk',
+          clientVersion: '3.0.0',
+          revision: 'revision',
+          botFiltering: true,
+          anonymizeIP: true,
+        },
+
+        user: {
+          id: 'userId',
+          attributes: [{ entityId: 'attr1-id', key: 'attr1-key', value: 'attr1-value' }],
+        },
+
+        layer: {
+          id: null,
+        },
+
+        experiment: {
+          id: null,
+          key: '',
+        },
+
+        variation: {
+          id: null,
+          key: '',
+        },
+
+        ruleKey: '',
+        flagKey: 'flagKey1',
+        ruleType: 'rollout',
+      }
+
+      const result = buildImpressionEventV1(impressionEvent)
+      expect(result).toEqual({
+        client_name: 'node-sdk',
+        client_version: '3.0.0',
+        account_id: 'accountId',
+        project_id: 'projectId',
+        revision: 'revision',
+        anonymize_ip: true,
+        enrich_decisions: true,
+
+        visitors: [
+          {
+            snapshots: [
+              {
+                decisions: [
+                  {
+                    campaign_id: null,
+                    experiment_id: null,
+                    variation_id: null,
+                    metadata: {
+                      flag_key: 'flagKey1',
+                      rule_key: '',
+                      rule_type: 'rollout',
+                      variation_key: '',
+                    },
+                  },
+                ],
+                events: [
+                  {
+                    entity_id: null,
                     timestamp: 69,
                     key: 'campaign_activated',
                     uuid: 'uuid',
@@ -438,6 +545,10 @@ describe('buildEventV1', () => {
           id: 'varId',
           key: 'varKey',
         },
+
+        ruleKey: 'expKey',
+        flagKey: 'flagKey1',
+        ruleType: 'experiment',
       }
 
       const result = makeBatchedEventV1([impressionEvent, conversionEvent])
@@ -460,6 +571,12 @@ describe('buildEventV1', () => {
                     campaign_id: 'layerId',
                     experiment_id: 'expId',
                     variation_id: 'varId',
+                    metadata: {
+                      flag_key: 'flagKey1',
+                      rule_key: 'expKey',
+                      rule_type: 'experiment',
+                      variation_key: 'varKey',
+                    },
                   },
                 ],
                 events: [

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -45,18 +45,22 @@ export interface ImpressionEvent extends BaseEvent {
   }
 
   layer: {
-    id: string
+    id: string | null
   } | null
 
   experiment: {
-    id: string
+    id: string | null
     key: string
   } | null
 
   variation: {
-    id: string
+    id: string | null
     key: string
   } | null
+
+  ruleKey: string
+  flagKey: string
+  ruleType: string
 }
 
 export interface ConversionEvent extends BaseEvent {

--- a/packages/event-processor/src/v1/buildEventV1.ts
+++ b/packages/event-processor/src/v1/buildEventV1.ts
@@ -44,6 +44,14 @@ namespace Visitor {
     campaign_id: string | null
     experiment_id: string | null
     variation_id: string | null
+    metadata: Metadata
+  }
+
+  type Metadata = {
+    flag_key: string;
+    rule_key: string;
+    rule_type: string;
+    variation_key: string;
   }
 
   export type SnapshotEvent = {
@@ -135,10 +143,11 @@ function makeConversionSnapshot(conversion: ConversionEvent): Visitor.Snapshot {
 }
 
 function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
-  const { layer, experiment, variation } = event
+  const { layer, experiment, variation, ruleKey, flagKey, ruleType } = event
   let layerId = layer ? layer.id : null
   let experimentId = experiment ? experiment.id : null
   let variationId = variation ? variation.id : null
+  let variationKey = variation ? variation.key : ''
 
   return {
     decisions: [
@@ -146,6 +155,12 @@ function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
         campaign_id: layerId,
         experiment_id: experimentId,
         variation_id: variationId,
+        metadata: {
+          flag_key: flagKey,
+          rule_key: ruleKey,
+          rule_type: ruleType,
+          variation_key: variationKey,
+        },
       },
     ],
     events: [


### PR DESCRIPTION
## Summary
 - update decisionSnapshot to include metadata object to support sending flag decisions

## Test plan
Unit tests
## Issues
- [OASIS-7113](https://optimizely.atlassian.net/browse/OASIS-7113)
