### PR TITLE
feat: Added React Native Client Engines to be sent in events

### DIFF
--- a/packages/optimizely-sdk/lib/index.react_native.tests.js
+++ b/packages/optimizely-sdk/lib/index.react_native.tests.js
@@ -92,7 +92,7 @@ describe('javascript-sdk/react-native', function() {
         assert.equal(optlyInstance.clientVersion, '4.6.2');
       });
 
-      it('should set the Javascript client engine and version', function() {
+      it('should set the React Native JS client engine and javascript SDK version', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           datafile: {},
           errorHandler: fakeErrorHandler,
@@ -101,11 +101,11 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('javascript-sdk', optlyInstance.clientEngine);
+        assert.equal('react-native-js-sdk', optlyInstance.clientEngine);
         assert.equal(packageJSON.version, optlyInstance.clientVersion);
       });
 
-      it('should allow passing of "react-sdk" as the clientEngine', function() {
+      it('should allow passing of "react-sdk" as the clientEngine and convert it to "react-native-sdk"', function() {
         var optlyInstance = optimizelyFactory.createInstance({
           clientEngine: 'react-sdk',
           datafile: {},
@@ -115,7 +115,7 @@ describe('javascript-sdk/react-native', function() {
         });
         // Invalid datafile causes onReady Promise rejection - catch this error
         optlyInstance.onReady().catch(function() {});
-        assert.equal('react-sdk', optlyInstance.clientEngine);
+        assert.equal('react-native-sdk', optlyInstance.clientEngine);
       });
 
       it('should activate with provided event dispatcher', function() {

--- a/packages/optimizely-sdk/lib/index.react_native.ts
+++ b/packages/optimizely-sdk/lib/index.react_native.ts
@@ -84,7 +84,7 @@ const createInstance = function(config: SDKOptions): Optimizely | null {
     }
 
     const optimizelyOptions = {
-      clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
+      clientEngine: enums.REACT_NATIVE_JS_CLIENT_ENGINE,
       eventDispatcher: defaultEventDispatcher,
       eventMaxQueueSize: DEFAULT_EVENT_MAX_QUEUE_SIZE,
       ...config,
@@ -93,6 +93,11 @@ const createInstance = function(config: SDKOptions): Optimizely | null {
       logger: logger,
       errorHandler: getErrorHandler()
     };
+
+    // If client engine is react, convert it to react native.
+    if (optimizelyOptions.clientEngine === enums.REACT_CLIENT_ENGINE) {
+      optimizelyOptions.clientEngine = enums.REACT_NATIVE_CLIENT_ENGINE;
+    }
 
     return new Optimizely(optimizelyOptions);
   } catch (e) {

--- a/packages/optimizely-sdk/lib/utils/enums/index.ts
+++ b/packages/optimizely-sdk/lib/utils/enums/index.ts
@@ -176,12 +176,16 @@ export const CONTROL_ATTRIBUTES = {
 export const JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 export const NODE_CLIENT_ENGINE = 'node-sdk';
 export const REACT_CLIENT_ENGINE = 'react-sdk';
+export const REACT_NATIVE_CLIENT_ENGINE = 'react-native-sdk';
+export const REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
 export const NODE_CLIENT_VERSION = '4.6.2';
 
 export const VALID_CLIENT_ENGINES = [
   NODE_CLIENT_ENGINE,
   REACT_CLIENT_ENGINE,
   JAVASCRIPT_CLIENT_ENGINE,
+  REACT_NATIVE_CLIENT_ENGINE,
+  REACT_NATIVE_JS_CLIENT_ENGINE,
 ];
 
 export const NOTIFICATION_TYPES = notificationTypesEnum;


### PR DESCRIPTION
## Summary
Added Two new client engine values to be sent in events.

**react-native-sdk**: Client name will be set to `react-native-sdk` when a react native application will use react sdk i.e `@optimizely/react-sdk`.

**react-native-js-sdk**: Client name will be set to `react-native-js-sdk` when a react native application will use javascript sdk directly i.e `@optimizely/optimizely-sdk`.

### Client Versions
Client versions behave the way they did without any change. Current behaviour is.
1. When a react native app uses javascript SDK directly, clientVersion will be the version of javascript SDK. Which means `react-native-js-sdk` goes with `clientVersion` of javascript SDK.
2. When a react native app uses React SDK, clientVersion will be the version passed in by react SDK. This means `react-native-sdk` goes with `clientVersion` of react SDK. 

## Test plan
Made appropriate changes to already existing unit tests.