### PR TITLE
hellofresh: use map instead of object

### DIFF
--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.tests.js
@@ -66,12 +66,12 @@ var conditionsPassingWithNoAttrs = [
 var conditionsPassingWithNoAttrsAudience = {
   conditions: conditionsPassingWithNoAttrs,
 };
-var audiencesById = {
-  0: chromeUserAudience,
-  1: iphoneUserAudience,
-  2: conditionsPassingWithNoAttrsAudience,
-  3: specialConditionTypeAudience,
-};
+var audiencesById = new Map([
+  ['0', chromeUserAudience],
+  ['1', iphoneUserAudience],
+  ['2', conditionsPassingWithNoAttrsAudience],
+  ['3', specialConditionTypeAudience],
+]);
 
 describe('lib/core/audience_evaluator', function() {
   var audienceEvaluator;

--- a/packages/optimizely-sdk/lib/core/audience_evaluator/index.ts
+++ b/packages/optimizely-sdk/lib/core/audience_evaluator/index.ts
@@ -63,7 +63,7 @@ export class AudienceEvaluator {
    */
   evaluate(
     audienceConditions: Array<string | string[]>,
-    audiencesById: { [id: string]: Audience },
+    audiencesById: Map<string, Audience>,
     userAttributes: UserAttributes = {}
   ): boolean {
     // if there are no audiences, return true because that means ALL users are included in the experiment
@@ -72,7 +72,7 @@ export class AudienceEvaluator {
     }
 
     const evaluateAudience = (audienceId: string) => {
-      const audience = audiencesById[audienceId];
+      const audience = audiencesById.get(audienceId);
       if (audience) {
         logger.log(
           LOG_LEVEL.DEBUG,

--- a/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/bucketer/index.tests.js
@@ -16,7 +16,7 @@
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
 import { cloneDeep } from 'lodash';
-import { sprintf } from '../../utils/fns';
+import { sprintf, toObject } from '../../utils/fns';
 
 import * as bucketer from './';
 import {
@@ -49,13 +49,14 @@ describe('lib/core/bucketer', function() {
       describe('return values for bucketing (excluding groups)', function() {
         beforeEach(function() {
           configObj = projectConfig.createProjectConfig(cloneDeep(testData));
+
           bucketerParams = {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
             trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
-            variationIdMap: configObj.variationIdMap,
-            experimentIdMap: configObj.experimentIdMap,
-            groupIdMap: configObj.groupIdMap,
+            variationIdMap: toObject(configObj.variationIdMap),
+            experimentIdMap: toObject(configObj.experimentIdMap),
+            groupIdMap: toObject(configObj.groupIdMap),
             logger: createdLogger,
           };
           sinon
@@ -101,9 +102,9 @@ describe('lib/core/bucketer', function() {
             experimentId: configObj.experiments[0].id,
             experimentKey: configObj.experiments[0].key,
             trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
-            variationIdMap: configObj.variationIdMap,
-            experimentIdMap: configObj.experimentIdMap,
-            groupIdMap: configObj.groupIdMap,
+            variationIdMap: toObject(configObj.variationIdMap),
+            experimentIdMap: toObject(configObj.experimentIdMap),
+            groupIdMap: toObject(configObj.groupIdMap),
             logger: createdLogger,
           };
           bucketerStub = sinon.stub(bucketer, '_generateBucketValue');
@@ -120,9 +121,9 @@ describe('lib/core/bucketer', function() {
               experimentId: configObj.experiments[4].id,
               experimentKey: configObj.experiments[4].key,
               trafficAllocationConfig: configObj.experiments[4].trafficAllocation,
-              variationIdMap: configObj.variationIdMap,
-              experimentIdMap: configObj.experimentIdMap,
-              groupIdMap: configObj.groupIdMap,
+              variationIdMap: toObject(configObj.variationIdMap),
+              experimentIdMap: toObject(configObj.experimentIdMap),
+              groupIdMap: toObject(configObj.groupIdMap),
               logger: createdLogger,
               userId: 'testUser',
             };
@@ -236,9 +237,9 @@ describe('lib/core/bucketer', function() {
               experimentId: configObj.experiments[6].id,
               experimentKey: configObj.experiments[6].key,
               trafficAllocationConfig: configObj.experiments[6].trafficAllocation,
-              variationIdMap: configObj.variationIdMap,
-              experimentIdMap: configObj.experimentIdMap,
-              groupIdMap: configObj.groupIdMap,
+              variationIdMap: toObject(configObj.variationIdMap),
+              experimentIdMap: toObject(configObj.experimentIdMap),
+              groupIdMap: toObject(configObj.groupIdMap),
               logger: createdLogger,
               userId: 'testUser',
             };
@@ -282,9 +283,9 @@ describe('lib/core/bucketer', function() {
                 endOfRange: 10000,
               },
             ],
-            variationIdMap: configObj.variationIdMap,
-            experimentIdMap: configObj.experimentIdMap,
-            groupIdMap: configObj.groupIdMap,
+            variationIdMap: toObject(configObj.variationIdMap),
+            experimentIdMap: toObject(configObj.experimentIdMap),
+            groupIdMap: toObject(configObj.groupIdMap),
             logger: createdLogger,
           };
         });
@@ -322,9 +323,9 @@ describe('lib/core/bucketer', function() {
                 endOfRange: 10000,
               },
             ],
-            variationIdMap: configObj.variationIdMap,
-            experimentIdMap: configObj.experimentIdMap,
-            groupIdMap: configObj.groupIdMap,
+            variationIdMap: toObject(configObj.variationIdMap),
+            experimentIdMap: toObject(configObj.experimentIdMap),
+            groupIdMap: toObject(configObj.groupIdMap),
             logger: createdLogger,
           };
         });
@@ -370,9 +371,9 @@ describe('lib/core/bucketer', function() {
         var configObj = projectConfig.createProjectConfig(cloneDeep(testData));
         bucketerParams = {
           trafficAllocationConfig: configObj.experiments[0].trafficAllocation,
-          variationIdMap: configObj.variationIdMap,
-          experimentIdMap: configObj.experimentIdMap,
-          groupIdMap: configObj.groupIdMap,
+          variationIdMap: toObject(configObj.variationIdMap),
+          experimentIdMap: toObject(configObj.experimentIdMap),
+          groupIdMap: toObject(configObj.groupIdMap),
           logger: createdLogger,
         };
       });

--- a/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.tests.js
@@ -16,7 +16,7 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
 import cloneDeep from 'lodash/cloneDeep';
-import { sprintf } from '../../utils/fns';
+import { sprintf, toObject } from '../../utils/fns';
 
 import { createDecisionService } from './';
 import * as bucketer from '../bucketer';
@@ -75,7 +75,7 @@ describe('lib/core/decision_service', function() {
           result: '111128',
           reasons: [],
         };
-        experiment = configObj.experimentIdMap['111127'];
+        experiment = configObj.experimentIdMap.get('111127');
         bucketerStub.returns(fakeDecisionResponse); // contains variation ID of the 'control' variation from `test_data`
         assert.strictEqual(
           'control',
@@ -89,7 +89,7 @@ describe('lib/core/decision_service', function() {
           optimizely: {},
           userId: 'user2'
         });
-        experiment = configObj.experimentIdMap['122227'];
+        experiment = configObj.experimentIdMap.get('122227');
         assert.strictEqual(
           'variationWithAudience',
           decisionServiceInstance.getVariation(configObj, experiment, user).result
@@ -111,7 +111,7 @@ describe('lib/core/decision_service', function() {
           optimizely: {},
           userId: 'user3'
         });
-        experiment = configObj.experimentIdMap['122227'];
+        experiment = configObj.experimentIdMap.get('122227');
         assert.isNull(
           decisionServiceInstance.getVariation(configObj, experiment, user, { foo: 'bar' }).result
         );
@@ -139,7 +139,7 @@ describe('lib/core/decision_service', function() {
           optimizely: {},
           userId: 'user1'
         });
-        experiment = configObj.experimentIdMap['133337'];
+        experiment = configObj.experimentIdMap.get('133337');
         assert.isNull(decisionServiceInstance.getVariation(configObj, experiment, user).result);
         sinon.assert.notCalled(bucketerStub);
         assert.strictEqual(1, mockLogger.log.callCount);
@@ -155,7 +155,7 @@ describe('lib/core/decision_service', function() {
             result: '111128',
             reasons: [],
           };
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           bucketerStub.returns(fakeDecisionResponse); // ID of the 'control' variation from `test_data`
           var attributes = {
             $opt_experiment_bucket_map: {
@@ -220,7 +220,7 @@ describe('lib/core/decision_service', function() {
               },
             },
           });
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -248,7 +248,7 @@ describe('lib/core/decision_service', function() {
             user_id: 'decision_service_user',
             experiment_bucket_map: {},
           });
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -274,7 +274,7 @@ describe('lib/core/decision_service', function() {
         it('should bucket if the user profile service returns null', function() {
           bucketerStub.returns(fakeDecisionResponse); // ID of the 'control' variation
           userProfileLookupStub.returns(null);
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -306,7 +306,7 @@ describe('lib/core/decision_service', function() {
               },
             },
           });
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -346,7 +346,7 @@ describe('lib/core/decision_service', function() {
             optimizely: {},
             userId: 'decision_service_user',
           });
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
 
           assert.strictEqual(
             'control',
@@ -376,7 +376,7 @@ describe('lib/core/decision_service', function() {
         it('should log an error message if "lookup" throws an error', function() {
           bucketerStub.returns(fakeDecisionResponse); // ID of the 'control' variation
           userProfileLookupStub.throws(new Error('I am an error'));
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -401,7 +401,7 @@ describe('lib/core/decision_service', function() {
           bucketerStub.returns(fakeDecisionResponse); // ID of the 'control' variation
           userProfileLookupStub.returns(null);
           userProfileSaveStub.throws(new Error('I am an error'));
-          experiment = configObj.experimentIdMap['111127'];
+          experiment = configObj.experimentIdMap.get('111127');
           user = new OptimizelyUserContext({
             optimizely: {},
             userId: 'decision_service_user',
@@ -453,7 +453,7 @@ describe('lib/core/decision_service', function() {
               },
             };
 
-            experiment = configObj.experimentIdMap['111127'];
+            experiment = configObj.experimentIdMap.get('111127');
 
             user = new OptimizelyUserContext({
               optimizely: {},
@@ -488,7 +488,7 @@ describe('lib/core/decision_service', function() {
               },
             });
 
-            experiment = configObj.experimentIdMap['111127'];
+            experiment = configObj.experimentIdMap.get('111127');
 
             var attributes = {
               $opt_experiment_bucket_map: {
@@ -532,7 +532,7 @@ describe('lib/core/decision_service', function() {
               },
             });
 
-            experiment = configObj.experimentIdMap['111127'];
+            experiment = configObj.experimentIdMap.get('111127');
 
             var attributes = {
               $opt_experiment_bucket_map: {
@@ -568,7 +568,7 @@ describe('lib/core/decision_service', function() {
           it('should use attributes when the userProfileLookup returns null', function() {
             userProfileLookupStub.returns(null);
 
-            experiment = configObj.experimentIdMap['111127'];
+            experiment = configObj.experimentIdMap.get('111127');
 
             var attributes = {
               $opt_experiment_bucket_map: {
@@ -605,7 +605,7 @@ describe('lib/core/decision_service', function() {
 
     describe('buildBucketerParams', function() {
       it('should return params object with correct properties', function() {
-        experiment = configObj.experimentIdMap['111127'];
+        experiment = configObj.experimentIdMap.get('111127');
         var bucketerParams = decisionServiceInstance.buildBucketerParams(
           configObj,
           experiment,
@@ -628,11 +628,11 @@ describe('lib/core/decision_service', function() {
               endOfRange: 9000,
             },
           ],
-          variationIdMap: configObj.variationIdMap,
+          variationIdMap: toObject(configObj.variationIdMap),
           logger: mockLogger,
-          experimentIdMap: configObj.experimentIdMap,
-          experimentKeyMap: configObj.experimentKeyMap,
-          groupIdMap: configObj.groupIdMap,
+          experimentIdMap: toObject(configObj.experimentIdMap),
+          experimentKeyMap: toObject(configObj.experimentKeyMap),
+          groupIdMap: toObject(configObj.groupIdMap),
         };
 
         assert.deepEqual(bucketerParams, expectedParams);
@@ -663,7 +663,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return decision response with result true when audience conditions are met', function() {
-        experiment = configObj.experimentIdMap['122227'];
+        experiment = configObj.experimentIdMap.get('122227');
         assert.isTrue(
           decisionServiceInstance.checkIfUserIsInAudience(
             configObj,
@@ -685,7 +685,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return decision response with result true when experiment has no audience', function() {
-        experiment = configObj.experimentIdMap['111127'];
+        experiment = configObj.experimentIdMap.get('111127');
         assert.isTrue(
           decisionServiceInstance.checkIfUserIsInAudience(
             configObj,
@@ -709,7 +709,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return decision response with result false when audience conditions can not be evaluated', function() {
-        experiment = configObj.experimentIdMap['122227'];
+        experiment = configObj.experimentIdMap.get('122227');
         assert.isFalse(
           decisionServiceInstance.checkIfUserIsInAudience(
             configObj,
@@ -733,7 +733,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return decision response with result false when audience conditions are not met', function() {
-        experiment = configObj.experimentIdMap['122227'];
+        experiment = configObj.experimentIdMap.get('122227');
         assert.isFalse(
           decisionServiceInstance.checkIfUserIsInAudience(
             configObj,
@@ -759,8 +759,8 @@ describe('lib/core/decision_service', function() {
 
     describe('getWhitelistedVariation', function() {
       it('should return forced variation ID if forced variation is provided for the user ID', function() {
-        var testExperiment = configObj.experimentKeyMap['testExperiment'];
-        var expectedVariation = configObj.variationIdMap['111128'];
+        var testExperiment = configObj.experimentKeyMap.get('testExperiment');
+        var expectedVariation = configObj.variationIdMap.get('111128');
         assert.strictEqual(
           decisionServiceInstance.getWhitelistedVariation(testExperiment, 'user1').result,
           expectedVariation
@@ -768,7 +768,7 @@ describe('lib/core/decision_service', function() {
       });
 
       it('should return null if forced variation is not provided for the user ID', function() {
-        var testExperiment = configObj.experimentKeyMap['testExperiment'];
+        var testExperiment = configObj.experimentKeyMap.get('testExperiment');
         assert.isNull(decisionServiceInstance.getWhitelistedVariation(testExperiment, 'notInForcedVariations').result);
       });
     });
@@ -1150,7 +1150,7 @@ describe('lib/core/decision_service', function() {
         userId: 'test_user',
         attributes: userAttributesWithBucketingId,
       });
-      var experiment = configObj.experimentIdMap['111127'];
+      var experiment = configObj.experimentIdMap.get('111127');
 
       var decisionServiceInstance = createDecisionService({
         logger: createdLogger,
@@ -1240,7 +1240,7 @@ describe('lib/core/decision_service', function() {
       describe('feature attached to an experiment, and not attached to a rollout', function() {
         var feature;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.test_feature_for_experiment;
+          feature = configObj.featureKeyMap.get('test_feature_for_experiment');
         });
 
         describe('user bucketed into this experiment', function() {
@@ -1258,7 +1258,7 @@ describe('lib/core/decision_service', function() {
               result: 'variation',
               reasons: [],
             };
-            experiment = configObj.experimentIdMap['594098'];
+            experiment = configObj.experimentIdMap.get('594098');
             getVariationStub = sandbox.stub(decisionServiceInstance, 'getVariation');
             getVariationStub.returns(fakeDecisionResponse);
             getVariationStub.withArgs(configObj, experiment, user).returns(fakeDecisionResponseWithArgs);
@@ -1474,7 +1474,13 @@ describe('lib/core/decision_service', function() {
               },
               decisionSource: DECISION_SOURCES.FEATURE_TEST,
             };
-            assert.deepEqual(decision, expectedDecision);
+            assert.deepEqual({
+              ...decision,
+              experiment: {
+                ...decision.experiment,
+                variationKeyMap: toObject(decision.experiment.variationKeyMap),
+              },
+            }, expectedDecision);
             sinon.assert.calledWithExactly(
               getVariationStub,
               configObj,
@@ -1515,7 +1521,7 @@ describe('lib/core/decision_service', function() {
       describe('feature attached to an experiment in a group, and not attached to a rollout', function() {
         var feature;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.feature_with_group;
+          feature = configObj.featureKeyMap.get('feature_with_group');
         });
 
         describe('user bucketed into an experiment in the group', function() {
@@ -1574,7 +1580,13 @@ describe('lib/core/decision_service', function() {
               },
               decisionSource: DECISION_SOURCES.FEATURE_TEST,
             };
-            assert.deepEqual(decision, expectedDecision);
+            assert.deepEqual({
+              ...decision,
+              experiment: {
+                ...decision.experiment,
+                variationKeyMap: toObject(decision.experiment.variationKeyMap),
+              },
+            }, expectedDecision);
           });
         });
 
@@ -1605,7 +1617,7 @@ describe('lib/core/decision_service', function() {
           });
 
           it('returns null decision for group experiment not referenced by the feature', function() {
-            var noTrafficExpFeature = configObj.featureKeyMap.feature_exp_no_traffic;
+            var noTrafficExpFeature = configObj.featureKeyMap.get('feature_exp_no_traffic');
             var decision = decisionServiceInstance.getVariationForFeature(configObj, noTrafficExpFeature, user).result;
             var expectedDecision = {
               experiment: null,
@@ -1627,7 +1639,7 @@ describe('lib/core/decision_service', function() {
         var feature;
         var bucketStub;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.test_feature;
+          feature = configObj.featureKeyMap.get('test_feature');
           bucketStub = sandbox.stub(bucketer, 'bucket');
         });
 
@@ -1744,7 +1756,15 @@ describe('lib/core/decision_service', function() {
               },
               decisionSource: DECISION_SOURCES.ROLLOUT,
             };
-            assert.deepEqual(decision, expectedDecision);
+
+            assert.deepEqual({
+              ...decision,
+              experiment: {
+                ...decision.experiment,
+                variationKeyMap: toObject(decision.experiment.variationKeyMap),
+              },
+            }, expectedDecision);
+
             sinon.assert.calledWithExactly(
               mockLogger.log,
               LOG_LEVEL.DEBUG,
@@ -1880,7 +1900,15 @@ describe('lib/core/decision_service', function() {
               },
               decisionSource: DECISION_SOURCES.ROLLOUT,
             };
-            assert.deepEqual(decision, expectedDecision);
+            
+            assert.deepEqual({
+              ...decision,
+              experiment: {
+                ...decision.experiment,
+                variationKeyMap: toObject(decision.experiment.variationKeyMap),
+              },
+            }, expectedDecision);
+
             sinon.assert.calledWithExactly(
               mockLogger.log,
               LOG_LEVEL.DEBUG,
@@ -2062,7 +2090,15 @@ describe('lib/core/decision_service', function() {
               },
               decisionSource: DECISION_SOURCES.ROLLOUT,
             };
-            assert.deepEqual(decision, expectedDecision);
+            
+            assert.deepEqual({
+              ...decision,
+              experiment: {
+                ...decision.experiment,
+                variationKeyMap: toObject(decision.experiment.variationKeyMap),
+              },
+            }, expectedDecision);
+
             sinon.assert.calledWithExactly(
               mockLogger.log,
               LOG_LEVEL.DEBUG,
@@ -2098,7 +2134,7 @@ describe('lib/core/decision_service', function() {
           reasons: [],
         }
         beforeEach(function() {
-          feature = configObj.featureKeyMap.shared_feature;
+          feature = configObj.featureKeyMap.get('shared_feature');
           getVariationStub = sandbox.stub(decisionServiceInstance, 'getVariation');
           getVariationStub.returns(fakeDecisionResponse); // No variation returned by getVariation
           bucketStub = sandbox.stub(bucketer, 'bucket');
@@ -2179,7 +2215,15 @@ describe('lib/core/decision_service', function() {
             },
             decisionSource: DECISION_SOURCES.ROLLOUT,
           };
-          assert.deepEqual(decision, expectedDecision);
+          
+          assert.deepEqual({
+            ...decision,
+            experiment: {
+              ...decision.experiment,
+              variationKeyMap: toObject(decision.experiment.variationKeyMap),
+            },
+          }, expectedDecision);
+
           sinon.assert.calledWithExactly(
             mockLogger.log,
             LOG_LEVEL.DEBUG,
@@ -2198,7 +2242,7 @@ describe('lib/core/decision_service', function() {
       describe('feature not attached to an experiment or a rollout', function() {
         var feature;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.unused_flag;
+          feature = configObj.featureKeyMap.get('unused_flag');
         });
 
         it('returns a decision with no variation, no experiment and source rollout', function() {
@@ -2232,7 +2276,7 @@ describe('lib/core/decision_service', function() {
         var feature;
         var generateBucketValueStub;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.test_feature_in_exclusion_group;
+          feature = configObj.featureKeyMap.get('test_feature_in_exclusion_group');
           generateBucketValueStub = sandbox.stub(bucketer, '_generateBucketValue');
         });
 
@@ -2422,7 +2466,7 @@ describe('lib/core/decision_service', function() {
         var feature;
         var generateBucketValueStub;
         beforeEach(function() {
-          feature = configObj.featureKeyMap.test_feature_in_multiple_experiments;
+          feature = configObj.featureKeyMap.get('test_feature_in_multiple_experiments');
           generateBucketValueStub = sandbox.stub(bucketer, '_generateBucketValue');
         });
 
@@ -2621,7 +2665,7 @@ describe('lib/core/decision_service', function() {
 
       beforeEach(function() {
         configObj = projectConfig.createProjectConfig(cloneDeep(testDataWithFeatures));
-        feature = configObj.featureKeyMap.test_feature;
+        feature = configObj.featureKeyMap.get('test_feature');
         decisionService = createDecisionService({
           logger: createLogger({ logLevel: LOG_LEVEL.INFO }),
         });
@@ -2641,8 +2685,8 @@ describe('lib/core/decision_service', function() {
         decisionService.getVariationForRollout(configObj, feature, user).result;
 
         sinon.assert.callCount(buildBucketerParamsSpy, 2);
-        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap['594031'], 'testUser', 'testUser');
-        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap['594037'], 'testUser', 'testUser');
+        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap.get('594031'), 'testUser', 'testUser');
+        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap.get('594037'), 'testUser', 'testUser');
       });
 
       it('should call buildBucketerParams with bucketing Id when bucketing Id is provided in the attributes', function() {
@@ -2658,8 +2702,8 @@ describe('lib/core/decision_service', function() {
         decisionService.getVariationForRollout(configObj, feature, user).result;
 
         sinon.assert.callCount(buildBucketerParamsSpy, 2);
-        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap['594031'], 'abcdefg', 'testUser');
-        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap['594037'], 'abcdefg', 'testUser');
+        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap.get('594031'), 'abcdefg', 'testUser');
+        sinon.assert.calledWithExactly(buildBucketerParamsSpy, configObj, configObj.experimentIdMap.get('594037'), 'abcdefg', 'testUser');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/core/decision_service/index.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.ts
@@ -120,7 +120,7 @@ export class DecisionService {
     const attributes = user.getAttributes();
     // by default, the bucketing ID should be the user ID
     const bucketingId = this.getBucketingId(userId, attributes);
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     const experimentKey = experiment.key;
     if (!this.checkIfExperimentIsActive(configObj, experimentKey)) {
       this.logger.log(LOG_LEVEL.INFO, LOG_MESSAGES.EXPERIMENT_NOT_RUNNING, MODULE_NAME, experimentKey);
@@ -262,7 +262,7 @@ export class DecisionService {
    *                                                      or user ID and the decide reasons.
    */
   private getWhitelistedVariation(experiment: Experiment, userId: string): DecisionResponse<Variation | null> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     if (experiment.forcedVariations && experiment.forcedVariations.hasOwnProperty(userId)) {
       const forcedVariationKey = experiment.forcedVariations[userId];
 
@@ -498,7 +498,7 @@ export class DecisionService {
     user: OptimizelyUserContext,
     options: { [key: string]: boolean } = {}
   ): DecisionResponse<DecisionObj> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     const decisionVariation = this.getVariationForFeatureExperiment(configObj, feature, user, options);
     decideReasons.push(...decisionVariation.reasons);
     const experimentDecision = decisionVariation.result;
@@ -537,7 +537,7 @@ export class DecisionService {
     user: OptimizelyUserContext,
     options: { [key: string]: boolean } = {}
   ): DecisionResponse<DecisionObj> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     let variationKey = null;
     let decisionVariation;
     let index;
@@ -593,7 +593,7 @@ export class DecisionService {
     feature: FeatureFlag,
     user: OptimizelyUserContext
   ): DecisionResponse<DecisionObj> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     let decisionObj: DecisionObj;
     if (!feature.rolloutId) {
       this.logger.log(LOG_LEVEL.DEBUG, LOG_MESSAGES.NO_ROLLOUT_EXISTS, MODULE_NAME, feature.key);
@@ -827,9 +827,7 @@ export class DecisionService {
     if (experimentToVariationMap) {
       experimentToVariationMap.set(experimentId, variationId);
     } else {
-      this.forcedVariationMap.set(userId, new Map([
-        [experimentId, variationId]
-      ]));
+      this.forcedVariationMap.set(userId, new Map([[experimentId, variationId]]));
     }
 
     this.logger.log(
@@ -1004,7 +1002,7 @@ export class DecisionService {
     user: OptimizelyUserContext,
     options: { [key: string]: boolean } = {}
   ): DecisionResponse<string | null> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
 
     // check forced decision first
     const forcedDecisionResponse = this.findValidatedForcedDecision(configObj, user, flagKey, rule.key);
@@ -1034,7 +1032,7 @@ export class DecisionService {
     ruleIndex: number,
     user: OptimizelyUserContext
   ): DeliveryRuleResponse<Variation | null, boolean> {
-    const decideReasons: (string | number | undefined)[][] = [];
+    const decideReasons: (string | number)[][] = [];
     let skipToEveryoneElse = false;
 
     // check forced decision first

--- a/packages/optimizely-sdk/lib/core/decision_service/index.ts
+++ b/packages/optimizely-sdk/lib/core/decision_service/index.ts
@@ -650,9 +650,9 @@ export class DecisionService {
       variation = decisionVariation.result;
       skipToEveryoneElse = decisionVariation.skipToEveryoneElse;
       if (variation) {
-        rolloutRule = configObj.experimentIdMap.get(rolloutRules[index].id)!;
+        rolloutRule = configObj.experimentIdMap.get(rolloutRules[index].id);
         decisionObj = {
-          experiment: rolloutRule,
+          experiment: rolloutRule as Experiment,
           variation: variation,
           decisionSource: DECISION_SOURCES.ROLLOUT,
         };

--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.tests.js
@@ -743,7 +743,7 @@ describe('lib/core/optimizely_config', function() {
           key: featureFlag.key,
         });
         featureFlag.experimentIds.forEach(function(experimentId) {
-          var experimentKey = projectConfigObject.experimentIdMap[experimentId].key;
+          var experimentKey = projectConfigObject.experimentIdMap.get(experimentId).key;
           assert.isTrue(!!featuresMap[featureFlag.key].experimentsMap[experimentKey]);
         });
         var variablesMap = featuresMap[featureFlag.key].variablesMap;
@@ -774,7 +774,7 @@ describe('lib/core/optimizely_config', function() {
       featureFlags.forEach(function(featureFlag) {
         var experimentIds = featureFlag.experimentIds;
         experimentIds.forEach(function(experimentId) {
-          var experimentKey = projectConfigObject.experimentIdMap[experimentId].key;
+          var experimentKey = projectConfigObject.experimentIdMap.get(experimentId).key;
           var experiment = optimizelyConfigObject.experimentsMap[experimentKey];
           var variations = datafileExperimentsMap[experimentKey].variations;
           var variationsMap = experiment.variationsMap;

--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
@@ -33,9 +33,7 @@ import {
   VariationVariable,
 } from '../../shared_types';
 
-interface FeatureVariablesMap {
-  [key: string]: FeatureVariable[];
-}
+type FeatureVariablesMap = Map<string, FeatureVariable[]>
 
 /**
  * The OptimizelyConfig class
@@ -69,10 +67,9 @@ export class OptimizelyConfig {
     this.events = configObj.events;
     this.revision = configObj.revision;
 
-    const featureIdVariablesMap = (configObj.featureFlags || []).reduce((resultMap: FeatureVariablesMap, feature) => {
-      resultMap[feature.id] = feature.variables;
-      return resultMap;
-    }, {});
+    const featureIdVariablesMap: FeatureVariablesMap = new Map((configObj.featureFlags || []).map(feature => {
+      return [feature.id, feature.variables]
+    }));
 
     const experimentsMapById = OptimizelyConfig.getExperimentsMapById(configObj, featureIdVariablesMap);
     this.experimentsMap = OptimizelyConfig.getExperimentsKeyMap(experimentsMapById);
@@ -212,7 +209,7 @@ export class OptimizelyConfig {
     featureVariableUsages: VariationVariable[] | undefined,
     isFeatureEnabled: boolean | undefined
   ): OptimizelyVariablesMap {
-    const variablesMap = (featureIdVariableMap[featureId] || []).reduce(
+    const variablesMap = (featureIdVariableMap.get(featureId) || []).reduce(
       (optlyVariablesMap: OptimizelyVariablesMap, featureVariable) => {
         optlyVariablesMap[featureVariable.key] = {
           id: featureVariable.id,

--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
@@ -136,7 +136,7 @@ export class OptimizelyConfig {
    */
   static getSerializedAudiences(
     conditions: Array<string | string[]>,
-    audiencesById: { [id: string]: Audience }
+    audiencesById: Map<string, Audience>
   ): string {
     let serializedAudience = '';
 
@@ -152,12 +152,12 @@ export class OptimizelyConfig {
           cond = item.toUpperCase();
         } else {
           // Checks if item is audience id
-          const audienceName = audiencesById[item] ? audiencesById[item].name : item;
+          const audienceName = audiencesById.get(item) ? audiencesById.get(item)?.name : item;
           // if audience condition is "NOT" then add "NOT" at start. Otherwise check if there is already audience id in serializedAudience then append condition between serializedAudience and item
           if (serializedAudience || cond === 'NOT') {
             cond = cond === '' ? 'OR' : cond;
             if (serializedAudience === '') {
-              serializedAudience = `${cond} "${audiencesById[item].name}"`;
+              serializedAudience = `${cond} "${audiencesById.get(item)?.name}"`;
             } else {
               serializedAudience = serializedAudience.concat(` ${cond} "${audienceName}"`);
             }
@@ -352,7 +352,7 @@ export class OptimizelyConfig {
 
     return (experiments || []).reduce((experimentsMap: { [id: string]: OptimizelyExperiment }, experiment) => {
       if (rolloutExperimentIds.indexOf(experiment.id) === -1) {
-        const featureIds = configObj.experimentFeatureMap[experiment.id];
+        const featureIds = configObj.experimentFeatureMap.get(experiment.id);
         let featureId = '';
         if (featureIds && featureIds.length > 0) {
           featureId = featureIds[0];
@@ -422,7 +422,7 @@ export class OptimizelyConfig {
         return variables;
       }, {});
       let deliveryRules: OptimizelyExperiment[] = [];
-      const rollout = configObj.rolloutIdMap[featureFlag.rolloutId];
+      const rollout = configObj.rolloutIdMap.get(featureFlag.rolloutId);
       if (rollout) {
         deliveryRules = OptimizelyConfig.getDeliveryRules(
           configObj,

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -17,7 +17,7 @@ import sinon from 'sinon';
 import { assert } from 'chai';
 import { forEach, cloneDeep } from 'lodash';
 import { getLogger } from '@optimizely/js-sdk-logging';
-import { sprintf } from '../../utils/fns';
+import { sprintf, toObject } from '../../utils/fns';
 
 import fns from '../../utils/fns';
 import projectConfig from './';
@@ -35,7 +35,7 @@ var logger = getLogger();
 
 describe('lib/core/project_config', function() {
   describe('createProjectConfig method', function() {
-    it('should set properties correctly when createProjectConfig is called', function() {
+    xit('should set properties correctly when createProjectConfig is called', function() {
       var testData = testDatafile.getTestProjectConfig();
       var configObj = projectConfig.createProjectConfig(testData);
 
@@ -51,7 +51,7 @@ describe('lib/core/project_config', function() {
       testData.groups.forEach(function(group) {
         group.experiments.forEach(function(experiment) {
           experiment.groupId = group.id;
-          experiment.variationKeyMap = fns.keyBy(experiment.variations, 'key');
+          experiment.variationKeyMap = fns.createMap(experiment.variations, 'key');
         });
       });
       assert.deepEqual(configObj.groups, testData.groups);
@@ -61,7 +61,7 @@ describe('lib/core/project_config', function() {
         667: testData.groups[1],
       };
 
-      assert.deepEqual(configObj.groupIdMap, expectedGroupIdMap);
+      assert.deepEqual(fns.toObject(configObj.groupIdMap), expectedGroupIdMap);
 
       var expectedExperiments = testData.experiments;
       forEach(configObj.groupIdMap, function(group, Id) {
@@ -72,7 +72,7 @@ describe('lib/core/project_config', function() {
       });
 
       forEach(expectedExperiments, function(experiment) {
-        experiment.variationKeyMap = fns.keyBy(experiment.variations, 'key');
+        experiment.variationKeyMap = fns.createMap(experiment.variations, 'key');
       });
 
       assert.deepEqual(configObj.experiments, expectedExperiments);
@@ -88,7 +88,7 @@ describe('lib/core/project_config', function() {
         array: testData.attributes[7],
       };
 
-      assert.deepEqual(configObj.attributeKeyMap, expectedAttributeKeyMap);
+      assert.deepEqual(toObject(configObj.attributeKeyMap), expectedAttributeKeyMap);
 
       var expectedExperimentKeyMap = {
         testExperiment: configObj.experiments[0],
@@ -100,7 +100,7 @@ describe('lib/core/project_config', function() {
         overlappingGroupExperiment1: configObj.experiments[6],
       };
 
-      assert.deepEqual(configObj.experimentKeyMap, expectedExperimentKeyMap);
+      assert.deepEqual(toObject(configObj.experimentKeyMap), expectedExperimentKeyMap);
 
       var expectedEventKeyMap = {
         testEvent: testData.events[0],
@@ -112,7 +112,7 @@ describe('lib/core/project_config', function() {
         testEventLaunched: testData.events[6],
       };
 
-      assert.deepEqual(configObj.eventKeyMap, expectedEventKeyMap);
+      assert.deepEqual(toObject(configObj.eventKeyMap), expectedEventKeyMap);
 
       var expectedExperimentIdMap = {
         '111127': configObj.experiments[0],
@@ -124,54 +124,37 @@ describe('lib/core/project_config', function() {
         '444': configObj.experiments[6],
       };
 
-      assert.deepEqual(configObj.experimentIdMap, expectedExperimentIdMap);
+      assert.deepEqual(toObject(configObj.experimentIdMap), expectedExperimentIdMap);
 
       var expectedVariationKeyMap = {};
-      expectedVariationKeyMap[testData.experiments[0].key + testData.experiments[0].variations[0].key] =
+      expectedVariationKeyMap.get(testData.experiments[0].key + testData.experiments[0].variations[0].key) =
         testData.experiments[0].variations[0];
-      expectedVariationKeyMap[testData.experiments[0].key + testData.experiments[0].variations[1].key] =
+      expectedVariationKeyMap.get(testData.experiments[0].key + testData.experiments[0].variations[1].key) =
         testData.experiments[0].variations[1];
-      expectedVariationKeyMap[testData.experiments[1].key + testData.experiments[1].variations[0].key] =
+      expectedVariationKeyMap.get(testData.experiments[1].key + testData.experiments[1].variations[0].key) =
         testData.experiments[1].variations[0];
-      expectedVariationKeyMap[testData.experiments[1].key + testData.experiments[1].variations[1].key] =
+      expectedVariationKeyMap.get(testData.experiments[1].key + testData.experiments[1].variations[1].key) =
         testData.experiments[1].variations[1];
-      expectedVariationKeyMap[testData.experiments[2].key + testData.experiments[2].variations[0].key] =
+      expectedVariationKeyMap.get(testData.experiments[2].key + testData.experiments[2].variations[0].key) =
         testData.experiments[2].variations[0];
-      expectedVariationKeyMap[testData.experiments[2].key + testData.experiments[2].variations[1].key] =
+      expectedVariationKeyMap.get(testData.experiments[2].key + testData.experiments[2].variations[1].key) =
         testData.experiments[2].variations[1];
-      expectedVariationKeyMap[configObj.experiments[3].key + configObj.experiments[3].variations[0].key] =
+      expectedVariationKeyMap.get(configObj.experiments[3].key + configObj.experiments[3].variations[0].key) =
         configObj.experiments[3].variations[0];
-      expectedVariationKeyMap[configObj.experiments[3].key + configObj.experiments[3].variations[1].key] =
+      expectedVariationKeyMap.get(configObj.experiments[3].key + configObj.experiments[3].variations[1].key) =
         configObj.experiments[3].variations[1];
-      expectedVariationKeyMap[configObj.experiments[4].key + configObj.experiments[4].variations[0].key] =
+      expectedVariationKeyMap.get(configObj.experiments[4].key + configObj.experiments[4].variations[0].key) =
         configObj.experiments[4].variations[0];
-      expectedVariationKeyMap[configObj.experiments[4].key + configObj.experiments[4].variations[1].key] =
+      expectedVariationKeyMap.get(configObj.experiments[4].key + configObj.experiments[4].variations[1].key) =
         configObj.experiments[4].variations[1];
-      expectedVariationKeyMap[configObj.experiments[5].key + configObj.experiments[5].variations[0].key] =
+      expectedVariationKeyMap.get(configObj.experiments[5].key + configObj.experiments[5].variations[0].key) =
         configObj.experiments[5].variations[0];
-      expectedVariationKeyMap[configObj.experiments[5].key + configObj.experiments[5].variations[1].key] =
+      expectedVariationKeyMap.get(configObj.experiments[5].key + configObj.experiments[5].variations[1].key) =
         configObj.experiments[5].variations[1];
-      expectedVariationKeyMap[configObj.experiments[6].key + configObj.experiments[6].variations[0].key] =
+      expectedVariationKeyMap.get(configObj.experiments[6].key + configObj.experiments[6].variations[0].key) =
         configObj.experiments[6].variations[0];
-      expectedVariationKeyMap[configObj.experiments[6].key + configObj.experiments[6].variations[1].key] =
+      expectedVariationKeyMap.get(configObj.experiments[6].key + configObj.experiments[6].variations[1].key) =
         configObj.experiments[6].variations[1];
-
-      var expectedVariationIdMap = {
-        '111128': testData.experiments[0].variations[0],
-        '111129': testData.experiments[0].variations[1],
-        '122228': testData.experiments[1].variations[0],
-        '122229': testData.experiments[1].variations[1],
-        '133338': testData.experiments[2].variations[0],
-        '133339': testData.experiments[2].variations[1],
-        '144448': testData.experiments[3].variations[0],
-        '144449': testData.experiments[3].variations[1],
-        '551': configObj.experiments[4].variations[0],
-        '552': configObj.experiments[4].variations[1],
-        '661': configObj.experiments[5].variations[0],
-        '662': configObj.experiments[5].variations[1],
-        '553': configObj.experiments[6].variations[0],
-        '554': configObj.experiments[6].variations[1],
-      };
     });
 
     it('should not mutate the datafile', function() {
@@ -187,23 +170,23 @@ describe('lib/core/project_config', function() {
         configObj = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
       });
 
-      it('creates a rolloutIdMap from rollouts in the datafile', function() {
-        assert.deepEqual(configObj.rolloutIdMap, testDatafile.datafileWithFeaturesExpectedData.rolloutIdMap);
+      xit('creates a rolloutIdMap from rollouts in the datafile', function() {
+        assert.deepEqual(toObject(configObj.rolloutIdMap), testDatafile.datafileWithFeaturesExpectedData.rolloutIdMap);
       });
 
       it('creates a variationVariableUsageMap from rollouts and experiments with features in the datafile', function() {
         assert.deepEqual(
-          configObj.variationVariableUsageMap,
+          Object.keys(toObject(configObj.variationVariableUsageMap)),
           testDatafile.datafileWithFeaturesExpectedData.variationVariableUsageMap
         );
       });
 
-      it('creates a featureKeyMap from feature flags in the datafile', function() {
-        assert.deepEqual(configObj.featureKeyMap, testDatafile.datafileWithFeaturesExpectedData.featureKeyMap);
+      xit('creates a featureKeyMap from feature flags in the datafile', function() {
+        assert.deepEqual(toObject(configObj.featureKeyMap), testDatafile.datafileWithFeaturesExpectedData.featureKeyMap);
       });
 
       it('adds variations from rollout experiments to variationIdMap', function() {
-        assert.deepEqual(configObj.variationIdMap['594032'], {
+        assert.deepEqual(configObj.variationIdMap.get('594032'), {
           variables: [
             { value: 'true', id: '4919852825313280' },
             { value: '395', id: '5482802778734592' },
@@ -215,7 +198,7 @@ describe('lib/core/project_config', function() {
           key: '594032',
           id: '594032',
         });
-        assert.deepEqual(configObj.variationIdMap['594038'], {
+        assert.deepEqual(configObj.variationIdMap.get('594038'), {
           variables: [
             { value: 'false', id: '4919852825313280' },
             { value: '400', id: '5482802778734592' },
@@ -227,7 +210,7 @@ describe('lib/core/project_config', function() {
           key: '594038',
           id: '594038',
         });
-        assert.deepEqual(configObj.variationIdMap['594061'], {
+        assert.deepEqual(configObj.variationIdMap.get('594061'), {
           variables: [
             { value: '27.34', id: '5060590313668608' },
             { value: 'Winter is NOT coming', id: '5342065290379264' },
@@ -238,7 +221,7 @@ describe('lib/core/project_config', function() {
           key: '594061',
           id: '594061',
         });
-        assert.deepEqual(configObj.variationIdMap['594067'], {
+        assert.deepEqual(configObj.variationIdMap.get('594067'), {
           variables: [
             { value: '30.34', id: '5060590313668608' },
             { value: 'Winter is coming definitely', id: '5342065290379264' },
@@ -260,9 +243,9 @@ describe('lib/core/project_config', function() {
 
       it('it should populate flagVariationsMap correctly', function() {
         var allVariationsForFlag = configObj.flagVariationsMap;
-        var feature1Variations = allVariationsForFlag.feature_1;
-        var feature2Variations = allVariationsForFlag.feature_2;
-        var feature3Variations = allVariationsForFlag.feature_3;
+        var feature1Variations = allVariationsForFlag.get('feature_1');
+        var feature2Variations = allVariationsForFlag.get('feature_2');
+        var feature3Variations = allVariationsForFlag.get('feature_3');
         var feature1VariationsKeys = feature1Variations.map((variation) => {
           return variation.key;
         }, {});
@@ -335,10 +318,10 @@ describe('lib/core/project_config', function() {
 
     it('should return null for invalid attribute key in getAttributeId', function() {
       // Adding attribute in key map with reserved prefix
-      configObj.attributeKeyMap['$opt_some_reserved_attribute'] = {
+      configObj.attributeKeyMap.set('$opt_some_reserved_attribute', {
         id: '42',
         key: '$opt_some_reserved_attribute',
-      };
+      });
       assert.strictEqual(projectConfig.getAttributeId(configObj, '$opt_some_reserved_attribute', createdLogger), '42');
       assert.strictEqual(
         buildLogMessageFromArgs(createdLogger.log.lastCall.args),
@@ -505,8 +488,8 @@ describe('lib/core/project_config', function() {
 
       describe('getVariableValueForVariation', function() {
         it('returns a value for a valid variation and variable', function() {
-          var variation = configObj.variationIdMap['594096'];
-          var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
+          var variation = configObj.variationIdMap.get('594096');
+          var variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('num_buttons');
           var result = projectConfig.getVariableValueForVariation(
             configObj,
             variable,
@@ -515,22 +498,22 @@ describe('lib/core/project_config', function() {
           );
           assert.strictEqual(result, '2');
 
-          variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.is_button_animated;
+          variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('is_button_animated');
           result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, 'true');
 
-          variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.button_txt;
+          variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('button_txt');
           result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, 'Buy me NOW');
 
-          variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.button_width;
+          variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('button_width');
           result = projectConfig.getVariableValueForVariation(configObj, variable, variation, featureManagementLogger);
           assert.strictEqual(result, '20.25');
         });
 
         it('returns null for a null variation', function() {
           var variation = null;
-          var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
+          var variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('num_buttons');
           var result = projectConfig.getVariableValueForVariation(
             configObj,
             variable,
@@ -541,7 +524,7 @@ describe('lib/core/project_config', function() {
         });
 
         it('returns null for a null variable', function() {
-          var variation = configObj.variationIdMap['594096'];
+          var variation = configObj.variationIdMap.get('594096');
           var variable = null;
           var result = projectConfig.getVariableValueForVariation(
             configObj,
@@ -570,7 +553,7 @@ describe('lib/core/project_config', function() {
             id: '999999999999',
             variables: [],
           };
-          var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
+          var variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('num_buttons');
           var result = projectConfig.getVariableValueForVariation(
             configObj,
             variable,
@@ -581,8 +564,8 @@ describe('lib/core/project_config', function() {
         });
 
         it('returns null if the variation does not have a value for this variable', function() {
-          var variation = configObj.variationIdMap['595008']; // This variation has no variable values associated with it
-          var variable = configObj.featureKeyMap.test_feature_for_experiment.variableKeyMap.num_buttons;
+          var variation = configObj.variationIdMap.get('595008'); // This variation has no variable values associated with it
+          var variable = configObj.featureKeyMap.get('test_feature_for_experiment').variableKeyMap.get('num_buttons');
           var result = projectConfig.getVariableValueForVariation(
             configObj,
             variable,
@@ -681,7 +664,7 @@ describe('lib/core/project_config', function() {
       });
 
       it('should retrieve audiences by checking first in typedAudiences, and then second in audiences', function() {
-        assert.deepEqual(projectConfig.getAudiencesById(configObj), testDatafile.typedAudiencesById);
+        assert.deepEqual(toObject(projectConfig.getAudiencesById(configObj)), testDatafile.typedAudiencesById);
       });
     });
 
@@ -777,8 +760,8 @@ describe('lib/core/project_config', function() {
       var configObj = {
         foo: 'bar',
         experimentKeyMap: {
-          "a": { key: "a", variationKeyMap: {} },
-          "b": { key: "b", variationKeyMap: {} }
+          "a": { key: "a", variationKeyMap: new Map() },
+          "b": { key: "b", variationKeyMap: new Map() }
         },
       };
 
@@ -790,7 +773,10 @@ describe('lib/core/project_config', function() {
         logger: logger,
       });
 
-      assert.deepInclude(result.configObj, configObj)
+      assert.deepInclude({
+        ...result.configObj, 
+        experimentKeyMap: toObject(result.configObj.experimentKeyMap),
+      }, configObj)
     });
 
     it('returns an error when validateDatafile throws', function() {
@@ -812,7 +798,7 @@ describe('lib/core/project_config', function() {
         jsonSchemaValidator: stubJsonSchemaValidator,
         logger: logger,
       });
-    assert.isNotNull(error);
+      assert.isNotNull(error);
     });
 
     it('skips json validation when jsonSchemaValidator is not provided', function() {
@@ -830,8 +816,8 @@ describe('lib/core/project_config', function() {
       var configObj = {
         foo: 'bar',
         experimentKeyMap: {
-          a: { key: 'a', variationKeyMap: {} },
-          b: { key: 'b', variationKeyMap: {} },
+          a: { key: 'a', variationKeyMap: new Map() },
+          b: { key: 'b', variationKeyMap: new Map() },
         },
       };
 
@@ -840,7 +826,10 @@ describe('lib/core/project_config', function() {
         logger: logger,
       });
 
-      assert.deepInclude(result.configObj, configObj);
+      assert.deepInclude({
+        ...result.configObj, 
+        experimentKeyMap: toObject(result.configObj.experimentKeyMap),
+      }, configObj);
       sinon.assert.notCalled(logger.error);
     });
   });

--- a/packages/optimizely-sdk/lib/core/project_config/index.tests.js
+++ b/packages/optimizely-sdk/lib/core/project_config/index.tests.js
@@ -35,7 +35,7 @@ var logger = getLogger();
 
 describe('lib/core/project_config', function() {
   describe('createProjectConfig method', function() {
-    xit('should set properties correctly when createProjectConfig is called', function() {
+    it('should set properties correctly when createProjectConfig is called', function() {
       var testData = testDatafile.getTestProjectConfig();
       var configObj = projectConfig.createProjectConfig(testData);
 
@@ -56,17 +56,17 @@ describe('lib/core/project_config', function() {
       });
       assert.deepEqual(configObj.groups, testData.groups);
 
-      var expectedGroupIdMap = {
-        666: testData.groups[0],
-        667: testData.groups[1],
-      };
+      var expectedGroupIdMap = new Map([
+        ['666', testData.groups[0]],
+        ['667', testData.groups[1]],
+      ]);
 
-      assert.deepEqual(fns.toObject(configObj.groupIdMap), expectedGroupIdMap);
+      assert.deepEqual(fns.toObject(configObj.groupIdMap), fns.toObject(expectedGroupIdMap));
 
       var expectedExperiments = testData.experiments;
-      forEach(configObj.groupIdMap, function(group, Id) {
+      configObj.groupIdMap.forEach((group, groupId) => {
         forEach(group.experiments, function(experiment) {
-          experiment.groupId = Id;
+          experiment.groupId = groupId;
           expectedExperiments.push(experiment);
         });
       });
@@ -126,35 +126,63 @@ describe('lib/core/project_config', function() {
 
       assert.deepEqual(toObject(configObj.experimentIdMap), expectedExperimentIdMap);
 
-      var expectedVariationKeyMap = {};
-      expectedVariationKeyMap.get(testData.experiments[0].key + testData.experiments[0].variations[0].key) =
-        testData.experiments[0].variations[0];
-      expectedVariationKeyMap.get(testData.experiments[0].key + testData.experiments[0].variations[1].key) =
-        testData.experiments[0].variations[1];
-      expectedVariationKeyMap.get(testData.experiments[1].key + testData.experiments[1].variations[0].key) =
-        testData.experiments[1].variations[0];
-      expectedVariationKeyMap.get(testData.experiments[1].key + testData.experiments[1].variations[1].key) =
-        testData.experiments[1].variations[1];
-      expectedVariationKeyMap.get(testData.experiments[2].key + testData.experiments[2].variations[0].key) =
-        testData.experiments[2].variations[0];
-      expectedVariationKeyMap.get(testData.experiments[2].key + testData.experiments[2].variations[1].key) =
-        testData.experiments[2].variations[1];
-      expectedVariationKeyMap.get(configObj.experiments[3].key + configObj.experiments[3].variations[0].key) =
-        configObj.experiments[3].variations[0];
-      expectedVariationKeyMap.get(configObj.experiments[3].key + configObj.experiments[3].variations[1].key) =
-        configObj.experiments[3].variations[1];
-      expectedVariationKeyMap.get(configObj.experiments[4].key + configObj.experiments[4].variations[0].key) =
-        configObj.experiments[4].variations[0];
-      expectedVariationKeyMap.get(configObj.experiments[4].key + configObj.experiments[4].variations[1].key) =
-        configObj.experiments[4].variations[1];
-      expectedVariationKeyMap.get(configObj.experiments[5].key + configObj.experiments[5].variations[0].key) =
-        configObj.experiments[5].variations[0];
-      expectedVariationKeyMap.get(configObj.experiments[5].key + configObj.experiments[5].variations[1].key) =
-        configObj.experiments[5].variations[1];
-      expectedVariationKeyMap.get(configObj.experiments[6].key + configObj.experiments[6].variations[0].key) =
-        configObj.experiments[6].variations[0];
-      expectedVariationKeyMap.get(configObj.experiments[6].key + configObj.experiments[6].variations[1].key) =
-        configObj.experiments[6].variations[1];
+      var expectedVariationKeyMap = new Map();
+      expectedVariationKeyMap.set(
+        testData.experiments[0].key + testData.experiments[0].variations[0].key, 
+        testData.experiments[0].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        testData.experiments[0].key + testData.experiments[0].variations[1].key, 
+        testData.experiments[0].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        testData.experiments[1].key + testData.experiments[1].variations[0].key, 
+        testData.experiments[1].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        testData.experiments[1].key + testData.experiments[1].variations[1].key, 
+        testData.experiments[1].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        testData.experiments[2].key + testData.experiments[2].variations[0].key, 
+        testData.experiments[2].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        testData.experiments[2].key + testData.experiments[2].variations[1].key, 
+        testData.experiments[2].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[3].key + configObj.experiments[3].variations[0].key, 
+        configObj.experiments[3].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[3].key + configObj.experiments[3].variations[1].key, 
+        configObj.experiments[3].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[4].key + configObj.experiments[4].variations[0].key, 
+        configObj.experiments[4].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[4].key + configObj.experiments[4].variations[1].key, 
+        configObj.experiments[4].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[5].key + configObj.experiments[5].variations[0].key, 
+        configObj.experiments[5].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[5].key + configObj.experiments[5].variations[1].key, 
+        configObj.experiments[5].variations[1]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[6].key + configObj.experiments[6].variations[0].key, 
+        configObj.experiments[6].variations[0]
+      );
+      expectedVariationKeyMap.set(
+        configObj.experiments[6].key + configObj.experiments[6].variations[1].key, 
+        configObj.experiments[6].variations[1]
+      );
     });
 
     it('should not mutate the datafile', function() {
@@ -170,19 +198,62 @@ describe('lib/core/project_config', function() {
         configObj = projectConfig.createProjectConfig(testDatafile.getTestProjectConfigWithFeatures());
       });
 
-      xit('creates a rolloutIdMap from rollouts in the datafile', function() {
-        assert.deepEqual(toObject(configObj.rolloutIdMap), testDatafile.datafileWithFeaturesExpectedData.rolloutIdMap);
+      it('creates a rolloutIdMap from rollouts in the datafile', function() {
+        const convertDeepMapToObject = (map) => {
+          const hash = map instanceof Map ? toObject(map) : map;
+  
+          return Object.keys(hash).reduce((acc, id) => {
+            const item = hash[id];
+  
+            return {
+              ...acc,
+              ...item,
+              experiments: [
+                ...item.experiments.map(experiment => ({
+                  ...experiment,
+                  variationKeyMap: experiment.variationKeyMap instanceof Map ? 
+                    toObject(experiment.variationKeyMap) : 
+                    experiment.variationKeyMap,
+                })),
+              ]
+            }
+          }, {});
+        };
+
+        assert.deepEqual(
+          convertDeepMapToObject(configObj.rolloutIdMap), 
+          convertDeepMapToObject(testDatafile.datafileWithFeaturesExpectedData.rolloutIdMap)
+        );
       });
 
       it('creates a variationVariableUsageMap from rollouts and experiments with features in the datafile', function() {
         assert.deepEqual(
-          Object.keys(toObject(configObj.variationVariableUsageMap)),
+          toObject(configObj.variationVariableUsageMap),
           testDatafile.datafileWithFeaturesExpectedData.variationVariableUsageMap
         );
       });
 
-      xit('creates a featureKeyMap from feature flags in the datafile', function() {
-        assert.deepEqual(toObject(configObj.featureKeyMap), testDatafile.datafileWithFeaturesExpectedData.featureKeyMap);
+      it('creates a featureKeyMap from feature flags in the datafile', function() {
+        const convertDeepMapToObject = (map) => {
+          const hash = map instanceof Map ? toObject(map) : map;
+  
+          return Object.keys(hash).reduce((acc, id) => {
+            const item = hash[id];
+  
+            return {
+              ...acc,
+              ...item,
+              variableKeyMap: item.variableKeyMap instanceof Map ? 
+                toObject(item.variableKeyMap) :
+                item.variableKeyMap,
+            }
+          }, {});
+        };
+
+        assert.deepEqual(
+          convertDeepMapToObject(configObj.featureKeyMap), 
+          convertDeepMapToObject(testDatafile.datafileWithFeaturesExpectedData.featureKeyMap)
+        );
       });
 
       it('adds variations from rollout experiments to variationIdMap', function() {

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 import { LoggerFacade, ErrorHandler } from '@optimizely/js-sdk-logging';
-import { sprintf, objectValues, toObject } from '../utils/fns';
+import { sprintf } from '../utils/fns';
 import { NotificationCenter } from '../core/notification_center';
 import { EventProcessor } from '@optimizely/js-sdk-event-processor';
 
@@ -25,7 +25,6 @@ import {
   OnReadyResult,
   UserProfileService,
   Variation,
-  FeatureFlag,
   FeatureVariable,
   OptimizelyOptions,
   OptimizelyDecideOption,
@@ -228,10 +227,10 @@ export default class Optimizely {
         }
 
         const experiment = projectConfig.getExperimentFromKey(configObj, experimentKey);
-        const variation = experiment.variationKeyMap.get(variationKey)!;
+        const variation = experiment.variationKeyMap.get(variationKey);
         const decisionObj = {
           experiment: experiment,
-          variation: variation,
+          variation: variation as Variation,
           decisionSource: enums.DECISION_SOURCES.EXPERIMENT
         }
 

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 import { LoggerFacade, ErrorHandler } from '@optimizely/js-sdk-logging';
-import { sprintf, objectValues } from '../utils/fns';
+import { sprintf, objectValues, toObject } from '../utils/fns';
 import { NotificationCenter } from '../core/notification_center';
 import { EventProcessor } from '@optimizely/js-sdk-event-processor';
 
@@ -1667,7 +1667,7 @@ export default class Optimizely {
       return decisionMap;
     }
 
-    const allFlagKeys = Object.keys(configObj.featureKeyMap);
+    const allFlagKeys = [...configObj.featureKeyMap.keys()];
 
     return this.decideForKeys(user, allFlagKeys, options);
   }

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -228,7 +228,7 @@ export default class Optimizely {
         }
 
         const experiment = projectConfig.getExperimentFromKey(configObj, experimentKey);
-        const variation = experiment.variationKeyMap[variationKey];
+        const variation = experiment.variationKeyMap.get(variationKey)!;
         const decisionObj = {
           experiment: experiment,
           variation: variation,
@@ -327,7 +327,7 @@ export default class Optimizely {
     let experiment;
 
     if (experimentId !== null && variationKey !== '') {
-      experiment = configObj.experimentIdMap[experimentId];
+      experiment = configObj.experimentIdMap.get(experimentId);
     }
 
     const impressionEventOptions = {
@@ -347,7 +347,7 @@ export default class Optimizely {
     const impressionEvent = getImpressionEvent(impressionEventOptions);
     let variation;
     if (experiment && experiment.variationKeyMap && variationKey !== '') {
-      variation = experiment.variationKeyMap[variationKey];
+      variation = experiment.variationKeyMap.get(variationKey);
     }
     this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {
       experiment: experiment,
@@ -476,7 +476,7 @@ export default class Optimizely {
           return null;
         }
 
-        const experiment = configObj.experimentKeyMap[experimentKey];
+        const experiment = configObj.experimentKeyMap.get(experimentKey);
         if (!experiment) {
           this.logger.log(
             LOG_LEVEL.DEBUG,
@@ -777,8 +777,8 @@ export default class Optimizely {
         return enabledFeatures;
       }
 
-      objectValues(configObj.featureKeyMap).forEach(
-        (feature: FeatureFlag) => {
+      configObj.featureKeyMap.forEach(
+        (feature) => {
           if (this.isFeatureEnabled(feature.key, userId, attributes)) {
             enabledFeatures.push(feature.key);
           }
@@ -1466,14 +1466,14 @@ export default class Optimizely {
     const userId = user.getUserId();
     const attributes = user.getAttributes();
     const configObj = this.projectConfigManager.getConfig();
-    const reasons: (string | number)[][] = [];
+    const reasons: (string | number | undefined)[][] = [];
     let decisionObj: DecisionObj;
     if (!this.isValidInstance() || !configObj) {
       this.logger.log(LOG_LEVEL.INFO, LOG_MESSAGES.INVALID_OBJECT, MODULE_NAME, 'decide');
       return newErrorDecision(key, user, [DECISION_MESSAGES.SDK_NOT_READY]);
     }
 
-    const feature = configObj.featureKeyMap[key];
+    const feature = configObj.featureKeyMap.get(key);
     if (!feature) {
       this.logger.log(LOG_LEVEL.ERROR, ERROR_MESSAGES.FEATURE_NOT_IN_DATAFILE, MODULE_NAME, key);
       return newErrorDecision(key, user, [sprintf(DECISION_MESSAGES.FLAG_KEY_INVALID, key)]);

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -34,7 +34,7 @@ export interface BucketerParams {
 
 export interface DecisionResponse<T> {
   readonly result: T;
-  readonly reasons: (string | number)[][];
+  readonly reasons: (string | number | undefined)[][];
 }
 
 export type UserAttributes = {
@@ -134,14 +134,14 @@ export interface Experiment {
   id: string;
   key: string;
   variations: Variation[];
-  variationKeyMap: { [key: string]: Variation };
+  variationKeyMap: Map<string, Variation>;
   groupId?: string;
   layerId: string;
   status: string;
   audienceConditions: Array<string | string[]>;
   audienceIds: string[];
   trafficAllocation: TrafficAllocation[];
-  forcedVariations?: { [key: string]: string };
+  forcedVariations?: Map<string, string>;
 }
 
 export enum VariableType {
@@ -164,9 +164,9 @@ export interface FeatureFlag {
   rolloutId: string;
   key: string;
   id: string;
-  experimentIds: string[],
-  variables: FeatureVariable[],
-  variableKeyMap: { [key: string]: FeatureVariable }
+  experimentIds: string[];
+  variables: FeatureVariable[];
+  variableKeyMap: Map<string, FeatureVariable>;
   groupId?: string;
 }
 

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -34,7 +34,7 @@ export interface BucketerParams {
 
 export interface DecisionResponse<T> {
   readonly result: T;
-  readonly reasons: (string | number | undefined)[][];
+  readonly reasons: (string | number)[][];
 }
 
 export type UserAttributes = {

--- a/packages/optimizely-sdk/lib/shared_types.ts
+++ b/packages/optimizely-sdk/lib/shared_types.ts
@@ -141,7 +141,7 @@ export interface Experiment {
   audienceConditions: Array<string | string[]>;
   audienceIds: string[];
   trafficAllocation: TrafficAllocation[];
-  forcedVariations?: Map<string, string>;
+  forcedVariations?: { [key: string]: string };
 }
 
 export enum VariableType {

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -39,34 +39,6 @@ describe('lib/utils/fns', function() {
       });
     });
 
-    describe('keyBy', function() {
-      it('should return correct object when a key is provided', function() {
-        var arr = [
-          { key1: 'row1', key2: 'key2row1' },
-          { key1: 'row2', key2: 'key2row2' },
-          { key1: 'row3', key2: 'key2row3' },
-          { key1: 'row4', key2: 'key2row4' },
-        ];
-
-        var obj = fns.keyBy(arr, 'key1');
-
-        assert.deepEqual(obj, {
-          row1: { key1: 'row1', key2: 'key2row1' },
-          row2: { key1: 'row2', key2: 'key2row2' },
-          row3: { key1: 'row3', key2: 'key2row3' },
-          row4: { key1: 'row4', key2: 'key2row4' },
-        });
-      });
-
-      it('should return empty object when first argument is null or undefined', function() {
-        var obj = fns.keyBy(null, 'key1');
-        assert.isEmpty(obj);
-
-        obj = fns.keyBy(undefined, 'key1');
-        assert.isEmpty(obj);
-      });
-    });
-
     describe('isNumber', function() {
       it('should return true in case of number', function() {
         assert.isTrue(fns.isNumber(3));

--- a/packages/optimizely-sdk/lib/utils/fns/index.tests.js
+++ b/packages/optimizely-sdk/lib/utils/fns/index.tests.js
@@ -17,10 +17,10 @@ import { assert } from 'chai';
 
 import fns from './';
 
-describe('lib/utils/fns', function() {
-  describe('APIs', function() {
-    describe('isFinite', function() {
-      it('should return false for invalid numbers', function() {
+describe('lib/utils/fns', function () {
+  describe('APIs', function () {
+    describe('isFinite', function () {
+      it('should return false for invalid numbers', function () {
         assert.isFalse(fns.isSafeInteger(Infinity));
         assert.isFalse(fns.isSafeInteger(-Infinity));
         assert.isFalse(fns.isSafeInteger(NaN));
@@ -30,7 +30,7 @@ describe('lib/utils/fns', function() {
         assert.isFalse(fns.isSafeInteger(-Math.pow(2, 53) - 2));
       });
 
-      it('should return true for valid numbers', function() {
+      it('should return true for valid numbers', function () {
         assert.isTrue(fns.isSafeInteger(0));
         assert.isTrue(fns.isSafeInteger(10));
         assert.isTrue(fns.isSafeInteger(10.5));
@@ -39,37 +39,73 @@ describe('lib/utils/fns', function() {
       });
     });
 
-    describe('isNumber', function() {
-      it('should return true in case of number', function() {
+    describe('isNumber', function () {
+      it('should return true in case of number', function () {
         assert.isTrue(fns.isNumber(3));
       });
-      it('should return true in case of value from Number object ', function() {
+      it('should return true in case of value from Number object ', function () {
         assert.isTrue(fns.isNumber(Number.MIN_VALUE));
       });
-      it('should return true in case of Infinity ', function() {
+      it('should return true in case of Infinity ', function () {
         assert.isTrue(fns.isNumber(Infinity));
       });
-      it('should return false in case of string', function() {
+      it('should return false in case of string', function () {
         assert.isFalse(fns.isNumber('3'));
       });
-      it('should return false in case of null', function() {
+      it('should return false in case of null', function () {
         assert.isFalse(fns.isNumber(null));
       });
     });
 
-    describe('assign', function() {      
-      it('should return empty object when target is not provided', function() {
-        assert.deepEqual(fns.assign(), {});        
+    describe('createMap', function () {
+      it('should return true in case of number', function () {
+        assert.deepEqual(
+          fns
+            .createMap(
+              [
+                {
+                  id: 'id.1',
+                  key: 'key.1',
+                },
+                {
+                  id: 'id.2',
+                  key: 'key.2',
+                },
+              ],
+              'key'
+            )
+            .get('key.2'),
+          {
+            id: 'id.2',
+            key: 'key.2',
+          }
+        );
+      });
+    });
+
+    describe('toObject', function () {
+      it('should return true in case of number', function () {
+        assert.deepEqual(fns.toObject(new Map([['id.1', { id: 'id.1' }]])), {
+          'id.1': {
+            id: 'id.1',
+          },
+        });
+      });
+    });
+
+    describe('assign', function () {
+      it('should return empty object when target is not provided', function () {
+        assert.deepEqual(fns.assign(), {});
       });
 
-      it('should copy correctly when Object.assign is available in environment', function() {        
-        assert.deepEqual(fns.assign({ a: 'a'}, {b: 'b'}), { a: 'a', b: 'b' });        
+      it('should copy correctly when Object.assign is available in environment', function () {
+        assert.deepEqual(fns.assign({ a: 'a' }, { b: 'b' }), { a: 'a', b: 'b' });
       });
 
-      it('should copy correctly when Object.assign is not available in environment', function() {
+      it('should copy correctly when Object.assign is not available in environment', function () {
         var originalAssign = Object.assign;
         Object.assign = null;
-        assert.deepEqual(fns.assign({ a: 'a'}, {b: 'b'}, {c: 'c'}), { a: 'a', b: 'b', c: 'c' });
+        assert.deepEqual(fns.assign({ a: 'a' }, { b: 'b' }, { c: 'c' }), { a: 'a', b: 'b', c: 'c' });
         Object.assign = originalAssign;
       });
     });

--- a/packages/optimizely-sdk/lib/utils/fns/index.ts
+++ b/packages/optimizely-sdk/lib/utils/fns/index.ts
@@ -49,6 +49,7 @@ function isSafeInteger(number: unknown): boolean {
   return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createMap<K extends { [key: string]: any }>(arr: K[], key: string): Map<string, K> {
   if (!arr || arr.length === 0) return new Map();
 
@@ -109,17 +110,19 @@ export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
   return found
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toObject<K extends { [key: string]: any }>(map: Map<string, K>): Record<string, K> {
   const obj: Record<string, K> = {};
-  return Object.fromEntries
-  ( Array.from
-      ( map.entries()
-      , ([ k, v ]) =>
-          v instanceof Map
-            ? [ k, toObject (v) ]
-            : [ k, v ]
-      )
-  )
+
+  map.forEach((item, key) => {
+    if (item instanceof Map) {
+      obj[key] = toObject(item) as K;
+    } else {
+      obj[key] = item;
+    }
+  });
+
+  return obj;
 }
 
 export function objectValues<K>(obj: { [key: string]: K }): K[] {

--- a/packages/optimizely-sdk/lib/utils/fns/index.ts
+++ b/packages/optimizely-sdk/lib/utils/fns/index.ts
@@ -49,12 +49,14 @@ function isSafeInteger(number: unknown): boolean {
   return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
 }
 
-export function keyBy<K>(arr: K[], key: string): { [key: string]: K } {
-  if (!arr) return {};
-  return keyByUtil(arr, function (item) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (item as any)[key];
-  });
+export function createMap<K extends { [key: string]: any }>(arr: K[], key: string): Map<string, K> {
+  if (!arr || arr.length === 0) return new Map();
+
+  return new Map(arr.map((item) => {
+    const identifier = item[key as keyof typeof item] as string;
+
+    return [identifier, item];
+  }));
 }
 
 function isNumber(value: unknown): boolean {
@@ -94,26 +96,6 @@ export function isValidEnum(enumToCheck: { [key: string]: any }, value: number |
   return found
 }
 
-export function groupBy<K>(arr: K[], grouperFn: (item: K) => string): Array<K[]> {
-  const grouper: { [key: string]: K[] } = {}
-
-  arr.forEach(item => {
-    const key = grouperFn(item)
-    grouper[key] = grouper[key] || []
-    grouper[key].push(item)
-  })
-
-  return objectValues(grouper)
-}
-
-export function objectValues<K>(obj: { [key: string]: K }): K[] {
-  return Object.keys(obj).map(key => obj[key])
-}
-
-export function objectEntries<K>(obj: { [key: string]: K }): [string, K][] {
-  return Object.keys(obj).map(key => [key, obj[key]])
-}
-
 export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
   let found
 
@@ -127,13 +109,18 @@ export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
   return found
 }
 
-export function keyByUtil<K>(arr: K[], keyByFn: (item: K) => string): { [key: string]: K } {
-  const map: { [key: string]: K } = {}
-  arr.forEach(item => {
-    const key = keyByFn(item)
-    map[key] = item
-  })
-  return map
+export function toObject<K extends { [key: string]: any }>(map: Map<string, K>): Record<string, K> {
+  const obj: Record<string, K> = {};
+
+  map.forEach((item, key) => {
+    obj[key] = item;
+  });
+
+  return obj;
+}
+
+export function objectValues<K>(obj: { [key: string]: K }): K[] {
+  return Object.keys(obj).map(key => obj[key])
 }
 
 // TODO[OASIS-6649]: Don't use any type
@@ -157,15 +144,13 @@ export default {
   assign,
   currentTimestamp,
   isSafeInteger,
-  keyBy,
+  createMap,
   uuid,
   isNumber,
   getTimestamp,
   isValidEnum,
-  groupBy,
-  objectValues,
-  objectEntries,
   find,
-  keyByUtil,
-  sprintf
+  sprintf,
+  toObject,
+  objectValues
 }

--- a/packages/optimizely-sdk/lib/utils/fns/index.ts
+++ b/packages/optimizely-sdk/lib/utils/fns/index.ts
@@ -111,12 +111,15 @@ export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
 
 export function toObject<K extends { [key: string]: any }>(map: Map<string, K>): Record<string, K> {
   const obj: Record<string, K> = {};
-
-  map.forEach((item, key) => {
-    obj[key] = item;
-  });
-
-  return obj;
+  return Object.fromEntries
+  ( Array.from
+      ( map.entries()
+      , ([ k, v ]) =>
+          v instanceof Map
+            ? [ k, toObject (v) ]
+            : [ k, v ]
+      )
+  )
 }
 
 export function objectValues<K>(obj: { [key: string]: K }): K[] {

--- a/packages/optimizely-sdk/tests/utils.spec.ts
+++ b/packages/optimizely-sdk/tests/utils.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import { isValidEnum, groupBy, objectEntries, objectValues, find, keyByUtil, sprintf } from '../lib/utils/fns'
+import { isValidEnum, groupBy, objectEntries, objectValues, find, sprintf } from '../lib/utils/fns'
 
 describe('utils', () => {
   describe('isValidEnum', () => {
@@ -72,22 +72,6 @@ describe('utils', () => {
       ]
 
       expect(find(input, item => item.firstName === 'joe')).toBeUndefined()
-    })
-  })
-
-  describe('keyBy', () => {
-    it('return an object with keys generated from the key function', () => {
-      const input = [
-        { key: 'foo', firstName: 'jordan', lastName: 'foo' },
-        { key: 'bar', firstName: 'jordan', lastName: 'bar' },
-        { key: 'baz', firstName: 'james', lastName: 'foxy' },
-      ]
-
-      expect(keyByUtil(input, item => item.key)).toEqual({
-        foo: { key: 'foo', firstName: 'jordan', lastName: 'foo' },
-        bar: { key: 'bar', firstName: 'jordan', lastName: 'bar' },
-        baz: { key: 'baz', firstName: 'james', lastName: 'foxy' },
-      })
     })
   })
 

--- a/packages/optimizely-sdk/tests/utils.spec.ts
+++ b/packages/optimizely-sdk/tests/utils.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import { isValidEnum, groupBy, objectEntries, objectValues, find, sprintf } from '../lib/utils/fns'
+import { isValidEnum, objectValues, find, sprintf } from '../lib/utils/fns'
 
 describe('utils', () => {
   describe('isValidEnum', () => {
@@ -18,32 +18,7 @@ describe('utils', () => {
     })
   })
 
-  describe('groupBy', () => {
-    it('should group values by some key function', () => {
-      const input = [
-        { firstName: 'jordan', lastName: 'foo' },
-        { firstName: 'jordan', lastName: 'bar' },
-        { firstName: 'james', lastName: 'foxy' },
-      ]
-      const result = groupBy(input, item => item.firstName)
-
-      expect(result).toEqual([
-        [
-          { firstName: 'jordan', lastName: 'foo' },
-          { firstName: 'jordan', lastName: 'bar' },
-        ],
-        [{ firstName: 'james', lastName: 'foxy' }],
-      ])
-    })
-  })
-
-  describe('objectEntries', () => {
-    it('should return object entries', () => {
-      expect(objectEntries({ foo: 'bar', bar: 123 })).toEqual([['foo', 'bar'], ['bar', 123]])
-    })
-  })
-
-  describe('objectValues', () => {
+  describe('oobjectValues', () => {
     it('should return object values', () => {
       expect(objectValues({ foo: 'bar', bar: 123 })).toEqual(['bar', 123])
     })

--- a/packages/optimizely-sdk/tsconfig.json
+++ b/packages/optimizely-sdk/tsconfig.json
@@ -13,6 +13,7 @@
     "outDir": "./dist",
     "sourceMap": true,
     "skipLibCheck": true,
+    "downlevelIteration": true
   },
   "exclude": [
     "./dist",


### PR DESCRIPTION
## Summary

This PR refactors the datafile maps to use Map() instead of object. The datafile at HelloFresh is quite sizeable and doing all these object lookups and remappings are bad for performance. Map is up to 5 times faster in big objects!

