### PR TITLE
fix: Fix type definitions to avoid compiling source files

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -62,6 +62,8 @@ declare module '@optimizely/optimizely-sdk' {
   export type ListenerPayload = import('./shared_types').ListenerPayload;
 
   export interface OptimizelyUserContext {
+    getUserId(): string;
+    getAttributes(): UserAttributes;
     setAttribute(key: string, value: unknown): void;
     decide(
       key: string,

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -43,17 +43,17 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type OptimizelyFeature = import('./shared_types').OptimizelyFeature;
 
-  export type EventTags = import ('./shared_types').EventTags;
+  export type EventTags = import('./shared_types').EventTags;
 
-  export type Event = import ('./shared_types').Event;
+  export type Event = import('./shared_types').Event;
 
-  export type EventDispatcher = import ('./shared_types').EventDispatcher;
+  export type EventDispatcher = import('./shared_types').EventDispatcher;
 
-  export type DatafileOptions = import ('./shared_types').DatafileOptions;
+  export type DatafileOptions = import('./shared_types').DatafileOptions;
 
-  export type SDKOptions = import ('./shared_types').SDKOptions;
+  export type SDKOptions = import('./shared_types').SDKOptions;
 
-  export type OptimizelyOptions = import ('./shared_types').OptimizelyOptions;
+  export type OptimizelyOptions = import('./shared_types').OptimizelyOptions;
 
   export type UserProfileService = import('./shared_types').UserProfileService;
 
@@ -61,13 +61,39 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type ListenerPayload = import('./shared_types').ListenerPayload;
 
-  export type OptimizelyUserContext = import('./optimizely_user_context').default;
+  // export type OptimizelyUserContext = import('./optimizely_user_context').default;
 
-  export type OptimizelyDecision = import('./optimizely_decision').OptimizelyDecision;
+  export interface OptimizelyUserContext {
+    setAttribute(key: string, value: unknown): void;
+    decide(
+      key: string,
+      options: OptimizelyDecideOption[]
+    ): OptimizelyDecision;
+    decideForKeys(
+      keys: string[],
+      options: OptimizelyDecideOption[],
+    ): { [key: string]: OptimizelyDecision };
+    decideAll(
+      options: OptimizelyDecideOption[],
+    ): { [key: string]: OptimizelyDecision };
+    trackEvent(eventName: string, eventTags?: EventTags): void;
+  }
+
+  // export type OptimizelyDecision = import('./optimizely_decision').OptimizelyDecision;
+
+  export interface OptimizelyDecision {
+    variationKey: string | null;
+    enabled: boolean;
+    variables: { [variableKey: string]: unknown };
+    ruleKey: string | null;
+    flagKey: string;
+    userContext: OptimizelyUserContext;
+    reasons: string[];
+  }
 
   export enum OptimizelyDecideOption {
     DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT',
-    ENABLED_FLAGS_ONLY =  'ENABLED_FLAGS_ONLY',
+    ENABLED_FLAGS_ONLY = 'ENABLED_FLAGS_ONLY',
     IGNORE_USER_PROFILE_SERVICE = 'IGNORE_USER_PROFILE_SERVICE',
     INCLUDE_REASONS = 'INCLUDE_REASONS',
     EXCLUDE_VARIABLES = 'EXCLUDE_VARIABLES'

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -61,33 +61,9 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type ListenerPayload = import('./shared_types').ListenerPayload;
 
-  export interface OptimizelyUserContext {
-    getUserId(): string;
-    getAttributes(): UserAttributes;
-    setAttribute(key: string, value: unknown): void;
-    decide(
-      key: string,
-      options: OptimizelyDecideOption[]
-    ): OptimizelyDecision;
-    decideForKeys(
-      keys: string[],
-      options: OptimizelyDecideOption[],
-    ): { [key: string]: OptimizelyDecision };
-    decideAll(
-      options: OptimizelyDecideOption[],
-    ): { [key: string]: OptimizelyDecision };
-    trackEvent(eventName: string, eventTags?: EventTags): void;
-  }
+  export type OptimizelyDecision = import('./shared_types').OptimizelyDecision;
 
-  export interface OptimizelyDecision {
-    variationKey: string | null;
-    enabled: boolean;
-    variables: { [variableKey: string]: unknown };
-    ruleKey: string | null;
-    flagKey: string;
-    userContext: OptimizelyUserContext;
-    reasons: string[];
-  }
+  export type OptimizelyUserContext = import('./shared_types').OptimizelyUserContext;
 
   export enum OptimizelyDecideOption {
     DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT',

--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -61,8 +61,6 @@ declare module '@optimizely/optimizely-sdk' {
 
   export type ListenerPayload = import('./shared_types').ListenerPayload;
 
-  // export type OptimizelyUserContext = import('./optimizely_user_context').default;
-
   export interface OptimizelyUserContext {
     setAttribute(key: string, value: unknown): void;
     decide(
@@ -78,8 +76,6 @@ declare module '@optimizely/optimizely-sdk' {
     ): { [key: string]: OptimizelyDecision };
     trackEvent(eventName: string, eventTags?: EventTags): void;
   }
-
-  // export type OptimizelyDecision = import('./optimizely_decision').OptimizelyDecision;
 
   export interface OptimizelyDecision {
     variationKey: string | null;

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -26,9 +26,10 @@ import {
   FeatureFlag,
   FeatureVariable,
   OptimizelyOptions,
-  OptimizelyDecideOption
+  OptimizelyDecideOption,
+  OptimizelyDecision
 } from '../shared_types';
-import { OptimizelyDecision, newErrorDecision } from '../optimizely_decision';
+import { newErrorDecision } from '../optimizely_decision';
 import OptimizelyUserContext from '../optimizely_user_context';
 import { createProjectConfigManager, ProjectConfigManager } from '../core/project_config/project_config_manager';
 import { createNotificationCenter, NotificationCenter } from '../core/notification_center';

--- a/packages/optimizely-sdk/lib/optimizely_decision/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely_decision/index.ts
@@ -13,23 +13,7 @@
  * See the License for the specific language governing permissions and      *
  * limitations under the License.                                           *
  ***************************************************************************/
-import OptimizelyUserContext from '../optimizely_user_context';
-
-export interface OptimizelyDecision {
-  variationKey: string | null;
-  // The boolean value indicating if the flag is enabled or not
-  enabled: boolean;
-  // The collection of variables associated with the decision
-  variables: { [variableKey: string]: unknown };
-  // The rule key of the decision
-  ruleKey: string | null;
-  // The flag key for which the decision has been made for
-  flagKey: string;
-  // A copy of the user context for which the decision has been made for
-  userContext: OptimizelyUserContext;
-  // An array of error/info messages describing why the decision has been made.
-  reasons: string[];
-}
+import { OptimizelyUserContext, OptimizelyDecision } from '../shared_types';
 
 export function newErrorDecision(key: string, user: OptimizelyUserContext, reasons: string[]): OptimizelyDecision {
   return {

--- a/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely_user_context/index.ts
@@ -14,8 +14,12 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 import Optimizely from '../../lib/optimizely';
-import { UserAttributes, OptimizelyDecideOption, EventTags } from '../../lib/shared_types';
-import { OptimizelyDecision } from '../optimizely_decision';
+import {
+  UserAttributes,
+  OptimizelyDecideOption,
+  OptimizelyDecision,
+  EventTags
+} from '../../lib/shared_types';
 
 export default class OptimizelyUserContext {
   private optimizely: Optimizely;

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -249,3 +249,37 @@ export interface OptimizelyConfig {
   revision: string;
   getDatafile(): string;
 }
+
+export interface OptimizelyUserContext {
+  getUserId(): string;
+  getAttributes(): UserAttributes;
+  setAttribute(key: string, value: unknown): void;
+  decide(
+    key: string,
+    options: OptimizelyDecideOption[]
+  ): OptimizelyDecision;
+  decideForKeys(
+    keys: string[],
+    options: OptimizelyDecideOption[],
+  ): { [key: string]: OptimizelyDecision };
+  decideAll(
+    options: OptimizelyDecideOption[],
+  ): { [key: string]: OptimizelyDecision };
+  trackEvent(eventName: string, eventTags?: EventTags): void;
+}
+
+export interface OptimizelyDecision {
+  variationKey: string | null;
+  // The boolean value indicating if the flag is enabled or not
+  enabled: boolean;
+  // The collection of variables associated with the decision
+  variables: { [variableKey: string]: unknown };
+  // The rule key of the decision
+  ruleKey: string | null;
+  // The flag key for which the decision has been made for
+  flagKey: string;
+  // A copy of the user context for which the decision has been made for
+  userContext: OptimizelyUserContext;
+  // An array of error/info messages describing why the decision has been made.
+  reasons: string[];
+}


### PR DESCRIPTION
## Summary
To prevent users from compiling our TS source files, the type definitions file `index.d.ts` has been updated to exclude imports from our source files (`OptimizelyUserContext` and `OptimizelyDecision`).


## Test plan
Existing unit tests
## Issues

