### PR TITLE
fix(Optimizely): Use any type for return value of setTimeout

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Bug fixes
 
-- In Optimizely class, use `any` type when assigning the return value of `setTimeout`. This is to allow it to type check regardless of whether it uses the browser or Node version of `setTimeout` ([PR #623](https://github.com/optimizely/javascript-sdk/pull/623)), ([Issue #622](https://github.com/optimizely/javascript-sdk/issues/622))
+- In `Optimizely` class, use `any` type when assigning the return value of `setTimeout`. This is to allow it to type check regardless of whether it uses the browser or Node version of `setTimeout` ([PR #623](https://github.com/optimizely/javascript-sdk/pull/623)), ([Issue #622](https://github.com/optimizely/javascript-sdk/issues/622))
 
 ## [4.4.1] - November 5, 2020
 

--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Bug fixes
+
+- In Optimizely class, use `any` type when assigning the return value of `setTimeout`. This is to allow it to type check regardless of whether it uses the browser or Node version of `setTimeout` ([PR #623](https://github.com/optimizely/javascript-sdk/pull/623)), ([Issue #622](https://github.com/optimizely/javascript-sdk/issues/622))
 
 ## [4.4.1] - November 5, 2020
 

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -95,7 +95,9 @@ export default class Optimizely {
   private isOptimizelyConfigValid: boolean;
   private disposeOnUpdate: (() => void ) | null;
   private readyPromise: Promise<{ success: boolean; reason?: string }>;
-  private readyTimeouts: { [key: string]: {readyTimeout: number; onClose:() => void} };
+  // readyTimeout is specified as any to make this work in both browser & Node
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readyTimeouts: { [key: string]: {readyTimeout: any; onClose:() => void} };
   private nextReadyTimeoutId: number;
   private clientEngine: string;
   private clientVersion: string;


### PR DESCRIPTION
## Summary

Fix for #622 . For the Node.js version of `setTimeout`, the return value isn't `number`, but `Timeout`. To allow this to typecheck regardless of whether the browser or Node.js version is used, set the type of `readyTimeout` to `any`.

## Test plan

Existing tests

## Issues
#622
