### PR TITLE
revert #735 and prep for release 0.9.3 for `js-sdk-datafile-manager` and 0.9.4 for `js-sdk-event-processor`

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.3] - January 31, 2022
+
+### Changed
+- Reverted changes in `0.9.2` and made `@react-native-async-storage/async-storage` a peer dependency again. Making it an optional dependency did not work as expected.
+
 ## [0.9.2] - January 28, 2022
 
 ### Changed

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -904,7 +904,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
       "integrity": "sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "deep-assign": "^3.0.0"
       }
@@ -1733,7 +1732,6 @@
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
       "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -2658,8 +2656,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -52,7 +52,7 @@
     "@optimizely/js-sdk-utils": "^0.4.0",
     "decompress-response": "^4.2.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.2.0"
   },
   "scripts": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Optimizely Full Stack Datafile Manager",
   "repository": {
     "type": "git",

--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.4] - January 31, 2022
+
+### Changed
+- Reverted changes in `0.9.3`. Changed these back to peer dependencies. Making them optional did not work as expected.
+  - `@react-native-async-storage/async-storage`
+  - `@react-native-community/netinfo`
+
 ## [0.9.3] - January 28, 2022
 
 ### Changed

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -70,17 +70,15 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
       "integrity": "sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "deep-assign": "^3.0.0"
       }
     },
     "@react-native-community/netinfo": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.4.tgz",
-      "integrity": "sha512-mb664NOqPvyUZ4TznzdYEfdS3OhSXWGbZprgsDZn4THw2X/4wcBFcBUeWuMzeQ56KhY0rm/YBBlZWHrSf3C/Aw==",
-      "dev": true,
-      "optional": true
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.5.tgz",
+      "integrity": "sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -1282,7 +1280,6 @@
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
       "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -2231,8 +2228,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/packages/event-processor/package-lock.json
+++ b/packages/event-processor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-event-processor",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Optimizely Full Stack Event Processor",
   "author": "jordangarcia <jordan@optimizely.com>",
   "homepage": "https://github.com/optimizely/javascript-sdk/tree/master/packages/event-processor",

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^23.10.5",
     "typescript": "^4.0.3"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@react-native-community/netinfo": "5.9.4",
     "@react-native-async-storage/async-storage": "^1.2.0"
   }


### PR DESCRIPTION
## Summary
React native dependencies were converted from `peer` to `optional` in `js-sd-datafile-manager` version `0.9.2` and `js-sdk-event-processor` version `0.9.3`. After releasing, it appeared that they did not work as expected. This PR reverts back that change which was made in #735 and updates changelog and npm version to make new releases for both the packages.

## Test plan
- Manually tested.
- All unit tests pass
