### PR TITLE
feat: setup TypeDoc for generating optimizely-sdk API documentation

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -54,6 +54,7 @@ const MODULE_NAME = 'OPTIMIZELY';
 const DEFAULT_ONREADY_TIMEOUT = 30000;
 
 /**
+ * @private
  * options required to create optimizely object
  */
 export interface OptimizelyOptions {
@@ -78,17 +79,17 @@ export interface OptimizelyOptions {
 
 /**
  * The Optimizely class
- * @param {OptimizelyOptions} config
- * @param {string}            config.clientEngine
- * @param {string}            config.clientVersion
- * @param {Object|string}     config.datafile
- * @param {Object}            config.errorHandler
- * @param {Object}            config.eventDispatcher
- * @param {Object}            config.logger
- * @param {Object}            config.userProfileService
- * @param {Object}            config.eventBatchSize
- * @param {Object}            config.eventFlushInterval
- * @param {string}            config.sdkKey
+ * @param {OptimizelyOptions} config                      config
+ * @param {string}            config.clientEngine         config.clientEngine
+ * @param {string}            config.clientVersion        config.clientVersion
+ * @param {Object|string}     config.datafile             config.datafile
+ * @param {Object}            config.errorHandler         config.errorHandler
+ * @param {Object}            config.eventDispatcher      config.eventDispatcher
+ * @param {Object}            config.logger               config.logger
+ * @param {Object}            config.userProfileService   config.userProfileService
+ * @param {Object}            config.eventBatchSize       config.eventBatchSize
+ * @param {Object}            config.eventFlushInterval   config.eventFlushInterval
+ * @param {string}            config.sdkKey               config.sdkKey
  */
 export default class Optimizely {
   private isOptimizelyConfigValid: boolean;

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -960,6 +960,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3175,6 +3181,27 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3327,6 +3354,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.1.tgz",
+      "integrity": "sha512-jeW8rdPdhshYKObedYg5XGbpVgb1/DT4AHvDFXhkU7UnGSIjy9kkJ7zHG7qplhFHMitTSzh5/iClKQk3Kb2RFQ==",
       "dev": true
     },
     "hmac-drbg": {
@@ -3573,6 +3606,12 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -4278,6 +4317,12 @@
         "yallist": "^2.1.2"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -4330,6 +4375,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
+      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -5496,6 +5547,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5901,6 +5961,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6971,11 +7042,73 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
+      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.2.0",
+        "lodash": "^4.17.20",
+        "lunr": "^2.3.9",
+        "marked": "^1.1.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.11.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
+      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "dev": true
+    },
     "typescript": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
+      "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
+      "dev": true,
+      "optional": true
     },
     "ultron": {
       "version": "1.1.1",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -18,7 +18,7 @@
     "prebuild": "npm run clean",
     "build": "rollup -c",
     "build-browser-umd": "rollup -c --config-umd",
-    "build-docs": "typedoc --options typedoc.json",
+    "build-docs": "typedoc --options typedoc.json --excludeNotDocumented",
     "precover": "nyc npm test",
     "cover": "nyc report -r lcov",
     "precoveralls": "npm run cover",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -18,6 +18,7 @@
     "prebuild": "npm run clean",
     "build": "rollup -c",
     "build-browser-umd": "rollup -c --config-umd",
+    "build-docs": "typedoc --options typedoc.json",
     "precover": "nyc npm test",
     "cover": "nyc report -r lcov",
     "precoveralls": "npm run cover",
@@ -78,6 +79,7 @@
     "sinon": "^2.3.1",
     "ts-loader": "^7.0.5",
     "ts-node": "^8.10.2",
+    "typedoc": "^0.19.2",
     "typescript": "^4.0.3",
     "webpack": "^4.42.1"
   },

--- a/packages/optimizely-sdk/typedoc.json
+++ b/packages/optimizely-sdk/typedoc.json
@@ -1,0 +1,10 @@
+{
+   "mode": "file",
+   "out": "./docs/out",
+   "exclude": "**/*+(.spec|.d|.tests).(ts/js)",
+   "excludePrivate": true,
+   "excludeProtected": true,
+   "excludeExternals": true,
+   "readme": "README.md",
+   "name": "Optimizely JavaScript SDK"
+}

--- a/packages/optimizely-sdk/typedoc.json
+++ b/packages/optimizely-sdk/typedoc.json
@@ -1,10 +1,11 @@
 {
-   "mode": "file",
-   "out": "./docs/out",
-   "exclude": "**/*+(.spec|.d|.tests).(ts/js)",
-   "excludePrivate": true,
-   "excludeProtected": true,
-   "excludeExternals": true,
-   "readme": "README.md",
-   "name": "Optimizely JavaScript SDK"
+  "inputFiles": ["./lib/optimizely/index.ts"],
+  "mode": "file",
+  "out": "./docs/out",
+  "exclude": "**/*+(.spec|.d|.tests).(ts/js)",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeExternals": true,
+  "readme": "README.md",
+  "name": "Optimizely JavaScript SDK"
 }


### PR DESCRIPTION
## Summary
- setup typedoc for generating optimizely-sdk API documentation. As a start, typedoc is setup in `optimizely-sdk` package. Once all packages are upgraded to TS v.4.0.3 including the root directory, the typedoc will be setup in the root of js-sdk.

## Test plan

N/A

## Issues
- [OASIS-7279](https://optimizely.atlassian.net/browse/OASIS-7279)

