### PR TITLE
fix:(event processor): Update ConversionEvent interface 

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Fixed
+- Update `ConversionEvent` interface to allow event `id` type null and `tags` type undefined.
+
 ## [0.8.1] - May 25th, 2021
 
 ### Fixed

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Optimizely
+ * Copyright 2019, 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -224,7 +224,7 @@ describe('buildEventV1', () => {
   })
 
   describe('buildConversionEventV1', () => {
-    it('should build an build a ConversionEventV1', () => {
+    it('should build an build a ConversionEventV1 when tags object is defined', () => {
       const conversionEvent: ConversionEvent = {
         type: 'conversion',
         timestamp: 69,
@@ -285,6 +285,164 @@ describe('buildEventV1', () => {
                       value: '123',
                       revenue: '1000',
                     },
+                    revenue: 1000,
+                    value: 123,
+                  },
+                ],
+              },
+            ],
+            visitor_id: 'userId',
+            attributes: [
+              {
+                entity_id: 'attr1-id',
+                key: 'attr1-key',
+                type: 'custom',
+                value: 'attr1-value',
+              },
+              {
+                entity_id: '$opt_bot_filtering',
+                key: '$opt_bot_filtering',
+                type: 'custom',
+                value: true,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should build an build a ConversionEventV1 when tags object is undefined', () => {
+      const conversionEvent: ConversionEvent = {
+        type: 'conversion',
+        timestamp: 69,
+        uuid: 'uuid',
+
+        context: {
+          accountId: 'accountId',
+          projectId: 'projectId',
+          clientName: 'node-sdk',
+          clientVersion: '3.0.0',
+          revision: 'revision',
+          botFiltering: true,
+          anonymizeIP: true,
+        },
+
+        user: {
+          id: 'userId',
+          attributes: [{ entityId: 'attr1-id', key: 'attr1-key', value: 'attr1-value' }],
+        },
+
+        event: {
+          id: 'event-id',
+          key: 'event-key',
+        },
+
+        tags: undefined,
+
+        revenue: 1000,
+        value: 123,
+      }
+
+      const result = buildConversionEventV1(conversionEvent)
+      expect(result).toEqual({
+        client_name: 'node-sdk',
+        client_version: '3.0.0',
+        account_id: 'accountId',
+        project_id: 'projectId',
+        revision: 'revision',
+        anonymize_ip: true,
+        enrich_decisions: true,
+
+        visitors: [
+          {
+            snapshots: [
+              {
+                events: [
+                  {
+                    entity_id: 'event-id',
+                    timestamp: 69,
+                    key: 'event-key',
+                    uuid: 'uuid',
+                    tags: undefined,
+                    revenue: 1000,
+                    value: 123,
+                  },
+                ],
+              },
+            ],
+            visitor_id: 'userId',
+            attributes: [
+              {
+                entity_id: 'attr1-id',
+                key: 'attr1-key',
+                type: 'custom',
+                value: 'attr1-value',
+              },
+              {
+                entity_id: '$opt_bot_filtering',
+                key: '$opt_bot_filtering',
+                type: 'custom',
+                value: true,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should build an build a ConversionEventV1 when event id is null', () => {
+      const conversionEvent: ConversionEvent = {
+        type: 'conversion',
+        timestamp: 69,
+        uuid: 'uuid',
+
+        context: {
+          accountId: 'accountId',
+          projectId: 'projectId',
+          clientName: 'node-sdk',
+          clientVersion: '3.0.0',
+          revision: 'revision',
+          botFiltering: true,
+          anonymizeIP: true,
+        },
+
+        user: {
+          id: 'userId',
+          attributes: [{ entityId: 'attr1-id', key: 'attr1-key', value: 'attr1-value' }],
+        },
+
+        event: {
+          id: null,
+          key: 'event-key',
+        },
+
+        tags: undefined,
+
+        revenue: 1000,
+        value: 123,
+      }
+
+      const result = buildConversionEventV1(conversionEvent)
+      expect(result).toEqual({
+        client_name: 'node-sdk',
+        client_version: '3.0.0',
+        account_id: 'accountId',
+        project_id: 'projectId',
+        revision: 'revision',
+        anonymize_ip: true,
+        enrich_decisions: true,
+
+        visitors: [
+          {
+            snapshots: [
+              {
+                events: [
+                  {
+                    entity_id: null,
+                    timestamp: 69,
+                    key: 'event-key',
+                    uuid: 'uuid',
+                    tags: undefined,
                     revenue: 1000,
                     value: 123,
                   },

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -224,7 +224,7 @@ describe('buildEventV1', () => {
   })
 
   describe('buildConversionEventV1', () => {
-    it('should build an build a ConversionEventV1 when tags object is defined', () => {
+    it('should build a ConversionEventV1 when tags object is defined', () => {
       const conversionEvent: ConversionEvent = {
         type: 'conversion',
         timestamp: 69,
@@ -311,7 +311,7 @@ describe('buildEventV1', () => {
       })
     })
 
-    it('should build an build a ConversionEventV1 when tags object is undefined', () => {
+    it('should build a ConversionEventV1 when tags object is undefined', () => {
       const conversionEvent: ConversionEvent = {
         type: 'conversion',
         timestamp: 69,
@@ -390,7 +390,7 @@ describe('buildEventV1', () => {
       })
     })
 
-    it('should build an build a ConversionEventV1 when event id is null', () => {
+    it('should build a ConversionEventV1 when event id is null', () => {
       const conversionEvent: ConversionEvent = {
         type: 'conversion',
         timestamp: 69,

--- a/packages/event-processor/src/events.ts
+++ b/packages/event-processor/src/events.ts
@@ -73,13 +73,13 @@ export interface ConversionEvent extends BaseEvent {
   }
 
   event: {
-    id: string
+    id: string | null
     key: string
   }
 
   revenue: number | null
   value: number | null
-  tags: EventTags
+  tags: EventTags | undefined
 }
 
 export type EventTags = {


### PR DESCRIPTION
## Summary
- Update `ConversionEvent` interface to allow event `id` type `null` and `tags` type `undefined`

The "why", or other context.

## Test plan
- Existing unit tests + added new tests
