### PR TITLE
fix: impression event attributes exp, var should be empty instead of null

### DIFF
--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.2] - November 3, 2021
+
+### Fixed
+- Impression event should send empty `experimentId` and `variationKey` instead of `null` when no `experiment` or `variation` is found.
+
 ## [0.9.1] - October 13, 2021
 
 ### Fixed

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -182,7 +182,7 @@ describe('buildEventV1', () => {
                   {
                     campaign_id: null,
                     experiment_id: "",
-                    variation_id: null,
+                    variation_id: "",
                     metadata: {
                       flag_key: 'flagKey1',
                       rule_key: '',

--- a/packages/event-processor/__tests__/buildEventV1.spec.ts
+++ b/packages/event-processor/__tests__/buildEventV1.spec.ts
@@ -181,7 +181,7 @@ describe('buildEventV1', () => {
                 decisions: [
                   {
                     campaign_id: null,
-                    experiment_id: null,
+                    experiment_id: "",
                     variation_id: null,
                     metadata: {
                       flag_key: 'flagKey1',

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Optimizely Full Stack Event Processor",
   "author": "jordangarcia <jordan@optimizely.com>",
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/event-processor",

--- a/packages/event-processor/src/v1/buildEventV1.ts
+++ b/packages/event-processor/src/v1/buildEventV1.ts
@@ -146,8 +146,8 @@ function makeConversionSnapshot(conversion: ConversionEvent): Visitor.Snapshot {
 function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
   const { layer, experiment, variation, ruleKey, flagKey, ruleType, enabled } = event
   let layerId = layer ? layer.id : null
-  let experimentId = experiment ? experiment.id : null
-  let variationId = variation ? variation.id : null
+  let experimentId = experiment ? (experiment.id ? experiment.id : '') : ''
+  let variationId = variation ? variation.id : ''
   let variationKey = variation ? variation.key : ''
 
   return {

--- a/packages/event-processor/src/v1/buildEventV1.ts
+++ b/packages/event-processor/src/v1/buildEventV1.ts
@@ -146,8 +146,8 @@ function makeConversionSnapshot(conversion: ConversionEvent): Visitor.Snapshot {
 function makeDecisionSnapshot(event: ImpressionEvent): Visitor.Snapshot {
   const { layer, experiment, variation, ruleKey, flagKey, ruleType, enabled } = event
   let layerId = layer ? layer.id : null
-  let experimentId = experiment ? (experiment.id ? experiment.id : '') : ''
-  let variationId = variation ? variation.id : ''
+  let experimentId = experiment?.id ?? ''
+  let variationId = variation?.id ?? ''
   let variationKey = variation ? variation.key : ''
 
   return {


### PR DESCRIPTION
## Summary
- experimentId and variationId should be empty if no variation or experiment is found.

## Test plan
- Manually tested
- All tests pass
