### PR TITLE
datafile-manager: typescript types file path updated in package.json

### DIFF
--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
-## [0.9.5] - June 2, 2022
+## [0.9.5] - June 6, 2022
 
 ### Changed
-- Changed types file path from `lib/index.d.ts` to `lib/index.node.d.ts`.
+- Changed typescript types file path from `lib/index.d.ts` to `lib/index.node.d.ts`.
 
 ## [0.9.4] - February 2, 2022
 

--- a/packages/datafile-manager/CHANGELOG.md
+++ b/packages/datafile-manager/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [0.9.5] - June 2, 2022
+
+### Changed
+- Changed types file path from `lib/index.d.ts` to `lib/index.node.d.ts`.
+
 ## [0.9.4] - February 2, 2022
 
 ### Changed

--- a/packages/datafile-manager/package-lock.json
+++ b/packages/datafile-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/datafile-manager/package.json
+++ b/packages/datafile-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/js-sdk-datafile-manager",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Optimizely Full Stack Datafile Manager",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   "main": "lib/index.node.js",
   "browser": "lib/index.browser.js",
   "react-native": "lib/index.react_native.js",
-  "types": "lib/index.d.ts",
+  "types": "lib/index.node.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__test__"


### PR DESCRIPTION
## Summary
- Updated typescript types file path from `lib/index.d.ts` to `lib/index.node.d.ts` in package.json
- Prep for release `0.9.5` for datafile manager

## Test plan
All existing tests pass

