### PR TITLE
fix: Fixed typescript compilation issue introduced by `4.9.0`

### DIFF
--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -18,8 +18,6 @@ import { EventProcessor } from '@optimizely/js-sdk-event-processor';
 
 import { NotificationCenter } from '@optimizely/js-sdk-utils';
 
-import { ProjectConfig } from './core/project_config';
-
 export interface BucketerParams {
   experimentId: string;
   experimentKey: string;


### PR DESCRIPTION
## Summary
`4.9.0` introduced a typescript compilation issue due to an unused import. This PR fixes that.

## Test plan
All unit, cross browser and full stack compatibility tests pass.

## Issues
"Fixes #732"
