### PR TITLE
Removed OptimizelyConfig creation from SDK initialization to reduce intialization time

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.tests.js
@@ -425,8 +425,6 @@ describe('lib/core/project_config/project_config_manager', function() {
           datafile: testData.getTestProjectConfig(),
           sdkKey: '12345',
         });
-        // creating optimizely config once project config manager for the first time
-        sinon.assert.calledOnce(optimizelyConfig.createOptimizelyConfig);
         // validate it should return the existing optimizely config
         manager.getOptimizelyConfig();
         sinon.assert.calledOnce(optimizelyConfig.createOptimizelyConfig);
@@ -437,6 +435,7 @@ describe('lib/core/project_config/project_config_manager', function() {
         newDatafile.revision = '36';
         fakeDatafileManager.get.returns(newDatafile);
         updateListener({ datafile: newDatafile });
+        manager.getOptimizelyConfig();        
         // verify the optimizely config is updated
         sinon.assert.calledTwice(optimizelyConfig.createOptimizelyConfig);
       });

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
@@ -214,7 +214,7 @@ export class ProjectConfigManager {
       const oldRevision = this.configObj ? this.configObj.revision : 'null';
       if (configObj && oldRevision !== configObj.revision) {
         this.configObj = configObj;
-        this.optimizelyConfigObj = createOptimizelyConfig(this.configObj, toDatafile(this.configObj));
+        this.optimizelyConfigObj = null;
         this.updateListeners.forEach((listener) => listener(configObj));
       }
     }
@@ -236,6 +236,9 @@ export class ProjectConfigManager {
    * @return {OptimizelyConfig|null}
    */
   getOptimizelyConfig(): OptimizelyConfig | null {
+    if (!this.optimizelyConfigObj && this.configObj) {
+      this.optimizelyConfigObj = createOptimizelyConfig(this.configObj, toDatafile(this.configObj));
+    }
     return this.optimizelyConfigObj;
   }
 


### PR DESCRIPTION
## Summary
`OptimizelyConfig` object is created during initialization of `Optimizely` Instance. This almost doubles the initialization time for the SDK. This PR moves the creation of `OptimizelyConfig` object to `getOptimizelyConfig`. The `OptimizelyConfig` object will be created and cached when the `getOptimizelyConfig` API is called for the first time after every data file update.

## Test plan
- Manually tested thoroughly
- Updated unit tests
- All FSC test pass
