### PR TITLE
feat: Implement IGNORE_USER_PROFILE_SERVICE flag in decide options

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
@@ -60,19 +60,21 @@ export interface DecisionService {
    * experiment properties (both objects), as well as a decisionSource property.
    * decisionSource indicates whether the decision was due to a rollout or an
    * experiment.
-   * @param   {ProjectConfig}     configObj         The parsed project configuration object
-   * @param   {FeatureFlag}       feature           A feature flag object from project configuration
-   * @param   {string}            userId            A string identifying the user, for bucketing
-   * @param   {unknown}           attributes        Optional user attributes
-   * @return  {DecisionResponse}  DecisionResponse  DecisionResponse containing an object with experiment, variation, and decisionSource
-   *                                                properties and the decide reasons. If the user was not bucketed into a variation, the
-   *                                                variation property in decision object is null.
+   * @param   {ProjectConfig}             configObj         The parsed project configuration object
+   * @param   {FeatureFlag}               feature           A feature flag object from project configuration
+   * @param   {string}                    userId            A string identifying the user, for bucketing
+   * @param   {unknown}                   attributes        Optional user attributes
+   * @param   {[key: string]: boolean}    options           Map of decide options
+   * @return  {DecisionResponse}          DecisionResponse  DecisionResponse containing an object with experiment, variation, and decisionSource
+   *                                                        properties and the decide reasons. If the user was not bucketed into a variation, the
+   *                                                        variation property in decision object is null.
    */
   getVariationForFeature(
     configObj: ProjectConfig,
     feature: FeatureFlag,
     userId: string,
-    attributes: unknown
+    attributes: unknown,
+    options?: { [key: string]: boolean }
   ): DecisionResponse<DecisionObj>;
 
   /**

--- a/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
@@ -52,7 +52,7 @@ export interface DecisionService {
     experimentKey: string,
     userId: string,
     attributes?: UserAttributes,
-    options?: { [key: string]: boolean },
+    options?: { [key: string]: boolean }
   ): DecisionResponse<string | null>;
 
   /**

--- a/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.d.ts
@@ -39,18 +39,20 @@ export interface DecisionService {
 
   /**
    * Gets a decision response containing variation where visitor will be bucketed and the decide reasons.
-   * @param   {ProjectConfig}     configObj         The parsed project configuration object
-   * @param   {string}            experimentKey
-   * @param   {string}            userId
-   * @param   {UserAttributes}    attributes
-   * @return  {DecisionResponse}  DecisionResponse  DecisionResponse containing variation
-   *                                                the user is bucketed into and the decide reasons.
+   * @param   {ProjectConfig}                     configObj         The parsed project configuration object
+   * @param   {string}                            experimentKey
+   * @param   {string}                            userId
+   * @param   {UserAttributes}                    attributes
+   * @param   {[key: string]: boolean}            options           Optional map of decide options
+   * @return  {DecisionResponse}                  DecisionResponse  DecisionResponse containing variation
+   *                                                                the user is bucketed into and the decide reasons.
    */
   getVariation(
     configObj: ProjectConfig,
     experimentKey: string,
     userId: string,
-    attributes?: UserAttributes
+    attributes?: UserAttributes,
+    options?: { [key: string]: boolean },
   ): DecisionResponse<string | null>;
 
   /**
@@ -64,7 +66,7 @@ export interface DecisionService {
    * @param   {FeatureFlag}               feature           A feature flag object from project configuration
    * @param   {string}                    userId            A string identifying the user, for bucketing
    * @param   {unknown}                   attributes        Optional user attributes
-   * @param   {[key: string]: boolean}    options           Map of decide options
+   * @param   {[key: string]: boolean}    options           Optional map of decide options
    * @return  {DecisionResponse}          DecisionResponse  DecisionResponse containing an object with experiment, variation, and decisionSource
    *                                                        properties and the decide reasons. If the user was not bucketed into a variation, the
    *                                                        variation property in decision object is null.

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -60,7 +60,7 @@ function DecisionService(options) {
  * @param  {string}                                 experimentKey
  * @param  {string}                                 userId
  * @param  {Object}                                 attributes
- * @param  {OptimizelyDecideOptions[]}              options           Decide options
+ * @param  {[key: string]: boolean}                 options           Optional map of decide options
  * @return {Object}                                 DecisionResonse   DecisionResonse containing the variation the user is bucketed into
  *                                                                    and the decide reasons.
  */

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -180,8 +180,10 @@ DecisionService.prototype.getVariation = function(configObj, experimentKey, user
   );
   this.logger.log(LOG_LEVEL.INFO, userInVariationLogMessage);
   decideReasons.push(userInVariationLogMessage);
-  // persist bucketing
-  this.__saveUserProfile(experiment, variation, userId, experimentBucketMap);
+  // persist bucketing if decide options do not include shouldIgnoreUPS
+  if (!shouldIgnoreUPS) {
+    this.__saveUserProfile(experiment, variation, userId, experimentBucketMap);
+  }
 
   return {
     result: variation.key,

--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -420,14 +420,14 @@ DecisionService.prototype.__saveUserProfile = function(experiment, variation, us
  * experiment properties (both objects), as well as a decisionSource property.
  * decisionSource indicates whether the decision was due to a rollout or an
  * experiment.
- * @param   {Object}            configObj         The parsed project configuration object
- * @param   {Object}            feature           A feature flag object from project configuration
- * @param   {String}            userId            A string identifying the user, for bucketing
- * @param   {Object}            attributes        Optional user attributes
- * @param   {Object}            options           Map of decide options
- * @return  {Object}            DecisionResponse  DecisionResponse containing an object with experiment, variation, and decisionSource
- *                                                properties and decide reasons. If the user was not bucketed into a variation, the variation
- *                                                property in decision object is null.
+ * @param   {Object}                      configObj         The parsed project configuration object
+ * @param   {Object}                      feature           A feature flag object from project configuration
+ * @param   {String}                      userId            A string identifying the user, for bucketing
+ * @param   {Object}                      attributes        Optional user attributes
+ * @param   {[key: string]: boolean}      options           Map of decide options
+ * @return  {Object}                      DecisionResponse  DecisionResponse containing an object with experiment, variation, and decisionSource
+ *                                                          properties and decide reasons. If the user was not bucketed into a variation, the variation
+ *                                                          property in decision object is null.
  */
 DecisionService.prototype.getVariationForFeature = function(configObj, feature, userId, attributes, options = {}) {
   var decideReasons = [];
@@ -465,7 +465,7 @@ DecisionService.prototype.getVariationForFeature = function(configObj, feature, 
 };
 
 
-DecisionService.prototype._getVariationForFeatureExperiment = function(configObj, feature, userId, attributes, options) {
+DecisionService.prototype._getVariationForFeatureExperiment = function(configObj, feature, userId, attributes, options = {}) {
   var decideReasons = [];
   var experiment = null;
   var variationKey = null;

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -1364,9 +1364,15 @@ describe('lib/core/decision_service', function() {
               decisionSource: DECISION_SOURCES.FEATURE_TEST,
             };
             assert.deepEqual(decision, expectedDecision);
-            sinon.assert.calledWithExactly(getVariationStub, configObj, 'testing_my_feature', 'user1', {
-              test_attribute: 'test_value',
-            });
+            sinon.assert.calledWithExactly(
+              getVariationStub,
+              configObj,
+              'testing_my_feature', 'user1',
+              {
+                test_attribute: 'test_value',
+              },
+              {}
+            );
           });
         });
 

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -155,8 +155,8 @@ describe('lib/core/decision_service', function() {
         var userProfileLookupStub;
         var userProfileSaveStub;
         var fakeDecisionWhitelistedVariation = {
-          getResult: sinon.stub().returns(null),
-          getReasons: sinon.stub().returns([])
+          result: null,
+          reasons: [],
         }
         beforeEach(function() {
           userProfileServiceInstance = {

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -1490,7 +1490,8 @@ export default class Optimizely {
       configObj,
       feature,
       userId,
-      attributes
+      attributes,
+      allDecideOptions,
     );
     reasons.push(...decisionVariation.reasons);
     const decisionObj = decisionVariation.result;


### PR DESCRIPTION
## Summary
- Implemented IGNORE_USER_PROFILE_SERVICE flag in decide options

## Test plan
- Fixed affected unit tests
- Added unit test coverage with IGNORE_USER_PROFILE_SERVICE decide option
- Manual Testing
## Note
This pr is to be finalized once https://github.com/optimizely/javascript-sdk/pull/640 is merged