### PR TITLE
fix stubbing issues and prep for release 0.9.1 for datafile manager and event processor packages

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.1] - October 13, 2021
+
+### Fixed
+- Downgrade version of typescript to `3.8.x` to fix stubbing issue.
+- Update version of logging to `0.3.1` to fix stubbing issue.
+
 ## [0.9.0] - October 8, 2021
 
 ### Changed

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -884,9 +884,9 @@
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.0.tgz",
-      "integrity": "sha512-A83iEAevHmHKjqrDqMqGEBHUGNfr07cZewHPz8qeHHbfwXq2lfc0g/G7XmgXFGG4anI9oTCNMN1IjUs2Locgxg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.1.tgz",
+      "integrity": "sha512-K71Jf283FP0E4oXehcXTTM3gvgHZHr7FUrIsw//0mdJlotHJT4Nss4hE0CWPbBxO7LJAtwNnO+VIA/YOcO4vHg==",
       "requires": {
         "@optimizely/js-sdk-utils": "^0.4.0"
       }
@@ -5127,9 +5127,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "universalify": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Optimizely Full Stack Datafile Manager",
   "repository": {
     "type": "git",
@@ -45,10 +45,10 @@
     "nock": "^10.0.6",
     "prettier": "^1.19.1",
     "ts-jest": "^27.0.1",
-    "typescript": "^4.0.3"
+    "typescript": "3.8.x"
   },
   "dependencies": {
-    "@optimizely/js-sdk-logging": "^0.3.0",
+    "@optimizely/js-sdk-logging": "^0.3.1",
     "@optimizely/js-sdk-utils": "^0.4.0",
     "decompress-response": "^4.2.1"
   },

--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.1] - October 13, 2021
+
+### Fixed
+- Update version of logging to `0.3.1` to fix stubbing issue.
+
 ## [0.9.0] - October 8, 2021
 
 ### Changed

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -50,9 +50,9 @@
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.0.tgz",
-      "integrity": "sha512-A83iEAevHmHKjqrDqMqGEBHUGNfr07cZewHPz8qeHHbfwXq2lfc0g/G7XmgXFGG4anI9oTCNMN1IjUs2Locgxg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.1.tgz",
+      "integrity": "sha512-K71Jf283FP0E4oXehcXTTM3gvgHZHr7FUrIsw//0mdJlotHJT4Nss4hE0CWPbBxO7LJAtwNnO+VIA/YOcO4vHg==",
       "requires": {
         "@optimizely/js-sdk-utils": "^0.4.0"
       }

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Optimizely Full Stack Event Processor",
   "author": "jordangarcia <jordan@optimizely.com>",
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/event-processor",
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@optimizely/js-sdk-logging": "^0.3.0",
+    "@optimizely/js-sdk-logging": "^0.3.1",
     "@optimizely/js-sdk-utils": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Upgrading to latest typescript version is causing stubbing issues and failing some unit tests. Downgrading the typescript version to `3.8.x` temporarily to fix this. Also updated the version of `logging` to `0.3.1` which downgrades typescript version in that package

## Test plan
- Manually tested thoroughly.
-  All existing tests pass
