### PR TITLE
fix: Allow logLevel to support string type to avoid compiler type error

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - In `Optimizely` class, use `any` type when assigning the return value of `setTimeout`. This is to allow it to type check regardless of whether it uses the browser or Node version of `setTimeout` ([PR #623](https://github.com/optimizely/javascript-sdk/pull/623)), ([Issue #622](https://github.com/optimizely/javascript-sdk/issues/622))
 
+- Allow to pass string type `logLevel` to `createInstance`. ([Issue #614](https://github.com/optimizely/javascript-sdk/issues/614))
+
 ### New Features
 
 - Added `enabled` field to decision metadata structure to support upcoming application-controlled introduction of tracking for non-experiment Flag decisions ([#619](https://github.com/optimizely/javascript-sdk/pull/619))

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -205,7 +205,7 @@ declare module '@optimizely/optimizely-sdk/lib/plugins/logger' {
   import { LogHandler } from '@optimizely/js-sdk-logging';
 
   export interface LoggerConfig {
-    logLevel?: enums.LOG_LEVEL;
+    logLevel?: enums.LOG_LEVEL | string;
     logToConsole?: boolean;
     prefix?: string;
   }

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -73,6 +73,7 @@ declare module '@optimizely/optimizely-sdk' {
     eventDispatcher?: EventDispatcher;
     logger?: LogHandler;
     logLevel?:
+      | string
       | enums.LOG_LEVEL.DEBUG
       | enums.LOG_LEVEL.ERROR
       | enums.LOG_LEVEL.INFO

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -145,7 +145,7 @@ export interface SDKOptions {
   // flag to validate if this instance is valid
   isValidInstance: boolean;
   // level of logging i.e debug, info, error, warning etc
-  logLevel?: LogLevel;
+  logLevel?: LogLevel | string;
   // LogHandler object for logging
   logger?: LogHandler;
   // sdk key


### PR DESCRIPTION
## Summary

Allow `logLevel` to support string type in addition to LogLevel enum to avoid compiler type error 

## Test plan
Existing unit tests

## Issues
[SDK-issue 614](https://github.com/optimizely/javascript-sdk/issues/614)
