### PR TITLE
feat(ats): [FSSDK-8690] fix configurable ODP request timeouts

### DIFF
--- a/packages/optimizely-sdk/lib/plugins/odp_manager/index.browser.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp_manager/index.browser.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { BROWSER_CLIENT_VERSION, ERROR_MESSAGES, JAVASCRIPT_CLIENT_ENGINE, ODP_USER_KEY } from '../../utils/enums';
+import { 
+  BROWSER_CLIENT_VERSION, 
+  ERROR_MESSAGES, 
+  JAVASCRIPT_CLIENT_ENGINE, 
+  ODP_USER_KEY, 
+  REQUEST_TIMEOUT_ODP_SEGMENTS_MS, 
+  REQUEST_TIMEOUT_ODP_EVENTS_MS 
+} from '../../utils/enums';
 import { getLogger, LoggerFacade, LogHandler, LogLevel } from '../../modules/logging';
 
 import { BrowserRequestHandler } from './../../utils/http_request_handler/browser_request_handler';
@@ -49,16 +56,22 @@ export class BrowserOdpManager extends OdpManager {
 
     if (odpOptions?.segmentsRequestHandler) {
       customSegmentRequestHandler = odpOptions.segmentsRequestHandler;
-    } else if (odpOptions?.segmentsApiTimeout) {
-      customSegmentRequestHandler = new BrowserRequestHandler(browserLogger, odpOptions.segmentsApiTimeout);
+    } else {
+      customSegmentRequestHandler = new BrowserRequestHandler(
+        browserLogger, 
+        odpOptions?.segmentsApiTimeout || REQUEST_TIMEOUT_ODP_SEGMENTS_MS
+      );
     }
 
     let customEventRequestHandler;
 
     if (odpOptions?.eventRequestHandler) {
       customEventRequestHandler = odpOptions.eventRequestHandler;
-    } else if (odpOptions?.eventApiTimeout) {
-      customEventRequestHandler = new BrowserRequestHandler(browserLogger, odpOptions.eventApiTimeout);
+    } else {
+      customEventRequestHandler = new BrowserRequestHandler(
+        browserLogger, 
+        odpOptions?.eventApiTimeout || REQUEST_TIMEOUT_ODP_EVENTS_MS
+      );
     }
 
     super({
@@ -68,8 +81,8 @@ export class BrowserOdpManager extends OdpManager {
           maxSize: odpOptions?.segmentsCacheSize,
           timeout: odpOptions?.segmentsCacheTimeout,
         }),
-      segmentRequestHandler: customSegmentRequestHandler || new BrowserRequestHandler(browserLogger),
-      eventRequestHandler: customEventRequestHandler || new BrowserRequestHandler(browserLogger),
+      segmentRequestHandler: customSegmentRequestHandler,
+      eventRequestHandler: customEventRequestHandler,
       logger: browserLogger,
       clientEngine: browserClientEngine,
       clientVersion: browserClientVersion,

--- a/packages/optimizely-sdk/lib/utils/enums/index.ts
+++ b/packages/optimizely-sdk/lib/utils/enums/index.ts
@@ -337,6 +337,8 @@ export enum NOTIFICATION_TYPES {
  * Default milliseconds before request timeout
  */
 export const REQUEST_TIMEOUT_MS = 60 * 1000; // 1 minute
+export const REQUEST_TIMEOUT_ODP_SEGMENTS_MS = 10 * 1000;  // 10 secs
+export const REQUEST_TIMEOUT_ODP_EVENTS_MS = 10 * 1000;  // 10 secs
 
 /**
  * ODP User Key Options

--- a/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
+++ b/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
@@ -336,6 +336,13 @@ describe('OdpManager', () => {
       expect(browserOdpManager.segmentManager.odpSegmentApiManager.requestHandler.timeout).toBe(4000);
     });
 
+    it('Browser default Segments API Request Handler timeout should be used when odpOptions does not include segmentsApiTimeout', () => {
+      const browserOdpManager = new BrowserOdpManager({});
+
+      // @ts-ignore
+      expect(browserOdpManager.segmentManager.odpSegmentApiManager.requestHandler.timeout).toBe(10000);
+    });
+
     it('Custom odpOptions.segmentsRequestHandler overrides default Segment API Request Handler', () => {
       const odpOptions: OdpOptions = {
         segmentsRequestHandler: new BrowserRequestHandler(fakeLogger, 4000),
@@ -429,6 +436,18 @@ describe('OdpManager', () => {
 
       // @ts-ignore
       expect(browserOdpManager.eventManager.apiManager.requestHandler.timeout).toBe(4000);
+    });
+
+    it('Browser default Events API Request Handler timeout should be used when odpOptions does not include eventssApiTimeout', () => {
+      const odpOptions: OdpOptions = {
+      };
+
+      const browserOdpManager = new BrowserOdpManager({
+        odpOptions,
+      });
+
+      // @ts-ignore
+      expect(browserOdpManager.eventManager.apiManager.requestHandler.timeout).toBe(10000);
     });
 
     it('Custom odpOptions.eventFlushInterval overrides default Event Manager flush interval', () => {

--- a/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
+++ b/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
@@ -438,7 +438,7 @@ describe('OdpManager', () => {
       expect(browserOdpManager.eventManager.apiManager.requestHandler.timeout).toBe(4000);
     });
 
-    it('Browser default Events API Request Handler timeout should be used when odpOptions does not include eventssApiTimeout', () => {
+    it('Browser default Events API Request Handler timeout should be used when odpOptions does not include eventsApiTimeout', () => {
       const odpOptions: OdpOptions = {
       };
 


### PR DESCRIPTION
## Summary
Support configurable timeouts for ODP segment and event requests.
Use default timeout of 10 secs if not configured.

## Test plan
- Add unit tests for configured and default timeout values

## Issues
- [FSSDK-8690](https://jira.sso.episerver.net/browse/FSSDK-8690)
