### PR TITLE
fix: Check if window.localStorage is available before use. Warn if not. (WIP)

### DIFF
--- a/packages/event-processor/CHANGELOG.md
+++ b/packages/event-processor/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+### Fixed
+- Warn instead of error if window.localStorage is undefined or not functioning properly.
+
 ## [0.9.5] - February 2, 2022
 
 ### Changed


### PR DESCRIPTION
## Summary
- Conditionally uses window.localStorage if it exists in `pendingEventsStore.ts`. If not, logs a warning message to notify the client.

**Goal**: Mute error messages coming from execution contexts that do not have localStorage (i.e. private/incognito settings or React Native).

## Test plan

- All unit tests and FSC should pass.
