### PR TITLE
feat: Add enabled to decision metadata in event processor

### DIFF
--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -62,6 +62,7 @@ describe('buildEventV1', () => {
         ruleKey: 'expKey',
         flagKey: 'flagKey1',
         ruleType: 'experiment',
+        enabled: true,
       }
 
       const result = buildImpressionEventV1(impressionEvent)
@@ -88,6 +89,7 @@ describe('buildEventV1', () => {
                       rule_key: 'expKey',
                       rule_type: 'experiment',
                       variation_key: 'varKey',
+                      enabled: true,
                     },
                   },
                 ],
@@ -159,6 +161,7 @@ describe('buildEventV1', () => {
         ruleKey: '',
         flagKey: 'flagKey1',
         ruleType: 'rollout',
+        enabled: true,
       }
 
       const result = buildImpressionEventV1(impressionEvent)
@@ -185,6 +188,7 @@ describe('buildEventV1', () => {
                       rule_key: '',
                       rule_type: 'rollout',
                       variation_key: '',
+                      enabled: true,
                     },
                   },
                 ],
@@ -549,6 +553,7 @@ describe('buildEventV1', () => {
         ruleKey: 'expKey',
         flagKey: 'flagKey1',
         ruleType: 'experiment',
+        enabled: true,
       }
 
       const result = makeBatchedEventV1([impressionEvent, conversionEvent])
@@ -576,6 +581,7 @@ describe('buildEventV1', () => {
                       rule_key: 'expKey',
                       rule_type: 'experiment',
                       variation_key: 'varKey',
+                      enabled: true,
                     },
                   },
                 ],

--- a/packages/event-processor/__tests__/v1EventProcessor.react_native.spec.ts
+++ b/packages/event-processor/__tests__/v1EventProcessor.react_native.spec.ts
@@ -66,6 +66,7 @@ function createImpressionEvent() {
     ruleKey: 'expKey',
     flagKey: 'flagKey1',
     ruleType: 'experiment',
+    enabled: false,
   }
 }
 

--- a/packages/event-processor/__tests__/v1EventProcessor.spec.ts
+++ b/packages/event-processor/__tests__/v1EventProcessor.spec.ts
@@ -63,6 +63,7 @@ function createImpressionEvent() {
     ruleKey: 'expKey',
     flagKey: 'flagKey1',
     ruleType: 'experiment',
+    enabled: true,
   }
 }
 

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -61,6 +61,7 @@ export interface ImpressionEvent extends BaseEvent {
   ruleKey: string
   flagKey: string
   ruleType: string
+  enabled: boolean
 }
 
 export interface ConversionEvent extends BaseEvent {

--- a/packages/event-processor/src/v1/buildEventV1.ts
+++ b/packages/event-processor/src/v1/buildEventV1.ts
@@ -52,6 +52,7 @@ namespace Visitor {
     rule_key: string;
     rule_type: string;
     variation_key: string;
+    enabled: boolean;
   }
 
   export type SnapshotEvent = {
@@ -143,7 +144,7 @@ function makeConversionSnapshot(conversion: ConversionEvent): Visitor.Snapshot {
 }
 
 function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
-  const { layer, experiment, variation, ruleKey, flagKey, ruleType } = event
+  const { layer, experiment, variation, ruleKey, flagKey, ruleType, enabled } = event
   let layerId = layer ? layer.id : null
   let experimentId = experiment ? experiment.id : null
   let variationId = variation ? variation.id : null
@@ -160,6 +161,7 @@ function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
           rule_key: ruleKey,
           rule_type: ruleType,
           variation_key: variationKey,
+          enabled: enabled,
         },
       },
     ],


### PR DESCRIPTION
## Summary

- add `enabled` field to decision metadata object


## Test plan
Unit tests

## Issues
[OASIS-7346](https://optimizely.atlassian.net/browse/OASIS-7346)

