### PR TITLE
refactor: Made react native dependencies optional

### DIFF
--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -904,6 +904,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
       "integrity": "sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "deep-assign": "^3.0.0"
       }
@@ -1732,6 +1733,7 @@
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
       "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -2656,7 +2658,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -52,7 +52,7 @@
     "@optimizely/js-sdk-utils": "^0.4.0",
     "decompress-response": "^4.2.1"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "@react-native-async-storage/async-storage": "^1.2.0"
   },
   "scripts": {

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -70,15 +70,17 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
       "integrity": "sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "deep-assign": "^3.0.0"
       }
     },
     "@react-native-community/netinfo": {
-      "version": "5.9.5",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.5.tgz",
-      "integrity": "sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==",
-      "dev": true
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.4.tgz",
+      "integrity": "sha512-mb664NOqPvyUZ4TznzdYEfdS3OhSXWGbZprgsDZn4THw2X/4wcBFcBUeWuMzeQ56KhY0rm/YBBlZWHrSf3C/Aw==",
+      "dev": true,
+      "optional": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -1280,6 +1282,7 @@
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
       "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -2228,7 +2231,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^23.10.5",
     "typescript": "^4.0.3"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "@react-native-community/netinfo": "5.9.4",
     "@react-native-async-storage/async-storage": "^1.2.0"
   }


### PR DESCRIPTION
## Summary
Made the following dependencies optional in `datafile-manager` and `event-processor` packages.
`@react-native-community/async-storage`
`@react-native-community/netinfo`

## Test Plan
- Manually tested thoroughly
- All tests pass 
