### PR TITLE
refactor: Correctly exported OptimizelyDecideOptions enum

### DIFF
--- a/packages/optimizely-sdk/lib/index.browser.ts
+++ b/packages/optimizely-sdk/lib/index.browser.ts
@@ -29,7 +29,7 @@ import * as enums from './utils/enums';
 import loggerPlugin from './plugins/logger';
 import Optimizely from './optimizely';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
 
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -153,6 +153,7 @@ export {
   setLogLevel,
   createInstance,
   __internalResetRetryState,
+  OptimizelyDecideOptions,
 };
 
 export default {
@@ -164,4 +165,5 @@ export default {
   setLogLevel,
   createInstance,
   __internalResetRetryState,
+  OptimizelyDecideOptions,
 };

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -65,7 +65,13 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type OptimizelyDecision = import('./optimizely_decision').OptimizelyDecision;
 
-  export type OptimizelyDecideOptions = import('./shared_types').OptimizelyDecideOptions;
+  export enum OptimizelyDecideOptions {
+    DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT',
+    ENABLED_FLAGS_ONLY =  'ENABLED_FLAGS_ONLY',
+    IGNORE_USER_PROFILE_SERVICE = 'IGNORE_USER_PROFILE_SERVICE',
+    INCLUDE_REASONS = 'INCLUDE_REASONS',
+    EXCLUDE_VARIABLES = 'EXCLUDE_VARIABLES'
+  }
 
   export type NotificationListener<T extends ListenerPayload> = import('./shared_types').NotificationListener<T>;
 

--- a/packages/optimizely-sdk/lib/index.node.ts
+++ b/packages/optimizely-sdk/lib/index.node.ts
@@ -28,7 +28,7 @@ import configValidator from './utils/config_validator';
 import defaultErrorHandler from './plugins/error_handler';
 import defaultEventDispatcher from './plugins/event_dispatcher/index.node';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
 
 const logger = getLogger();
 setLogLevel(LogLevel.ERROR);
@@ -116,6 +116,7 @@ export {
   setLogHandler as setLogger,
   setLogLevel,
   createInstance,
+  OptimizelyDecideOptions,
 };
 
 export default {
@@ -126,4 +127,5 @@ export default {
   setLogger: setLogHandler,
   setLogLevel,
   createInstance,
+  OptimizelyDecideOptions,
 };

--- a/packages/optimizely-sdk/lib/index.react_native.ts
+++ b/packages/optimizely-sdk/lib/index.react_native.ts
@@ -28,7 +28,7 @@ import defaultErrorHandler from './plugins/error_handler';
 import loggerPlugin from './plugins/logger/index.react_native';
 import defaultEventDispatcher from './plugins/event_dispatcher/index.browser';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
 
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -112,6 +112,7 @@ export {
   setLogHandler as setLogger,
   setLogLevel,
   createInstance,
+  OptimizelyDecideOptions,
 };
 
 export default {
@@ -122,4 +123,5 @@ export default {
   setLogger: setLogHandler,
   setLogLevel,
   createInstance,
+  OptimizelyDecideOptions,
 };


### PR DESCRIPTION
## Summary
The `OptimizelyDecideOptions` enum was being exported as a type. Correctly exported it as enum and added declaration to typings.

## Test plan
1. Unit tests pass.
2. Full stack Compatibility suite tests pass.