### PR TITLE
feat: add support for ignoring forced variation validation

### DIFF
--- a/packages/optimizely-sdk/lib/core/decision_service/index.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.ts
@@ -832,32 +832,48 @@ export class DecisionService {
           ])
         }
       } else {
-        if (ruleKey) {
+        if (!config.validateForcedVariations) {
           this.logger.log(
             LOG_LEVEL.INFO,
-            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_RULE_SPECIFIED_BUT_INVALID,
+            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED,
+            variationKey,
             flagKey,
-            ruleKey,
             userId
           );
           decideReasons.push([
-            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_RULE_SPECIFIED_BUT_INVALID,
+            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED,
+            variationKey,
             flagKey,
-            ruleKey,
-            userId
+            userId,
           ]);
         } else {
-          this.logger.log(
-            LOG_LEVEL.INFO,
-            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED_BUT_INVALID,
-            flagKey,
-            userId
-          );
-          decideReasons.push([
-            LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED_BUT_INVALID,
-            flagKey,
-            userId
-          ])
+          if (ruleKey) {
+            this.logger.log(
+              LOG_LEVEL.INFO,
+              LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_RULE_SPECIFIED_BUT_INVALID,
+              flagKey,
+              ruleKey,
+              userId
+            );
+            decideReasons.push([
+              LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_RULE_SPECIFIED_BUT_INVALID,
+              flagKey,
+              ruleKey,
+              userId,
+            ]);
+          } else {
+            this.logger.log(
+              LOG_LEVEL.INFO,
+              LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED_BUT_INVALID,
+              flagKey,
+              userId
+            );
+            decideReasons.push([
+              LOG_MESSAGES.USER_HAS_FORCED_DECISION_WITH_NO_RULE_SPECIFIED_BUT_INVALID,
+              flagKey,
+              userId,
+            ]);
+          }
         }
       }
     }

--- a/packages/optimizely-sdk/lib/core/project_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/index.ts
@@ -50,6 +50,7 @@ interface TryCreatingProjectConfigConfig {
     validate(jsonObject: unknown): boolean,
   };
   logger: LogHandler;
+  validateForcedVariations?: boolean;
 }
 
 interface Event {
@@ -95,6 +96,7 @@ export interface ProjectConfig {
   accountId: string;
   flagRulesMap: { [key: string]: Experiment[] };
   flagVariationsMap: { [key: string]: Variation[] };
+  validateForcedVariations: boolean;
 }
 
 const EXPERIMENT_RUNNING_STATUS = 'Running';
@@ -142,9 +144,12 @@ function createMutationSafeDatafileCopy(datafile: any): ProjectConfig {
  */
 export const createProjectConfig = function(
   datafileObj?: JSON,
-  datafileStr: string | null = null
+  datafileStr: string | null = null,
+  validateForcedVariations = true
 ): ProjectConfig {
   const projectConfig = createMutationSafeDatafileCopy(datafileObj);
+
+  projectConfig.validateForcedVariations = validateForcedVariations;
 
   projectConfig.__datafileStr = datafileStr === null ? JSON.stringify(datafileObj) : datafileStr;
 

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
@@ -29,12 +29,13 @@ const logger = getLogger();
 const MODULE_NAME = 'PROJECT_CONFIG_MANAGER';
 
 interface ProjectConfigManagerConfig {
-  datafile?: string,
+  datafile?: string;
   jsonSchemaValidator?: {
-    validate(jsonObject: unknown): boolean,
+    validate(jsonObject: unknown): boolean;
   };
-  sdkKey?: string,
-  datafileManager?: DatafileManager
+  sdkKey?: string;
+  datafileManager?: DatafileManager;
+  validateForcedVariations?: boolean;
 }
 
 /**
@@ -66,6 +67,7 @@ export class ProjectConfigManager {
   private readyPromise: Promise<OnReadyResult>;
   public jsonSchemaValidator: { validate(jsonObject: unknown): boolean } | undefined;
   public datafileManager: DatafileManager | null = null;
+  private validateForcedVariations = true;
 
   constructor(config: ProjectConfigManagerConfig) {
     try {
@@ -102,6 +104,10 @@ export class ProjectConfigManager {
           success: false,
           reason: getErrorMessage(handleNewDatafileException, 'Invalid datafile'),
         });
+      }
+
+      if (config.validateForcedVariations === false) {
+        this.validateForcedVariations = config.validateForcedVariations;
       }
     } catch (ex) {
       logger.error(ex);
@@ -176,7 +182,8 @@ export class ProjectConfigManager {
     const { configObj, error } = tryCreatingProjectConfig({
       datafile: newDatafile,
       jsonSchemaValidator: this.jsonSchemaValidator,
-      logger: logger
+      logger: logger,
+      validateForcedVariations: this.validateForcedVariations,
     });
 
     if (error) {

--- a/packages/optimizely-sdk/lib/index.browser.ts
+++ b/packages/optimizely-sdk/lib/index.browser.ts
@@ -115,7 +115,9 @@ const createInstance = function(config: SDKOptions): Optimizely | null {
       batchSize: eventBatchSize,
       maxQueueSize:  config.eventMaxQueueSize || DEFAULT_EVENT_MAX_QUEUE_SIZE,
       notificationCenter,
-    }
+    };
+
+    const { validateForcedVariations } = config;
 
     const optimizelyOptions = {
       clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
@@ -125,6 +127,7 @@ const createInstance = function(config: SDKOptions): Optimizely | null {
       errorHandler,
       datafileManager: config.sdkKey ? createHttpPollingDatafileManager(config.sdkKey, logger, config.datafile, config.datafileOptions) : undefined,
       notificationCenter,
+      validateForcedVariations,
     };
 
     const optimizely = new Optimizely(optimizelyOptions);

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -293,6 +293,8 @@ export interface SDKOptions {
   userProfileService?: UserProfileService;
   // dafault options for decide API
   defaultDecideOptions?: OptimizelyDecideOption[];
+  // validate if variation is in datafile or not when forcing variation
+  validateForcedVariations?: boolean;
 }
 
 export type OptimizelyExperimentsMap = {


### PR DESCRIPTION
## Summary
- Add support for ignoring validation when getting forced variations

## Background

In order to support forcing variations, regardless of rules, we need a way to ignore the validation against the datafile that is currently happening. Our use case for this is to use forced decisions in our automated E2E and unit tests. Right now the test becomes flaky since they are dependent on the configuration of the datafile and we want to avoid having to mock the datafile.

