### PR TITLE
fix: Allow using --isolatedModules flag in tsconfig by fixing exports in event_processor

### DIFF
--- a/packages/optimizely-sdk/lib/core/event_processor/index.ts
+++ b/packages/optimizely-sdk/lib/core/event_processor/index.ts
@@ -22,6 +22,6 @@ export function createEventProcessor(
   return new LogTierV1EventProcessor(...args);
 }
 
-export { EventProcessor, LocalStoragePendingEventsDispatcher } from '@optimizely/js-sdk-event-processor';
+export type { EventProcessor, LocalStoragePendingEventsDispatcher } from '@optimizely/js-sdk-event-processor';
 
 export default { createEventProcessor, LocalStoragePendingEventsDispatcher };

--- a/packages/optimizely-sdk/lib/core/event_processor/index.ts
+++ b/packages/optimizely-sdk/lib/core/event_processor/index.ts
@@ -22,6 +22,6 @@ export function createEventProcessor(
   return new LogTierV1EventProcessor(...args);
 }
 
-export type { EventProcessor, LocalStoragePendingEventsDispatcher } from '@optimizely/js-sdk-event-processor';
+export type { EventProcessor } from '@optimizely/js-sdk-event-processor';
 
 export default { createEventProcessor, LocalStoragePendingEventsDispatcher };


### PR DESCRIPTION
## Summary
 - Allow using `--isolatedModules` flag in tsconfig by fixing exports in event_processor

## Test plan
FSC and unit tests

## Issues
[SDK-issue 609](https://github.com/optimizely/javascript-sdk/issues/609)
