### PR TITLE
fix: made React Native peer dependencies optional and prep for release `0.9.4` for `js-sdk-datafile-manager` and `0.9.5` for `js-sdk-event-processor`

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.4] - February 2, 2022
+
+### Changed
+- Made `@react-native-async-storage/async-storage` an optional peer dependency.
+
 ## [0.9.3] - January 31, 2022
 
 ### Changed

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -55,6 +55,11 @@
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.2.0"
   },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    }
+  },
   "scripts": {
     "lint": "tsc --noEmit && eslint --fix 'src/**/*.ts' '__test__/**/*.ts'",
     "test": "jest",

--- a/packages/event-processor/CHANGELOG.MD
+++ b/packages/event-processor/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.5] - February 2, 2022
+
+### Changed
+- Made these react native peer dependencies optional.
+  - `@react-native-async-storage/async-storage`
+  - `@react-native-community/netinfo`
+
 ## [0.9.4] - January 31, 2022
 
 ### Changed

--- a/packages/event-processor/package.json
+++ b/packages/event-processor/package.json
@@ -54,5 +54,13 @@
   "peerDependencies": {
     "@react-native-community/netinfo": "5.9.4",
     "@react-native-async-storage/async-storage": "^1.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    },
+    "@react-native-community/netinfo": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
Made the following peer dependencies optional in `datafile-manager` and `event-processor` packages.
`@react-native-community/async-storage`
`@react-native-community/netinfo`

## Test Plan
- Manually tested thoroughly
- All tests pass 
