### PR TITLE
chore: Ship unminified file as ESM entrypoint

### DIFF
--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@optimizely/optimizely-sdk",
   "version": "4.9.1",
   "description": "JavaScript SDK for Optimizely X Full Stack",
-  "module": "dist/optimizely.browser.es.min.js",
+  "module": "dist/optimizely.browser.es.js",
   "main": "dist/optimizely.node.min.js",
   "browser": "dist/optimizely.browser.min.js",
   "react-native": "dist/optimizely.react_native.min.js",


### PR DESCRIPTION
## Background

This PR is copied from [484](https://github.com/optimizely/javascript-sdk/pull/484). It was contributed by @jasonkarns a couple of years ago. I just pulled his changes, merged master and resolved conflicts.

## Summary

ESM entrypoints are very very likely to be consumed by bundlers, not loaded directly into browsers. Therefore it is preferable that the bundlers have access to the unminified source so that consumers can have more control over the final output.

~~This change _adds_ an ESM output bundle that is not minified with terser.~~ (https://github.com/optimizely/javascript-sdk/pull/477 has merged which also adds the unminified ES bundle, so this PR now just makes the unminified bundle the `module` entrypoint.)
Notably, the unminified bundle is created _in addition to_ the minified bundle;
so the minified bundle is still distributed with the package (at the same output location).

This way users who do actually want the minified bundle may still use it.

However, the `package.json#module` entrypoint is changed to reference the unminified bundle, as this is most likely what users will want when consuming from a bundler. (And bundlers are virtually the exclusive consumers of the `module` entrypoint.)