### PR TITLE
Add interface DecisionListenerPayload

### DIFF
--- a/packages/optimizely-sdk/lib/index.d.ts
+++ b/packages/optimizely-sdk/lib/index.d.ts
@@ -202,6 +202,11 @@ declare module '@optimizely/optimizely-sdk' {
     eventTags: EventTags;
     logEvent: Event;
   }
+
+  export interface DecisionListenerPayload extends ListenerPayload {
+    type: string;
+    decisionInfo: OptimizelyDecision;
+  }
 }
 
 declare module '@optimizely/optimizely-sdk/lib/utils/enums' {


### PR DESCRIPTION
## Summary
- Added missing type for `DecisionListenerPayload`

I'm not sure what should be the correct type for `type` property.
[Beta version of docs](https://docs.developers.optimizely.com/full-stack/v4.0/docs/decision-notification-listener#section-parameters) says it's `flag` but [current version](https://docs.developers.optimizely.com/full-stack/docs/decision-notification-listener#section-type-parameter) states it can be many different strings. I couldn't find any union of enum for that, but maybe I'm missing something. 😉