### PR TITLE
fix: Change experimentKey and variationKey to be null in rollout in decisionInfo payload

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.js
@@ -21,7 +21,7 @@ import * as enums from '../../utils/enums';
 import projectConfig from '../project_config';
 import AudienceEvaluator from '../audience_evaluator';
 import * as stringValidator from '../../utils/string_value_validator';
-import { OptimizelyDecideOptions } from '../../shared_types';
+import { OptimizelyDecideOption } from '../../shared_types';
 
 var MODULE_NAME = 'DECISION_SERVICE';
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
@@ -100,7 +100,7 @@ DecisionService.prototype.getVariation = function(configObj, experimentKey, user
     };
   }
 
-  var shouldIgnoreUPS = options[OptimizelyDecideOptions.IGNORE_USER_PROFILE_SERVICE];
+  var shouldIgnoreUPS = options[OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE];
 
   // check for sticky bucketing if decide options do not include shouldIgnoreUPS
   if (!shouldIgnoreUPS) {

--- a/packages/optimizely-sdk/lib/index.browser.ts
+++ b/packages/optimizely-sdk/lib/index.browser.ts
@@ -29,7 +29,7 @@ import * as enums from './utils/enums';
 import loggerPlugin from './plugins/logger';
 import Optimizely from './optimizely';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOption } from './shared_types';
 
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -153,7 +153,7 @@ export {
   setLogLevel,
   createInstance,
   __internalResetRetryState,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };
 
 export default {
@@ -165,5 +165,5 @@ export default {
   setLogLevel,
   createInstance,
   __internalResetRetryState,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -65,7 +65,7 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type OptimizelyDecision = import('./optimizely_decision').OptimizelyDecision;
 
-  export enum OptimizelyDecideOptions {
+  export enum OptimizelyDecideOption {
     DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT',
     ENABLED_FLAGS_ONLY =  'ENABLED_FLAGS_ONLY',
     IGNORE_USER_PROFILE_SERVICE = 'IGNORE_USER_PROFILE_SERVICE',

--- a/packages/optimizely-sdk/lib/index.node.ts
+++ b/packages/optimizely-sdk/lib/index.node.ts
@@ -28,7 +28,7 @@ import configValidator from './utils/config_validator';
 import defaultErrorHandler from './plugins/error_handler';
 import defaultEventDispatcher from './plugins/event_dispatcher/index.node';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOption } from './shared_types';
 
 const logger = getLogger();
 setLogLevel(LogLevel.ERROR);
@@ -116,7 +116,7 @@ export {
   setLogHandler as setLogger,
   setLogLevel,
   createInstance,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };
 
 export default {
@@ -127,5 +127,5 @@ export default {
   setLogger: setLogHandler,
   setLogLevel,
   createInstance,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };

--- a/packages/optimizely-sdk/lib/index.react_native.ts
+++ b/packages/optimizely-sdk/lib/index.react_native.ts
@@ -28,7 +28,7 @@ import defaultErrorHandler from './plugins/error_handler';
 import loggerPlugin from './plugins/logger/index.react_native';
 import defaultEventDispatcher from './plugins/event_dispatcher/index.browser';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
-import { SDKOptions, OptimizelyDecideOptions } from './shared_types';
+import { SDKOptions, OptimizelyDecideOption } from './shared_types';
 
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -112,7 +112,7 @@ export {
   setLogHandler as setLogger,
   setLogLevel,
   createInstance,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };
 
 export default {
@@ -123,5 +123,5 @@ export default {
   setLogger: setLogHandler,
   setLogLevel,
   createInstance,
-  OptimizelyDecideOptions,
+  OptimizelyDecideOption,
 };

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -21,7 +21,7 @@ import * as logging from '@optimizely/js-sdk-logging';
 
 import Optimizely from './';
 import OptimizelyUserContext from '../optimizely_user_context';
-import { OptimizelyDecideOptions } from '../shared_types';
+import { OptimizelyDecideOption } from '../shared_types';
 import AudienceEvaluator from '../core/audience_evaluator';
 import bluebird from 'bluebird';
 import bucketer from '../core/bucketer';
@@ -4707,7 +4707,7 @@ describe('lib/optimizely', function() {
             optimizely: optlyInstance,
             userId,
           });
-          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOptions.DISABLE_DECISION_EVENT ]);
+          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOption.DISABLE_DECISION_EVENT ]);
           var expectedDecision = {
             variationKey: 'variation_with_traffic',
             enabled: true,
@@ -4747,7 +4747,7 @@ describe('lib/optimizely', function() {
             optimizely: optlyInstance,
             userId,
           });
-          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOptions.DISABLE_DECISION_EVENT, OptimizelyDecideOptions.EXCLUDE_VARIABLES ]);
+          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOption.DISABLE_DECISION_EVENT, OptimizelyDecideOption.EXCLUDE_VARIABLES ]);
           var expectedDecision = {
             variationKey: 'variation_with_traffic',
             enabled: true,
@@ -4919,7 +4919,7 @@ describe('lib/optimizely', function() {
             logger: createdLogger,
             isValidInstance: true,
             eventBatchSize: 1,
-            defaultDecideOptions: [ OptimizelyDecideOptions.EXCLUDE_VARIABLES ],
+            defaultDecideOptions: [ OptimizelyDecideOption.EXCLUDE_VARIABLES ],
           });
 
           sinon.stub(optlyInstance.notificationCenter, 'sendNotifications');
@@ -4981,7 +4981,7 @@ describe('lib/optimizely', function() {
             optimizely: optlyInstance,
             userId
           });
-          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOptions.DISABLE_DECISION_EVENT ]);
+          var decision = optlyInstance.decide(user, flagKey, [ OptimizelyDecideOption.DISABLE_DECISION_EVENT ]);
           var expectedDecisionObj = {
             variationKey: 'variation_with_traffic',
             enabled: true,
@@ -5027,7 +5027,7 @@ describe('lib/optimizely', function() {
             logger: createdLogger,
             isValidInstance: true,
             eventBatchSize: 1,
-            defaultDecideOptions: [ OptimizelyDecideOptions.DISABLE_DECISION_EVENT ],
+            defaultDecideOptions: [ OptimizelyDecideOption.DISABLE_DECISION_EVENT ],
           });
 
           sinon.stub(optlyInstance.notificationCenter, 'sendNotifications');
@@ -5090,7 +5090,7 @@ describe('lib/optimizely', function() {
             logger: createdLogger,
             isValidInstance: true,
             eventBatchSize: 1,
-            defaultDecideOptions: [ OptimizelyDecideOptions.INCLUDE_REASONS ],
+            defaultDecideOptions: [ OptimizelyDecideOption.INCLUDE_REASONS ],
           });
 
           sinon.stub(optlyInstance.notificationCenter, 'sendNotifications');
@@ -5145,7 +5145,7 @@ describe('lib/optimizely', function() {
             logger: createdLogger,
             isValidInstance: true,
             eventBatchSize: 1,
-            defaultDecideOptions: [ OptimizelyDecideOptions.INCLUDE_REASONS ],
+            defaultDecideOptions: [ OptimizelyDecideOption.INCLUDE_REASONS ],
           });
           var user = new OptimizelyUserContext({
             optimizely: optlyInstanceWithUserProfile,
@@ -5694,7 +5694,7 @@ describe('lib/optimizely', function() {
             var decision1 = optlyInstanceWithUserProfile.decide(user, flagKey);
             // should return variationId2 set by UPS
             assert.equal(variationKey2, decision1.variationKey);
-            var decision2 = optlyInstanceWithUserProfile.decide(user, flagKey, [ OptimizelyDecideOptions.IGNORE_USER_PROFILE_SERVICE ]);
+            var decision2 = optlyInstanceWithUserProfile.decide(user, flagKey, [ OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE ]);
             // should ignore variationId2 set by UPS and return variationId1
             assert.equal(variationKey1, decision2.variationKey);
             // also should not save either
@@ -5728,7 +5728,7 @@ describe('lib/optimizely', function() {
               logger: createdLogger,
               isValidInstance: true,
               eventBatchSize: 1,
-              defaultDecideOptions: [ OptimizelyDecideOptions.IGNORE_USER_PROFILE_SERVICE ]
+              defaultDecideOptions: [ OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE ]
             });
             var user = new OptimizelyUserContext({
               optimizely: optlyInstanceWithUserProfile,
@@ -5827,7 +5827,7 @@ describe('lib/optimizely', function() {
         var flagKey2 = 'feature_3';
         var user = optlyInstance.createUserContext(userId, { gender: 'female' });
         var expectedVariables = optlyInstance.getAllFeatureVariables(flagKey1, userId);
-        var decisionsMap = optlyInstance.decideForKeys(user, [ flagKey1, flagKey2 ], [ OptimizelyDecideOptions.ENABLED_FLAGS_ONLY ]);
+        var decisionsMap = optlyInstance.decideForKeys(user, [ flagKey1, flagKey2 ], [ OptimizelyDecideOption.ENABLED_FLAGS_ONLY ]);
         var decision = decisionsMap[flagKey1];
         var expectedDecision = {
           variationKey: 'variation_with_traffic',
@@ -5918,7 +5918,7 @@ describe('lib/optimizely', function() {
           var user = optlyInstance.createUserContext(userId, { gender: 'female' });
           var expectedVariables1 = optlyInstance.getAllFeatureVariables(flagKey1, userId);
           var expectedVariables2 = optlyInstance.getAllFeatureVariables(flagKey2, userId);
-          var decisionsMap = optlyInstance.decideAll(user, [ OptimizelyDecideOptions.ENABLED_FLAGS_ONLY ]);
+          var decisionsMap = optlyInstance.decideAll(user, [ OptimizelyDecideOption.ENABLED_FLAGS_ONLY ]);
           var decision1 = decisionsMap[flagKey1];
           var decision2 = decisionsMap[flagKey2];
           var expectedDecision1 = {
@@ -5957,7 +5957,7 @@ describe('lib/optimizely', function() {
             logger: createdLogger,
             isValidInstance: true,
             eventBatchSize: 1,
-            defaultDecideOptions: [ OptimizelyDecideOptions.ENABLED_FLAGS_ONLY ],
+            defaultDecideOptions: [ OptimizelyDecideOption.ENABLED_FLAGS_ONLY ],
           });
 
           sinon.stub(optlyInstance.notificationCenter, 'sendNotifications');
@@ -6004,7 +6004,7 @@ describe('lib/optimizely', function() {
           var flagKey1 = 'feature_1';
           var flagKey2 = 'feature_2';
           var user = optlyInstance.createUserContext(userId, { gender: 'female' });
-          var decisionsMap = optlyInstance.decideAll(user, [ OptimizelyDecideOptions.EXCLUDE_VARIABLES ]);
+          var decisionsMap = optlyInstance.decideAll(user, [ OptimizelyDecideOption.EXCLUDE_VARIABLES ]);
           var decision1 = decisionsMap[flagKey1];
           var decision2 = decisionsMap[flagKey2];
           var expectedDecision1 = {

--- a/packages/optimizely-sdk/lib/optimizely/index.tests.js
+++ b/packages/optimizely-sdk/lib/optimizely/index.tests.js
@@ -4875,10 +4875,10 @@ describe('lib/optimizely', function() {
           });
           var decision = optlyInstance.decide(user, flagKey);
           var expectedDecision = {
-            variationKey: '',
+            variationKey: null,
             enabled: false,
             variables: expectedVariables,
-            ruleKey: '',
+            ruleKey: null,
             flagKey: flagKey,
             userContext: user,
             reasons: [],
@@ -4896,8 +4896,8 @@ describe('lib/optimizely', function() {
               decisionInfo: {
                 flagKey: 'feature_3',
                 enabled: false,
-                ruleKey: '',
-                variationKey: '',
+                ruleKey: null,
+                variationKey: null,
                 variables: expectedVariables,
                 decisionEventDispatched: true,
                 reasons: [],
@@ -5897,10 +5897,10 @@ describe('lib/optimizely', function() {
             reasons: [],
           }
           var expectedDecision3 = {
-            variationKey: '',
+            variationKey: null,
             enabled: false,
             variables: expectedVariables3,
-            ruleKey: '',
+            ruleKey: null,
             flagKey: allFlagKeysArray[2],
             userContext: user,
             reasons: [],

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -1496,8 +1496,8 @@ export default class Optimizely {
     reasons.push(...decisionVariation.reasons);
     const decisionObj = decisionVariation.result;
     const decisionSource = decisionObj.decisionSource;
-    const experimentKey = decision.getExperimentKey(decisionObj);
-    const variationKey = decision.getVariationKey(decisionObj);
+    const experimentKey = decisionObj.experiment?.key ?? null;
+    const variationKey = decisionObj.variation?.key ?? null;
     const flagEnabled: boolean = decision.getFeatureEnabledFromVariation(decisionObj);
     if (flagEnabled === true) {
       this.logger.log(

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -26,7 +26,7 @@ import {
   FeatureFlag,
   FeatureVariable,
   OptimizelyOptions,
-  OptimizelyDecideOptions
+  OptimizelyDecideOption
 } from '../shared_types';
 import { OptimizelyDecision, newErrorDecision } from '../optimizely_decision';
 import OptimizelyUserContext from '../optimizely_user_context';
@@ -122,8 +122,8 @@ export default class Optimizely {
 
     const defaultDecideOptions: { [key: string]: boolean } = {};
     decideOptionsArray.forEach((option) => {
-      // Filter out all provided default decide options that are not in OptimizelyDecideOptions[]
-      if (OptimizelyDecideOptions[option]) {
+      // Filter out all provided default decide options that are not in OptimizelyDecideOption[]
+      if (OptimizelyDecideOption[option]) {
         defaultDecideOptions[option] = true;
       } else {
         this.logger.log(
@@ -1466,7 +1466,7 @@ export default class Optimizely {
   decide(
     user: OptimizelyUserContext,
     key: string,
-    options: OptimizelyDecideOptions[] = []
+    options: OptimizelyDecideOption[] = []
   ): OptimizelyDecision {
     const configObj = this.projectConfigManager.getConfig();
     const reasons: string[] = [];
@@ -1514,7 +1514,7 @@ export default class Optimizely {
     const variablesMap: { [key: string]: unknown } = {};
     let decisionEventDispatched = false;
 
-    if (!allDecideOptions[OptimizelyDecideOptions.EXCLUDE_VARIABLES]) {
+    if (!allDecideOptions[OptimizelyDecideOption.EXCLUDE_VARIABLES]) {
       feature.variables.forEach(variable => {
         variablesMap[variable.key] =
         this.getFeatureVariableValueFromVariation(
@@ -1528,7 +1528,7 @@ export default class Optimizely {
     }
 
     if (
-      !allDecideOptions[OptimizelyDecideOptions.DISABLE_DECISION_EVENT] && (
+      !allDecideOptions[OptimizelyDecideOption.DISABLE_DECISION_EVENT] && (
       decisionSource === DECISION_SOURCES.FEATURE_TEST ||
       decisionSource === DECISION_SOURCES.ROLLOUT && projectConfig.getSendFlagDecisionsValue(configObj))
     ) {
@@ -1542,7 +1542,7 @@ export default class Optimizely {
       decisionEventDispatched = true;
     }
 
-    const shouldIncludeReasons = allDecideOptions[OptimizelyDecideOptions.INCLUDE_REASONS];
+    const shouldIncludeReasons = allDecideOptions[OptimizelyDecideOption.INCLUDE_REASONS];
     const reportedReasons = shouldIncludeReasons ? reasons: [];
 
     const featureInfo = {
@@ -1575,17 +1575,17 @@ export default class Optimizely {
 
   /**
    * Get all decide options.
-   * @param  {OptimizelyDecideOptions[]}          options   decide options
+   * @param  {OptimizelyDecideOption[]}          options   decide options
    * @return {[key: string]: boolean}             Map of all provided decide options including default decide options
    */
-  private getAllDecideOptions(options: OptimizelyDecideOptions[]): { [key: string]: boolean } {
+  private getAllDecideOptions(options: OptimizelyDecideOption[]): { [key: string]: boolean } {
     const allDecideOptions = {...this.defaultDecideOptions};
     if (!Array.isArray(options)) {
       this.logger.log(LOG_LEVEL.DEBUG, sprintf(LOG_MESSAGES.INVALID_DECIDE_OPTIONS, MODULE_NAME));
     } else {
       options.forEach((option) => {
-        // Filter out all provided decide options that are not in OptimizelyDecideOptions[]
-        if (OptimizelyDecideOptions[option]) {
+        // Filter out all provided decide options that are not in OptimizelyDecideOption[]
+        if (OptimizelyDecideOption[option]) {
           allDecideOptions[option] = true;
         } else {
           this.logger.log(
@@ -1605,13 +1605,13 @@ export default class Optimizely {
    * The SDK will always return an object of decisions. When it cannot process requests, it will return an empty object after logging the errors.
    * @param     {OptimizelyUserContext}      user        A user context associated with this OptimizelyClient
    * @param     {string[]}                   keys        An array of flag keys for which decisions will be made.
-   * @param     {OptimizelyDecideOptions[]}  options     An array of options for decision-making.
+   * @param     {OptimizelyDecideOption[]}  options     An array of options for decision-making.
    * @return    {[key: string]: OptimizelyDecision}      An object of decision results mapped by flag keys.
    */
   decideForKeys(
     user: OptimizelyUserContext,
     keys: string[],
-    options: OptimizelyDecideOptions[] = []
+    options: OptimizelyDecideOption[] = []
   ): { [key: string]: OptimizelyDecision } {
     const decisionMap: { [key: string]: OptimizelyDecision } = {};
     if (!this.isValidInstance()) {
@@ -1625,7 +1625,7 @@ export default class Optimizely {
     const allDecideOptions = this.getAllDecideOptions(options);
     keys.forEach(key => {
       const optimizelyDecision: OptimizelyDecision = this.decide(user, key, options);
-      if (!allDecideOptions[OptimizelyDecideOptions.ENABLED_FLAGS_ONLY] || optimizelyDecision.enabled) {
+      if (!allDecideOptions[OptimizelyDecideOption.ENABLED_FLAGS_ONLY] || optimizelyDecision.enabled) {
         decisionMap[key] = optimizelyDecision;
       }
     });
@@ -1636,12 +1636,12 @@ export default class Optimizely {
   /**
    * Returns an object of decision results for all active flag keys.
    * @param     {OptimizelyUserContext}      user        A user context associated with this OptimizelyClient
-   * @param     {OptimizelyDecideOptions[]}  options     An array of options for decision-making.
+   * @param     {OptimizelyDecideOption[]}  options     An array of options for decision-making.
    * @return    {[key: string]: OptimizelyDecision}      An object of all decision results mapped by flag keys.
    */
   decideAll(
     user: OptimizelyUserContext,
-    options: OptimizelyDecideOptions[] = []
+    options: OptimizelyDecideOption[] = []
   ): { [key: string]: OptimizelyDecision } {
     const configObj = this.projectConfigManager.getConfig();
     const decisionMap: { [key: string]: OptimizelyDecision } = {};

--- a/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 import Optimizely from '../../lib/optimizely';
-import { UserAttributes, OptimizelyDecideOptions, EventTags } from '../../lib/shared_types';
+import { UserAttributes, OptimizelyDecideOption, EventTags } from '../../lib/shared_types';
 import { OptimizelyDecision } from '../optimizely_decision';
 
 export default class OptimizelyUserContext {
@@ -66,7 +66,7 @@ export default class OptimizelyUserContext {
    */
   decide(
     key: string,
-    options: OptimizelyDecideOptions[] = []
+    options: OptimizelyDecideOption[] = []
   ): OptimizelyDecision {
 
     return this.optimizely.decide(this.cloneUserContext(), key, options);
@@ -77,12 +77,12 @@ export default class OptimizelyUserContext {
    * If the SDK finds an error for a key, the response will include a decision for the key showing reasons for the error.
    * The SDK will always return key-mapped decisions. When it cannot process requests, it will return an empty map after logging the errors.
    * @param     {string[]}                   keys        An array of flag keys for which decisions will be made.
-   * @param     {OptimizelyDecideOptions[]}  options     An array of options for decision-making.
+   * @param     {OptimizelyDecideOption[]}   options     An array of options for decision-making.
    * @return    {[key: string]: OptimizelyDecision}      An object of decision results mapped by flag keys.
    */
   decideForKeys(
     keys: string[],
-    options: OptimizelyDecideOptions[] = [],
+    options: OptimizelyDecideOption[] = [],
   ): { [key: string]: OptimizelyDecision } {
 
     return this.optimizely.decideForKeys(this.cloneUserContext(), keys, options);
@@ -90,11 +90,11 @@ export default class OptimizelyUserContext {
 
   /**
    * Returns an object of decision results for all active flag keys.
-   * @param     {OptimizelyDecideOptions[]}  options     An array of options for decision-making.
+   * @param     {OptimizelyDecideOption[]}   options     An array of options for decision-making.
    * @return    {[key: string]: OptimizelyDecision}      An object of all decision results mapped by flag keys.
    */
   decideAll(
-    options: OptimizelyDecideOptions[] = []
+    options: OptimizelyDecideOption[] = []
   ): { [key: string]: OptimizelyDecision } {
 
     return this.optimizely.decideAll(this.cloneUserContext(), options);

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -132,8 +132,8 @@ export interface Rollout {
   experiments: Experiment[];
 }
 
-//TODO: Move OptimizelyDecideOptions to @optimizely/optimizely-sdk/lib/utils/enums
-export enum OptimizelyDecideOptions {
+//TODO: Move OptimizelyDecideOption to @optimizely/optimizely-sdk/lib/utils/enums
+export enum OptimizelyDecideOption {
   DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT',
   ENABLED_FLAGS_ONLY =  'ENABLED_FLAGS_ONLY',
   IGNORE_USER_PROFILE_SERVICE = 'IGNORE_USER_PROFILE_SERVICE',
@@ -162,7 +162,7 @@ export interface OptimizelyOptions {
   logger: LogHandler;
   sdkKey?: string;
   userProfileService?: UserProfileService | null;
-  defaultDecideOptions?: OptimizelyDecideOptions[]
+  defaultDecideOptions?: OptimizelyDecideOption[]
 }
 
 /**


### PR DESCRIPTION
## Summary
 - This pr changes `variationKey` and `ruleKey` from empty string to `null`  in a rollout `decisionInfo` payload in order to pass FSC tests.
 - Changed `OptimizelyDecideOptions` enums to `OptimizelyDecideOption` to be consistent with other SDKs.
## Test plan
- Unit tests
- [FSC tests](https://travis-ci.com/github/optimizely/fullstack-sdk-compatibility-suite/builds/213362981) with `uzair/decide-api-endpoints` testapp branch - all pass except for DECIDE WORLD tests, which will be addressed separately