### PR TITLE
fix: Move OptimizelyOptions interface to shared_types

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.MD
+++ b/packages/optimizely-sdk/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+-  Refactored TypeScript type definitions to have `OptimizelyOptions` imported from `shared_types` to provide isolation from internal modules ([#629](https://github.com/optimizely/javascript-sdk/pull/629))
 
 ## [4.4.2] - November 19, 2020
 

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -53,7 +53,7 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type SDKOptions = import ('./shared_types').SDKOptions;
 
-  export type OptimizelyOptions = import ('./optimizely').OptimizelyOptions;
+  export type OptimizelyOptions = import ('./shared_types').OptimizelyOptions;
 
   export type UserProfileService = import('./shared_types').UserProfileService;
 

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -22,10 +22,10 @@ import {
   EventDispatcher,
   OnReadyResult,
   UserProfileService,
-  DatafileOptions,
   Variation,
   FeatureFlag,
-  FeatureVariable
+  FeatureVariable,
+  OptimizelyOptions
 } from '../shared_types';
 import { createProjectConfigManager, ProjectConfigManager } from '../core/project_config/project_config_manager';
 import { createNotificationCenter, NotificationCenter } from '../core/notification_center';
@@ -55,28 +55,6 @@ const MODULE_NAME = 'OPTIMIZELY';
 
 const DEFAULT_ONREADY_TIMEOUT = 30000;
 
-/**
- * options required to create optimizely object
- */
-export interface OptimizelyOptions {
-  UNSTABLE_conditionEvaluators?: unknown;
-  clientEngine: string;
-  clientVersion?: string;
-  datafile?: string;
-  datafileOptions?: DatafileOptions;
-  errorHandler: ErrorHandler;
-  eventBatchSize?: number;
-  eventDispatcher: EventDispatcher;
-  eventFlushInterval?: number;
-  eventMaxQueueSize?: number;
-  isValidInstance: boolean;
-  // TODO[OASIS-6649]: Don't use object type
-  // eslint-disable-next-line  @typescript-eslint/ban-types
-  jsonSchemaValidator?: object;
-  logger: LogHandler;
-  sdkKey?: string;
-  userProfileService?: UserProfileService | null;
-}
 
 // TODO: Make feature_key, user_id, variable_key, experiment_key, event_key camelCase
 export type InputKey = 'feature_key' | 'user_id' | 'variable_key' | 'experiment_key' | 'event_key' | 'variation_id';

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -111,6 +111,29 @@ export type ObjectWithUnknownProperties = {
 }
 
 /**
+ * options required to create optimizely object
+ */
+export interface OptimizelyOptions {
+  UNSTABLE_conditionEvaluators?: unknown;
+  clientEngine: string;
+  clientVersion?: string;
+  datafile?: string;
+  datafileOptions?: DatafileOptions;
+  errorHandler: ErrorHandler;
+  eventBatchSize?: number;
+  eventDispatcher: EventDispatcher;
+  eventFlushInterval?: number;
+  eventMaxQueueSize?: number;
+  isValidInstance: boolean;
+  // TODO[OASIS-6649]: Don't use object type
+  // eslint-disable-next-line  @typescript-eslint/ban-types
+  jsonSchemaValidator?: object;
+  logger: LogHandler;
+  sdkKey?: string;
+  userProfileService?: UserProfileService | null;
+}
+
+/**
  * Optimizely Config Entities
  */
 export interface OptimizelyExperiment {


### PR DESCRIPTION
## Summary
- Move `OptimizelyOptions` interface to `shared_types` to provide isolation from internal ts modules

## Test plan
Existing unit tests

