### PR TITLE
prep for release 0.9.0 for event processor and datafile manager.

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.0] - October 8, 2021
+
+### Changed
+- Update `@optimizely/js-sdk-logging` to `0.3.0`.
+
 ## [0.8.1] - May 25, 2021
 
 ### Fixed

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -884,21 +884,11 @@
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.1.0.tgz",
-      "integrity": "sha512-Bs2zHvsdNIk2QSg05P6mKIlROHoBIRNStbrVwlePm603CucojKRPlFJG4rt7sFZQOo8xS8I7z1BmE4QI3/ZE9A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.0.tgz",
+      "integrity": "sha512-A83iEAevHmHKjqrDqMqGEBHUGNfr07cZewHPz8qeHHbfwXq2lfc0g/G7XmgXFGG4anI9oTCNMN1IjUs2Locgxg==",
       "requires": {
-        "@optimizely/js-sdk-utils": "^0.1.0"
-      },
-      "dependencies": {
-        "@optimizely/js-sdk-utils": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.1.0.tgz",
-          "integrity": "sha512-p7499GgVaX94YmkrwOiEtLgxgjXTPbUQsvETaAil5J7zg1TOA4Wl8ClalLSvCh+AKWkxGdkL4/uM/zfbxPSNNw==",
-          "requires": {
-            "uuid": "^3.3.2"
-          }
-        }
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-utils": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Optimizely Full Stack Datafile Manager",
   "repository": {
     "type": "git",
@@ -48,7 +48,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@optimizely/js-sdk-logging": "^0.1.0",
+    "@optimizely/js-sdk-logging": "^0.3.0",
     "@optimizely/js-sdk-utils": "^0.4.0",
     "decompress-response": "^4.2.1"
   },

--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.0] - October 8, 2021
+
+### Changed
+- Update `@optimizely/js-sdk-logging` to `0.3.0`.
+
 ## [0.8.2] - June 14th, 2021
 
 ### Fixed

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -50,21 +50,11 @@
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.1.0.tgz",
-      "integrity": "sha512-Bs2zHvsdNIk2QSg05P6mKIlROHoBIRNStbrVwlePm603CucojKRPlFJG4rt7sFZQOo8xS8I7z1BmE4QI3/ZE9A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.0.tgz",
+      "integrity": "sha512-A83iEAevHmHKjqrDqMqGEBHUGNfr07cZewHPz8qeHHbfwXq2lfc0g/G7XmgXFGG4anI9oTCNMN1IjUs2Locgxg==",
       "requires": {
-        "@optimizely/js-sdk-utils": "^0.1.0"
-      },
-      "dependencies": {
-        "@optimizely/js-sdk-utils": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.1.0.tgz",
-          "integrity": "sha512-p7499GgVaX94YmkrwOiEtLgxgjXTPbUQsvETaAil5J7zg1TOA4Wl8ClalLSvCh+AKWkxGdkL4/uM/zfbxPSNNw==",
-          "requires": {
-            "uuid": "^3.3.2"
-          }
-        }
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-utils": {

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Optimizely Full Stack Event Processor",
   "author": "jordangarcia <jordan@optimizely.com>",
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/event-processor",
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@optimizely/js-sdk-logging": "^0.1.0",
+    "@optimizely/js-sdk-logging": "^0.3.0",
     "@optimizely/js-sdk-utils": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
1. update datafile-manager and event-processor to use `@optimizely/js-sdk-logging 0.3.0`.
2. Prep for release `0.9.0` for `@optimizely/js-sdk-datafile-manager` and `optimizely/js-sdk-event-processor`.

## Test plan
All existing tests pass