### PR TITLE
Run project config parse inside web worker

### DIFF
--- a/packages/optimizely-sdk/lib/core/project_config/parseDatafileWorker.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/parseDatafileWorker.ts
@@ -1,0 +1,33 @@
+import { tryCreatingProjectConfig } from '.';
+
+const messageListener = (e: MessageEvent<{ type: string; payload: { datafile: string | object } }>) => {
+  if (e.data.type === 'START_PARSE_DATAFILE') {
+    const { configObj, error } = tryCreatingProjectConfig({
+      datafile: e.data.payload.datafile,
+      logger: {
+        log: (...args) => {
+          console.log(...args);
+        },
+      },
+    });
+
+    if (error) {
+      postMessage({
+        type: 'DATAFILE_PARSE_ERROR',
+        payload: {
+          error: error.message,
+          parsedDatafile: null
+        }
+      })
+    } else {
+      postMessage({
+        type: 'DATAFILE_PARSE_SUCCESS',
+        payload: {
+          parsedDatafile: configObj
+        }
+      })
+    }
+  }
+};
+
+addEventListener('message', messageListener);

--- a/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
+++ b/packages/optimizely-sdk/lib/core/project_config/project_config_manager.ts
@@ -18,11 +18,7 @@ import { sprintf } from '../../utils/fns';
 
 import { ERROR_MESSAGES } from '../../utils/enums';
 import { createOptimizelyConfig } from '../optimizely_config';
-import {
-  OnReadyResult,
-  OptimizelyConfig,
-  DatafileManager,
-} from '../../shared_types';
+import { OnReadyResult, OptimizelyConfig, DatafileManager } from '../../shared_types';
 import { ProjectConfig, toDatafile, tryCreatingProjectConfig } from '../project_config';
 
 const logger = getLogger();
@@ -31,12 +27,13 @@ const MODULE_NAME = 'PROJECT_CONFIG_MANAGER';
 interface ProjectConfigManagerConfig {
   // TODO[OASIS-6649]: Don't use object type
   // eslint-disable-next-line  @typescript-eslint/ban-types
-  datafile?: string | object,
+  datafile?: string | object;
   jsonSchemaValidator?: {
-    validate(jsonObject: unknown): boolean,
+    validate(jsonObject: unknown): boolean;
   };
-  sdkKey?: string,
-  datafileManager?: DatafileManager
+  sdkKey?: string;
+  datafileManager?: DatafileManager;
+  useWebWorker?: boolean;
 }
 
 /**
@@ -74,7 +71,9 @@ export class ProjectConfigManager {
       this.jsonSchemaValidator = config.jsonSchemaValidator;
 
       if (!config.datafile && !config.sdkKey) {
-        const datafileAndSdkKeyMissingError = new Error(sprintf(ERROR_MESSAGES.DATAFILE_AND_SDK_KEY_MISSING, MODULE_NAME));
+        const datafileAndSdkKeyMissingError = new Error(
+          sprintf(ERROR_MESSAGES.DATAFILE_AND_SDK_KEY_MISSING, MODULE_NAME)
+        );
         this.readyPromise = Promise.resolve({
           success: false,
           reason: getErrorMessage(datafileAndSdkKeyMissingError),
@@ -85,10 +84,14 @@ export class ProjectConfigManager {
 
       let handleNewDatafileException = null;
       if (config.datafile) {
-        handleNewDatafileException = this.handleNewDatafile(config.datafile);
+        if (config.useWebWorker) {
+          this.readyPromise = this.handleDatafileInWebWorker(config.datafile);
+        } else {
+          handleNewDatafileException = this.handleNewDatafile(config.datafile);
+        }
       }
 
-      if (config.sdkKey &&  config.datafileManager) {
+      if (config.sdkKey && config.datafileManager) {
         this.datafileManager = config.datafileManager;
         this.datafileManager.start();
         this.readyPromise = this.datafileManager
@@ -105,7 +108,7 @@ export class ProjectConfigManager {
           reason: getErrorMessage(handleNewDatafileException, 'Invalid datafile'),
         });
       }
-    } catch (ex: any) {
+    } catch (ex) {
       logger.error(ex);
       this.readyPromise = Promise.resolve({
         success: false,
@@ -137,7 +140,7 @@ export class ProjectConfigManager {
     return {
       success: false,
       reason: getErrorMessage(null, 'Datafile manager is not provided'),
-    }
+    };
   }
 
   /**
@@ -180,7 +183,7 @@ export class ProjectConfigManager {
     const { configObj, error } = tryCreatingProjectConfig({
       datafile: newDatafile,
       jsonSchemaValidator: this.jsonSchemaValidator,
-      logger: logger
+      logger: logger,
     });
 
     if (error) {
@@ -195,6 +198,41 @@ export class ProjectConfigManager {
     }
 
     return error;
+  }
+
+  private async handleDatafileInWebWorker(newDatafile: string | object): Promise<OnReadyResult> {
+    const workerCode = '';
+    const workerBlob = new Blob([workerCode]);
+    const workerUrl = URL.createObjectURL(workerBlob);
+    const worker = new Worker(workerUrl);
+
+    return new Promise((resolve, reject) => {
+      worker.onmessage = (
+        e: MessageEvent<{ type: string; payload: { parsedDatafile: ProjectConfig | null; error?: string } }>
+      ) => {
+        if (e.data.type === 'DATAFILE_PARSE_SUCCESS') {
+          this.configObj = e.data.payload.parsedDatafile;
+
+          resolve({
+            success: true,
+          });
+        }
+
+        if (e.data.type === 'DATAFILE_PARSE_ERROR') {
+          reject({
+            success: false,
+            reason: e.data.payload.error,
+          });
+        }
+      };
+
+      worker.postMessage({
+        type: 'START_PARSE_DATAFILE',
+        payload: {
+          datafile: newDatafile,
+        },
+      });
+    });
   }
 
   /**
@@ -248,7 +286,7 @@ export class ProjectConfigManager {
    * @param  {Function} listener
    * @return {Function}
    */
-  onUpdate(listener: (config: ProjectConfig) => void): (() => void) {
+  onUpdate(listener: (config: ProjectConfig) => void): () => void {
     this.updateListeners.push(listener);
     return () => {
       const index = this.updateListeners.indexOf(listener);


### PR DESCRIPTION
## Summary

The `createProjectConfig()` function is quite slow and runs sync with the application if the datafile is provided as an `object`.

This function could easily be run inside a web worker, freeing up the main thread, and we could use the same promise to track when it's done as we use for when we fetch the datafile.

For this PR to work, we'd still need:

- A way to publish a worker with this project, we could parse the worker code as a string, for that we should isolate the functions it uses a bit better to reduce the load of this string. We could also have the worker as its own file in the repo, and the consumer could pass it as a parameter to the `createInstance` function.
