### PR TITLE
feat: Use enum to define type in getTypeCastValue

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/index.ts
@@ -35,7 +35,8 @@ import {
   FeatureVariable,
   Variation,
   OptimizelyVariation,
-  VariationVariable,
+  VariableType,
+  VariationVariable
 } from '../../shared_types';
 
 interface TryCreatingProjectConfigConfig {
@@ -203,7 +204,7 @@ export const createProjectConfig = function(
       // Converting it to a first-class json type while creating Project Config
       feature.variables.forEach((variable) => {
         if (variable.type === FEATURE_VARIABLE_TYPES.STRING && variable.subType === FEATURE_VARIABLE_TYPES.JSON) {
-          variable.type = FEATURE_VARIABLE_TYPES.JSON;
+          variable.type = FEATURE_VARIABLE_TYPES.JSON as VariableType;
           delete variable.subType;
         }
       });
@@ -582,9 +583,10 @@ export const getVariableValueForVariation = function(
  * @returns {*}                       Variable value of the appropriate type, or
  *                                    null if the type cast failed
  */
+
 export const getTypeCastValue = function(
   variableValue: string,
-  variableType: string,
+  variableType: VariableType,
   logger: LogHandler
 ): unknown {
   let castValue;

--- a/packages/optimizely-sdk/lib/core/project_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/index.ts
@@ -583,7 +583,6 @@ export const getVariableValueForVariation = function(
  * @returns {*}                       Variable value of the appropriate type, or
  *                                    null if the type cast failed
  */
-
 export const getTypeCastValue = function(
   variableValue: string,
   variableType: VariableType,

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -124,8 +124,16 @@ export interface Experiment {
   forcedVariations?: { [key: string]: string };
 }
 
+export enum VariableType {
+  BOOLEAN = 'boolean',
+  DOUBLE = 'double',
+  INTEGER = 'integer',
+  STRING = 'string',
+  JSON = 'json',
+}
+
 export interface FeatureVariable {
-  type: string;
+  type: VariableType;
   key: string;
   id: string;
   defaultValue: string;


### PR DESCRIPTION
## Summary
Use enum to define type in getTypeCastValue in project_config


## Issues
