### PR TITLE
[FSSDK-8887] chore: Prepare release 4.9.3

### DIFF
--- a/packages/optimizely-sdk/CHANGELOG.md
+++ b/packages/optimizely-sdk/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Safari versions earlier than `13.0`.
 - Dropped support for Node JS versions earlier than `14`.
 
+## [4.9.3] - March 17, 2022
+
+### Changed
+- Updated README.md and package.json files to reflect that this SDK supports both Optimizely Feature Experimentation and Optimizely Full Stack ([#803](https://github.com/optimizely/javascript-sdk/pull/803)).
+
 ## [4.9.2] - June 27, 2022
 
 ### Changed

--- a/packages/optimizely-sdk/CHANGELOG.md
+++ b/packages/optimizely-sdk/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Safari versions earlier than `13.0`.
 - Dropped support for Node JS versions earlier than `14`.
 
-## [4.9.3] - March 17, 2022
+## [4.9.3] - March 17, 2023
 
 ### Changed
 - Updated README.md and package.json files to reflect that this SDK supports both Optimizely Feature Experimentation and Optimizely Full Stack ([#803](https://github.com/optimizely/javascript-sdk/pull/803)).

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -186,7 +186,7 @@ describe('javascript-sdk (Browser)', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '4.9.2');
+        assert.equal(optlyInstance.clientVersion, '4.9.3');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/packages/optimizely-sdk/lib/index.lite.tests.js
+++ b/packages/optimizely-sdk/lib/index.lite.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2022 Optimizely
+ * Copyright 2021-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/index.lite.tests.js
+++ b/packages/optimizely-sdk/lib/index.lite.tests.js
@@ -76,7 +76,7 @@ describe('optimizelyFactory', function () {
         optlyInstance.onReady().catch(function () { });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '4.9.2');
+        assert.equal(optlyInstance.clientVersion, '4.9.3');
       });
     });
   });

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -90,7 +90,7 @@ describe('optimizelyFactory', function () {
         optlyInstance.onReady().catch(function () { });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '4.9.2');
+        assert.equal(optlyInstance.clientVersion, '4.9.3');
       });
 
       describe('event processor configuration', function () {

--- a/packages/optimizely-sdk/lib/index.node.tests.js
+++ b/packages/optimizely-sdk/lib/index.node.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020, 2022 Optimizely
+ * Copyright 2016-2020, 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/utils/enums/index.ts
+++ b/packages/optimizely-sdk/lib/utils/enums/index.ts
@@ -220,8 +220,8 @@ export const NODE_CLIENT_ENGINE = 'node-sdk';
 export const REACT_CLIENT_ENGINE = 'react-sdk';
 export const REACT_NATIVE_CLIENT_ENGINE = 'react-native-sdk';
 export const REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
-export const BROWSER_CLIENT_VERSION = '4.9.2';
-export const NODE_CLIENT_VERSION = '4.9.2';
+export const BROWSER_CLIENT_VERSION = '4.9.3';
+export const NODE_CLIENT_VERSION = '4.9.3';
 
 export const DECISION_NOTIFICATION_TYPES = {
   AB_TEST: 'ab-test',

--- a/packages/optimizely-sdk/package-lock.json
+++ b/packages/optimizely-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@optimizely/optimizely-sdk",
-      "version": "4.9.2",
+      "version": "4.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@optimizely/js-sdk-datafile-manager": "^0.9.5",

--- a/packages/optimizely-sdk/package.json
+++ b/packages/optimizely-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "description": "JavaScript SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "module": "dist/optimizely.browser.es.js",
   "main": "dist/optimizely.node.min.js",

--- a/packages/optimizely-sdk/tests/index.react_native.spec.ts
+++ b/packages/optimizely-sdk/tests/index.react_native.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020, 2022 Optimizely
+ * Copyright 2019-2020, 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/tests/index.react_native.spec.ts
+++ b/packages/optimizely-sdk/tests/index.react_native.spec.ts
@@ -90,7 +90,7 @@ describe('javascript-sdk/react-native', () => {
 
         expect(optlyInstance).toBeInstanceOf(Optimizely);
         // @ts-ignore
-        expect(optlyInstance.clientVersion).toEqual('4.9.2');
+        expect(optlyInstance.clientVersion).toEqual('4.9.3');
       });
 
       it('should set the React Native JS client engine and javascript SDK version', () => {

--- a/packages/optimizely-sdk/tests/odpEventManager.spec.ts
+++ b/packages/optimizely-sdk/tests/odpEventManager.spec.ts
@@ -55,7 +55,7 @@ const EVENTS: OdpEvent[] = [
 ];
 // naming for object destructuring
 const clientEngine = 'javascript-sdk';
-const clientVersion = '4.9.2';
+const clientVersion = '4.9.3';
 const PROCESSED_EVENTS: OdpEvent[] = [
   new OdpEvent(
     't1',


### PR DESCRIPTION
## Summary
- Incremented Optimizely SDK version from 4.9.2 to 4.9.3

## Test plan

All tests should pass.

## Issues
- [FSSDK-8887](https://jira.sso.episerver.net/browse/FSSDK-8887) 