### PR TITLE
fix stubbing issues and prep for release `0.3.1` for logging package

### DIFF
--- a/packages/logging/CHANGELOG.MD
+++ b/packages/logging/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.3.1] - October 13, 2021
+
+### Bug Fixes
+- Downgrade typescript version to `3.8.x` due to stubbing issues.
+
 ## [0.3.0] - October 8, 2021
 
 ### New Features

--- a/packages/logging/package-lock.json
+++ b/packages/logging/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@optimizely/js-sdk-logging",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5221,9 +5221,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-logging",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Optimizely Full Stack Core Logging",
   "author": "jordangarcia <jordan@optimizely.com>",
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/logging",
@@ -44,6 +44,6 @@
     "@types/jest": "^23.3.12",
     "jest": "^23.6.0",
     "ts-jest": "^23.10.5",
-    "typescript": "^4.0.3"
+    "typescript": "3.8.x"
   }
 }


### PR DESCRIPTION
## Summary
Upgrading to latest typescript version is causing stubbing issues and failing some unit tests. Downgrading the typescript version to `3.8.x` temporarily to fix this.

## Test plan
- Manually tested thoroughly.
-  All existing tests pass
