### PR TITLE
chore: prepare for 0.3.0 release of logging package 

### DIFF
--- a/packages/logging/CHANGELOG.MD
+++ b/packages/logging/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.3.0] - October 8, 2021
+
+### New Features
+- Upgraded `@optimizely/js-sdk-utils` package to version `0.4.0`
+
 ## [0.2.0] - October 6, 2021
 
 ### New Features

--- a/packages/logging/package-lock.json
+++ b/packages/logging/package-lock.json
@@ -33,9 +33,9 @@
 			}
 		},
 		"@optimizely/js-sdk-utils": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.1.0.tgz",
-			"integrity": "sha512-p7499GgVaX94YmkrwOiEtLgxgjXTPbUQsvETaAil5J7zg1TOA4Wl8ClalLSvCh+AKWkxGdkL4/uM/zfbxPSNNw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.4.0.tgz",
+			"integrity": "sha512-QG2oytnITW+VKTJK+l0RxjaS5VrA6W+AZMzpeg4LCB4Rn4BEKtF+EcW/5S1fBDLAviGq/0TLpkjM3DlFkJ9/Gw==",
 			"requires": {
 				"uuid": "^3.3.2"
 			}

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@optimizely/js-sdk-utils": "^0.1.0"
+    "@optimizely/js-sdk-utils": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^23.3.12",


### PR DESCRIPTION
## Summary

- upgraded js-sdk-utils package to v0.4.0 
- prepared for 0.3.0 release 