### PR TITLE
feat: Clone OptimizelyUserContext before calling decide api

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely_decision/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely_decision/index.ts
@@ -17,11 +17,17 @@ import OptimizelyUserContext from '../optimizely_user_context';
 
 export interface OptimizelyDecision {
   variationKey: string | null;
+  // The boolean value indicating if the flag is enabled or not
   enabled: boolean;
+  // The collection of variables associated with the decision
   variables: { [variableKey: string]: unknown };
+  // The rule key of the decision
   ruleKey: string | null;
+  // The flag key for which the decision has been made for
   flagKey: string;
+  // A copy of the user context for which the decision has been made for
   userContext: OptimizelyUserContext;
+  // An array of error/info messages describing why the decision has been made.
   reasons: string[];
 }
 

--- a/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
@@ -69,7 +69,7 @@ export default class OptimizelyUserContext {
     options: OptimizelyDecideOptions[] = []
   ): OptimizelyDecision {
 
-    return this.optimizely.decide(this, key, options);
+    return this.optimizely.decide(this.cloneUserContext(), key, options);
   }
 
   /**
@@ -85,7 +85,7 @@ export default class OptimizelyUserContext {
     options: OptimizelyDecideOptions[] = [],
   ): { [key: string]: OptimizelyDecision } {
 
-    return this.optimizely.decideForKeys(this, keys, options);
+    return this.optimizely.decideForKeys(this.cloneUserContext(), keys, options);
   }
 
   /**
@@ -97,7 +97,7 @@ export default class OptimizelyUserContext {
     options: OptimizelyDecideOptions[] = []
   ): { [key: string]: OptimizelyDecision } {
 
-    return this.optimizely.decideAll(this, options);
+    return this.optimizely.decideAll(this.cloneUserContext(), options);
   }
 
   /**
@@ -107,5 +107,13 @@ export default class OptimizelyUserContext {
    */
   trackEvent(eventName: string, eventTags?: EventTags): void {
     this.optimizely.track(eventName, this.userId, this.attributes, eventTags);
+  }
+
+  private cloneUserContext(): OptimizelyUserContext {
+    return new OptimizelyUserContext({
+      optimizely: this.getOptimizely(),
+      userId: this.getUserId(),
+      attributes: this.getAttributes(),
+    })
   }
 }


### PR DESCRIPTION
## Summary
The OptimizelyUserContext instance is returned as a part of decision at the end of the decide api call. If the instance is not cloned at the beginning, it may have different states than one used for the decision.
In this pr, cloning of user context is implemented before calling decide api.

## Test plan
Unit tests + Manual testing

## Issues
- [OASIS-2700](https://optimizely.atlassian.net/browse/OASIS-7400)
