### PR TITLE
[FSSDK-8993]feat: switch odp event rest endpoint

### DIFF
--- a/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
@@ -16,7 +16,7 @@
 
 import { LogHandler, LogLevel } from '../../modules/logging';
 import { OdpEvent } from './odp_event';
-import { browserMode } from './odp_utils';
+import { isBrowserContext } from './odp_utils';
 import { RequestHandler } from '../../utils/http_request_handler/http';
 import { ODP_EVENT_BROWSER_ENDPOINT } from '../../utils/enums';
 
@@ -35,7 +35,7 @@ export interface IOdpEventApiManager {
 export class OdpEventApiManager implements IOdpEventApiManager {
   private readonly logger: LogHandler;
   private readonly requestHandler: RequestHandler;
-  private readonly browserMode: boolean;
+  private readonly isBrowser: boolean;
 
   /**
    * Creates instance to access Optimizely Data Platform (ODP) REST API
@@ -45,7 +45,7 @@ export class OdpEventApiManager implements IOdpEventApiManager {
   constructor(requestHandler: RequestHandler, logger: LogHandler) {
     this.requestHandler = requestHandler;
     this.logger = logger;
-    this.browserMode = browserMode()
+    this.isBrowser = isBrowserContext()
   }
 
   /**
@@ -68,14 +68,14 @@ export class OdpEventApiManager implements IOdpEventApiManager {
       return shouldRetry;
     }
 
-    if (events.length > 1 && this.browserMode) {
+    if (events.length > 1 && this.isBrowser) {
       this.logger.log(LogLevel.ERROR, `${EVENT_SENDING_FAILURE_MESSAGE} (browser only supports batch size 1)`);
       return shouldRetry;
     }
 
     let method, endpoint, headers, data;
 
-    if (this.browserMode) {
+    if (this.isBrowser) {
       method = 'GET';
       const event = events[0];
       const url = new URL(ODP_EVENT_BROWSER_ENDPOINT);

--- a/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
@@ -41,7 +41,6 @@ export class OdpEventApiManager implements IOdpEventApiManager {
    * Creates instance to access Optimizely Data Platform (ODP) REST API
    * @param requestHandler Desired request handler for testing
    * @param logger Collect and record events/errors for this GraphQL implementation
-   * @param browserMode true if running in browser
    */
   constructor(requestHandler: RequestHandler, logger: LogHandler) {
     this.requestHandler = requestHandler;

--- a/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_api_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, Optimizely
+ * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import { LogHandler, LogLevel } from '../../modules/logging';
 import { OdpEvent } from './odp_event';
+import { browserMode } from './odp_utils';
 import { RequestHandler } from '../../utils/http_request_handler/http';
 import { ODP_EVENT_BROWSER_ENDPOINT } from '../../utils/enums';
 
@@ -45,7 +46,7 @@ export class OdpEventApiManager implements IOdpEventApiManager {
   constructor(requestHandler: RequestHandler, logger: LogHandler) {
     this.requestHandler = requestHandler;
     this.logger = logger;
-    this.browserMode = typeof process === 'undefined';
+    this.browserMode = browserMode()
   }
 
   /**

--- a/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
@@ -22,7 +22,7 @@ import { ERROR_MESSAGES, ODP_USER_KEY, ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION 
 import { OdpEvent } from './odp_event';
 import { OdpConfig } from './odp_config';
 import { OdpEventApiManager } from './odp_event_api_manager';
-import { invalidOdpDataFound } from './odp_utils';
+import { invalidOdpDataFound, browserMode } from './odp_utils';
 
 const MAX_RETRIES = 3;
 const DEFAULT_BATCH_SIZE = 10;
@@ -146,7 +146,7 @@ export class OdpEventManager implements IOdpEventManager {
     // browser only accepts batchSize = 1
     this.batchSize = 1
 
-    if (typeof process  !== 'undefined') {
+    if (!browserMode()) {
       defaultQueueSize = DEFAULT_SERVER_QUEUE_SIZE;
       this.batchSize = batchSize || DEFAULT_BATCH_SIZE;
     } else if (typeof batchSize !== 'undefined' && batchSize !== 1) {
@@ -393,7 +393,7 @@ export class OdpEventManager implements IOdpEventManager {
       return true;
     }
 
-    if (typeof process !== 'undefined') {
+    if (!browserMode()) {
       // if Node/server-side context, empty queue items before ready state
       this.logger.log(LogLevel.WARNING, 'ODPConfig not ready. Discarding events in queue.');
       this.queue = new Array<OdpEvent>();

--- a/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
@@ -22,7 +22,7 @@ import { ERROR_MESSAGES, ODP_USER_KEY, ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION 
 import { OdpEvent } from './odp_event';
 import { OdpConfig } from './odp_config';
 import { OdpEventApiManager } from './odp_event_api_manager';
-import { invalidOdpDataFound, browserMode } from './odp_utils';
+import { invalidOdpDataFound, isBrowserContext } from './odp_utils';
 
 const MAX_RETRIES = 3;
 const DEFAULT_BATCH_SIZE = 10;
@@ -97,12 +97,12 @@ export class OdpEventManager implements IOdpEventManager {
    */
   private readonly queueSize: number;
   /**
-   * Maximum number of events to process at once
+   * Maximum number of events to process at once. Ignored in browser context
    * @private
    */
   private readonly batchSize: number;
   /**
-   * Milliseconds between setTimeout() to process new batches
+   * Milliseconds between setTimeout() to process new batches. Ignored in browser context
    * @private
    */
   private readonly flushInterval: number;
@@ -142,7 +142,7 @@ export class OdpEventManager implements IOdpEventManager {
     this.clientEngine = clientEngine;
     this.clientVersion = clientVersion;
 
-    const isBrowser = browserMode();
+    const isBrowser = isBrowserContext();
 
     const defaultQueueSize = isBrowser ? DEFAULT_BROWSER_QUEUE_SIZE : DEFAULT_SERVER_QUEUE_SIZE;
     this.queueSize = queueSize || defaultQueueSize;
@@ -402,7 +402,7 @@ export class OdpEventManager implements IOdpEventManager {
       return true;
     }
 
-    if (!browserMode()) {
+    if (!isBrowserContext()) {
       // if Node/server-side context, empty queue items before ready state
       this.logger.log(LogLevel.WARNING, 'ODPConfig not ready. Discarding events in queue.');
       this.queue = new Array<OdpEvent>();

--- a/packages/optimizely-sdk/lib/core/odp/odp_utils.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_utils.ts
@@ -30,3 +30,14 @@ export function invalidOdpDataFound(data: Map<string, any>): boolean {
   });
   return foundInvalidValue;
 }
+
+/**
+ * Determine if the runtime environment is a browser
+ * @returns True if in the browser
+ * @private
+ */
+export function browserMode(): boolean {
+   return !(typeof process !== "undefined" &&
+    process.versions != null &&
+    process.versions.node != null);
+}

--- a/packages/optimizely-sdk/lib/core/odp/odp_utils.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_utils.ts
@@ -36,7 +36,7 @@ export function invalidOdpDataFound(data: Map<string, any>): boolean {
  * @returns True if in the browser
  * @private
  */
-export function browserMode(): boolean {
+export function isBrowserContext(): boolean {
    return !(typeof process !== "undefined" &&
     process.versions != null &&
     process.versions.node != null);

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -30,7 +30,7 @@ import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
 import { OdpConfig } from './core/odp/odp_config';
 import { OdpEventManager } from './core/odp/odp_event_manager';
 import { OdpEventApiManager } from './core/odp/odp_event_api_manager';
-import { browserMode } from './core/odp/odp_utils';
+import { isBrowserContext } from './core/odp/odp_utils';
 
 var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEventsDispatcher;
 
@@ -589,10 +589,10 @@ describe('javascript-sdk (Browser)', function() {
       const requestParams = new Map;
       const mockRequestHandler = {
         makeRequest: (endpoint, headers, method, data) => {
-          requestParams.endpoint = endpoint;
-          requestParams.headers = headers;
-          requestParams.method = method;
-          requestParams.data = data;
+          requestParams.set('endpoint', endpoint);
+          requestParams.set('headers', headers);
+          requestParams.set('method', method);
+          requestParams.set('data', data);
           return {responsePromise: (async()=>{return {statusCode: 200}})()}
         },
         args: requestParams
@@ -825,7 +825,7 @@ describe('javascript-sdk (Browser)', function() {
       });
 
       it('should log a warning when attempting to use an event batch size other than 1', async () => {
-        if (!browserMode()) {
+        if (!isBrowserContext()) {
           return
         }
         const client = optimizelyFactory.createInstance({
@@ -851,7 +851,7 @@ describe('javascript-sdk (Browser)', function() {
       });
 
       it('should send an odp event to the browser endpoint', async () => {
-        if (!browserMode()) {
+        if (!isBrowserContext()) {
           return
         }
         const odpConfig = new OdpConfig();
@@ -884,9 +884,9 @@ describe('javascript-sdk (Browser)', function() {
 
         let publicKey = datafile.integrations[0].publicKey;
 
-        let requestEndpoint = new URL(requestParams.endpoint);
+        let requestEndpoint = new URL(requestParams.get('endpoint'));
         assert.equal(requestEndpoint.origin + requestEndpoint.pathname, ODP_EVENT_BROWSER_ENDPOINT)
-        assert.equal(requestParams.method, 'GET')
+        assert.equal(requestParams.get('method'), 'GET')
 
         let searchParams = requestEndpoint.searchParams;
         assert.lengthOf(searchParams.get('idempotence_id'), 36);

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -30,6 +30,7 @@ import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
 import { OdpConfig } from './core/odp/odp_config';
 import { OdpEventManager } from './core/odp/odp_event_manager';
 import { OdpEventApiManager } from './core/odp/odp_event_api_manager';
+import { browserMode } from './core/odp/odp_utils';
 
 var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEventsDispatcher;
 
@@ -824,8 +825,11 @@ describe('javascript-sdk (Browser)', function() {
       });
 
       it('should log a warning when attempting to use an event batch size other than 1', async () => {
+        if (!browserMode()) {
+          return
+        }
         const client = optimizelyFactory.createInstance({
-          datafile: testData.getTestProjectConfigWithFeatures(),
+          datafile: testData.getOdpIntegratedConfigWithSegments(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
@@ -847,6 +851,9 @@ describe('javascript-sdk (Browser)', function() {
       });
 
       it('should send an odp event to the browser endpoint', async () => {
+        if (!browserMode()) {
+          return
+        }
         const odpConfig = new OdpConfig();
         const apiManager = new OdpEventApiManager(mockRequestHandler, logger);
         const eventManager = new OdpEventManager({odpConfig, apiManager, logger, clientEngine: "javascript-sdk", clientVersion: "great" })

--- a/packages/optimizely-sdk/lib/index.browser.tests.js
+++ b/packages/optimizely-sdk/lib/index.browser.tests.js
@@ -25,9 +25,11 @@ import optimizelyFactory from './index.browser';
 import configValidator from './utils/config_validator';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
 import OptimizelyUserContext from './optimizely_user_context';
-import { LOG_MESSAGES, ODP_EVENT_ACTION } from './utils/enums';
+import { LOG_MESSAGES, ODP_EVENT_ACTION, ODP_EVENT_BROWSER_ENDPOINT } from './utils/enums';
 import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
 import { OdpConfig } from './core/odp/odp_config';
+import { OdpEventManager } from './core/odp/odp_event_manager';
+import { OdpEventApiManager } from './core/odp/odp_event_api_manager';
 
 var LocalStoragePendingEventsDispatcher = eventProcessor.LocalStoragePendingEventsDispatcher;
 
@@ -582,14 +584,29 @@ describe('javascript-sdk (Browser)', function() {
 
       const testFsUserId = 'fs_test_user';
       const testVuid = 'vuid_test_user';
+      var clock;
+      const requestParams = new Map;
+      const mockRequestHandler = {
+        makeRequest: (endpoint, headers, method, data) => {
+          requestParams.endpoint = endpoint;
+          requestParams.headers = headers;
+          requestParams.method = method;
+          requestParams.data = data;
+          return {responsePromise: (async()=>{return {statusCode: 200}})()}
+        },
+        args: requestParams
+      };
 
       beforeEach(function() {
         sandbox.stub(logger, 'log');
         sandbox.stub(logger, 'error');
+        clock = sinon.useFakeTimers(new Date());
       });
 
       afterEach(function() {
         sandbox.restore();
+        clock.restore()
+        requestParams.clear()
       });
 
       it('should send identify event by default when initialized', () => {
@@ -672,13 +689,10 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
-            logger,
-            odpOptions: {
-              segmentsCacheSize: 10,
-              segmentsCacheTimeout: 10,
-            },
-          }),
+          odpOptions: {
+            segmentsCacheSize: 10,
+            segmentsCacheTimeout: 10,
+          },
         });
 
         sinon.assert.calledWith(
@@ -694,7 +708,6 @@ describe('javascript-sdk (Browser)', function() {
         );
       });
 
-      // TODO: Patch VUID Promise Pattern (@Andy)
       it('should accept a valid custom odp segment manager', async () => {
         const fakeSegmentManager = {
           fetchQualifiedSegments: sinon.spy(),
@@ -707,29 +720,25 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
-            logger,
-            odpOptions: {
-              segmentManager: fakeSegmentManager,
-            },
-          }),
+          odpOptions: {
+            segmentManager: fakeSegmentManager,
+          },
         });
 
         sinon.assert.called(fakeSegmentManager.updateSettings);
 
-        try {
-          const readyData = await client.onReady();
-          assert.equal(readyData.success, true);
-          assert.isEmpty(readyData.reason);
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
 
-          await client.fetchQualifiedSegments(testVuid);
+        await client.fetchQualifiedSegments(testVuid);
 
-          sinon.assert.notCalled(logger.error);
-          sinon.assert.called(fakeSegmentManager.fetchQualifiedSegments);
-        } catch (e) {}
+        sinon.assert.notCalled(logger.error);
+        sinon.assert.called(fakeSegmentManager.fetchQualifiedSegments);
+
       });
 
-      it('should accept a valid custom odp event manager', () => {
+      it('should accept a valid custom odp event manager', async () => {
         const fakeEventManager = {
           start: sinon.spy(),
           updateSettings: sinon.spy(),
@@ -746,49 +755,51 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
-            logger,
-            odpOptions: {
-              eventManager: fakeEventManager,
-            },
-          }),
+          odpOptions: {
+            disabled: false,
+            eventManager: fakeEventManager,
+          }
         });
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
 
         sinon.assert.called(fakeEventManager.start);
       });
 
-      // TODO: Patch VUID Promise Pattern (@Andy)
       it('should send an odp event with sendOdpEvent', async () => {
-        const fakeOdpManager = {
-          sendEvent: sinon.spy(),
+        const fakeEventManager = {
           updateSettings: sinon.spy(),
+          start: sinon.spy(),
+          stop: sinon.spy(),
+          registerVuid: sinon.spy(),
           identifyUser: sinon.spy(),
-          close: sinon.spy(),
+          sendEvent: sinon.spy(),
+          flush: sinon.spy(),
         };
 
         const client = optimizelyFactory.createInstance({
-          datafile: testData.getTestProjectConfigWithFeatures(),
+          datafile: testData.getOdpIntegratedConfigWithSegments(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: fakeOdpManager,
+          odpOptions: {
+            eventManager: fakeEventManager
+          }
         });
 
-        try {
-          const readyData = await client.onReady();
-          assert.equal(readyData.success, true);
-          assert.isEmpty(readyData.reason);
-          client.sendOdpEvent({
-            action: ODP_EVENT_ACTION.INITIALIZED,
-          });
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
+        await client.sendOdpEvent({
+          action: ODP_EVENT_ACTION.INITIALIZED,
+        });
 
-          sinon.assert.notCalled(logger.error);
-          sinon.assert.called(fakeOdpManager.sendEvent);
-        } catch (e) {}
+        sinon.assert.notCalled(logger.error);
+        sinon.assert.called(fakeEventManager.sendEvent);
       });
 
-      // TODO: Patch VUID Promise Pattern (@Andy)
       it('should log an error when attempting to send an odp event when odp is disabled', async () => {
         const client = optimizelyFactory.createInstance({
           datafile: testData.getTestProjectConfigWithFeatures(),
@@ -796,25 +807,92 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
-            logger,
-            odpOptions: {
-              disabled: true,
-            },
-          }),
+          odpOptions: {
+            disabled: true,
+          },
         });
 
-        try {
-          const readyData = await client.onReady();
-          assert.equal(readyData.success, true);
-          assert.isEmpty(readyData.reason);
-          client.sendOdpEvent({
-            action: ODP_EVENT_ACTION.INITIALIZED,
-          });
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
+        await client.sendOdpEvent({
+          action: ODP_EVENT_ACTION.INITIALIZED,
+        });
 
-          sinon.assert.calledWith(logger.error, 'ODP event send failed.');
-          sinon.assert.calledWith(logger.error, 'ODP is not enabled.');
-        } catch (e) {}
+        sinon.assert.calledWith(logger.error, 'ODP event send failed.');
+        sinon.assert.calledWith(logger.log, optimizelyFactory.enums.LOG_LEVEL.INFO, 'ODP Disabled.');
+      });
+
+      it('should log a warning when attempting to use an event batch size other than 1', async () => {
+        const client = optimizelyFactory.createInstance({
+          datafile: testData.getTestProjectConfigWithFeatures(),
+          errorHandler: fakeErrorHandler,
+          eventDispatcher: fakeEventDispatcher,
+          eventBatchSize: null,
+          logger,
+          odpOptions: {
+            eventBatchSize: 5
+          },
+        });
+
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
+        await client.sendOdpEvent({
+          action: ODP_EVENT_ACTION.INITIALIZED,
+        });
+
+        sinon.assert.calledWith(logger.log, optimizelyFactory.enums.LOG_LEVEL.WARNING, 'ODP event batch size must be 1 in the browser.');
+        assert(client.odpManager.eventManager.batchSize, 1);
+      });
+
+      it('should send an odp event to the browser endpoint', async () => {
+        const odpConfig = new OdpConfig();
+        const apiManager = new OdpEventApiManager(mockRequestHandler, logger);
+        const eventManager = new OdpEventManager({odpConfig, apiManager, logger, clientEngine: "javascript-sdk", clientVersion: "great" })
+
+        let datafile = testData.getOdpIntegratedConfigWithSegments();
+
+        const client = optimizelyFactory.createInstance({
+          datafile,
+          errorHandler: fakeErrorHandler,
+          eventDispatcher: fakeEventDispatcher,
+          eventBatchSize: null,
+          logger,
+          odpOptions: {
+            odpConfig,
+            eventManager
+          }
+        });
+
+        const readyData = await client.onReady();
+        assert.equal(readyData.success, true);
+        assert.isUndefined(readyData.reason);
+        await client.sendOdpEvent({
+          action: ODP_EVENT_ACTION.INITIALIZED,
+        });
+
+        // wait for request to be sent
+        clock.tick(100);
+
+        let publicKey = datafile.integrations[0].publicKey;
+
+        let requestEndpoint = new URL(requestParams.endpoint);
+        assert.equal(requestEndpoint.origin + requestEndpoint.pathname, ODP_EVENT_BROWSER_ENDPOINT)
+        assert.equal(requestParams.method, 'GET')
+
+        let searchParams = requestEndpoint.searchParams;
+        assert.lengthOf(searchParams.get('idempotence_id'), 36);
+        assert.equal(searchParams.get('data_source'), 'javascript-sdk');
+        assert.equal(searchParams.get('data_source_type'), 'sdk');
+        assert.equal(searchParams.get('data_source_version'), 'great');
+        assert.equal(searchParams.get('tracker_id'), publicKey);
+        assert.equal(searchParams.get('event_type'), 'fullstack');
+        assert.equal(searchParams.get('vdl_action'), ODP_EVENT_ACTION.INITIALIZED);
+        assert.isTrue(searchParams.get('vuid').startsWith('vuid_'));
+        assert.isNotNull(searchParams.get('data_source_version'));
+
+        sinon.assert.notCalled(logger.error);
       });
     });
   });

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -1668,7 +1668,7 @@ export default class Optimizely {
    * @param {Map<string, string>} odpEvent.identifiers    (Optional) Key-value map of user identifiers
    * @param {Map<string, string>} odpEvent.data           (Optional) Event data in a key-value map.
    */
-  public sendOdpEvent({
+  public async sendOdpEvent({
     type,
     action,
     identifiers,
@@ -1678,16 +1678,17 @@ export default class Optimizely {
     action: ODP_EVENT_ACTION;
     identifiers?: Map<string, string>;
     data?: Map<string, unknown>;
-  }): void {
+  }): Promise<void> {
     if (!this.odpManager) {
       this.logger.error(ERROR_MESSAGES.ODP_EVENT_FAILED_ODP_MANAGER_MISSING);
+      return;
     }
 
     const odpEventType = type ?? ODP_DEFAULT_EVENT_TYPE;
 
     try {
       const odpEvent = new OdpEvent(odpEventType, action, identifiers, data);
-      this.odpManager!.sendEvent(odpEvent);
+      await this.odpManager.sendEvent(odpEvent);
     } catch (e) {
       this.logger.error(ERROR_MESSAGES.ODP_EVENT_FAILED, e);
     }
@@ -1697,9 +1698,9 @@ export default class Optimizely {
    * Identifies user with ODP server in a fire-and-forget manner.
    * @param {string} userId
    */
-  public identifyUser(userId: string): void {
+  public async identifyUser(userId: string): Promise<void> {
     if (this.odpManager && this.odpManager.enabled) {
-      this.odpManager.identifyUser(userId);
+      await this.odpManager.identifyUser(userId);
     }
   }
 

--- a/packages/optimizely-sdk/lib/plugins/odp_manager/index.browser.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp_manager/index.browser.ts
@@ -38,6 +38,7 @@ interface BrowserOdpManagerConfig {
 export class BrowserOdpManager extends OdpManager {
   static cache = new BrowserAsyncStorageCache();
   vuid?: string;
+  initPromise?: Promise<void>
 
   constructor({ logger, odpOptions }: BrowserOdpManagerConfig) {
     const browserLogger = logger || getLogger('BrowserOdpManager');
@@ -77,7 +78,9 @@ export class BrowserOdpManager extends OdpManager {
     });
 
     this.logger = browserLogger;
-    this.initializeVuid(BrowserOdpManager.cache);
+    this.initPromise = this.initializeVuid(BrowserOdpManager.cache).catch(e => {
+      this.logger.log(this.enabled ? LogLevel.ERROR : LogLevel.DEBUG, e);
+    });
   }
 
   /**
@@ -108,7 +111,8 @@ export class BrowserOdpManager extends OdpManager {
    * - Additionally, also passes VUID to help identify client-side users
    * @param fsUserId Unique identifier of a target user.
    */
-  public identifyUser(fsUserId?: string, vuid?: string): void {
+  public async identifyUser(fsUserId?: string, vuid?: string): Promise<void> {
+    await this.initPromise;
     if (fsUserId && VuidManager.isVuid(fsUserId)) {
       super.identifyUser(undefined, fsUserId);
       return;
@@ -129,7 +133,8 @@ export class BrowserOdpManager extends OdpManager {
    * - Identifiers must contain at least one key-value pair
    * @param {OdpEvent} odpEvent  > ODP Event to send to event manager
    */
-  public sendEvent({ type, action, identifiers, data }: OdpEvent): void {
+  public async sendEvent({ type, action, identifiers, data }: OdpEvent): Promise<void> {
+    await this.initPromise;
     const identifiersWithVuid = new Map<string, string>(identifiers);
 
     if (!identifiers.has(ODP_USER_KEY.VUID)) {

--- a/packages/optimizely-sdk/lib/utils/enums/index.ts
+++ b/packages/optimizely-sdk/lib/utils/enums/index.ts
@@ -347,6 +347,7 @@ export enum ODP_USER_KEY {
 }
 
 export const ODP_DEFAULT_EVENT_TYPE = 'fullstack';
+export const ODP_EVENT_BROWSER_ENDPOINT = 'https://jumbe.zaius.com/v2/zaius.gif';
 
 /**
  * ODP Event Action Options

--- a/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
+++ b/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
@@ -126,7 +126,7 @@ describe('OdpManager', () => {
     await browserOdpManager.fetchQualifiedSegments('vuid_user1', []);
     verify(mockLogger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_ENABLED)).once();
 
-    browserOdpManager.identifyUser('vuid_user1');
+    await browserOdpManager.identifyUser('vuid_user1');
     verify(mockLogger.log(LogLevel.DEBUG, LOG_MESSAGES.ODP_IDENTIFY_FAILED_ODP_DISABLED)).once();
 
     expect(browserOdpManager.eventManager).toBeUndefined;
@@ -172,7 +172,7 @@ describe('OdpManager', () => {
     const updateSettingsArgsA = capture(mockEventManager.updateSettings).last();
     expect(updateSettingsArgsA[0]).toStrictEqual(odpConfigA);
 
-    browserOdpManager.identifyUser(userA);
+    await browserOdpManager.identifyUser(userA);
     const identifyUserArgsA = capture(mockEventManager.identifyUser).last();
     expect(identifyUserArgsA[0]).toStrictEqual(userA);
 
@@ -183,7 +183,7 @@ describe('OdpManager', () => {
     const updateSettingsArgsB = capture(mockEventManager.updateSettings).last();
     expect(updateSettingsArgsB[0]).toStrictEqual(odpConfigB);
 
-    browserOdpManager.eventManager!.identifyUser(userB);
+    await browserOdpManager.eventManager!.identifyUser(userB);
     const identifyUserArgsB = capture(mockEventManager.identifyUser).last();
     expect(identifyUserArgsB[0]).toStrictEqual(userB);
   });
@@ -236,7 +236,7 @@ describe('OdpManager', () => {
     expect(browserOdpManagerB.eventManager).not.toBe(null);
   });
 
-  it("should call event manager's sendEvent if ODP Event is valid", () => {
+  it("should call event manager's sendEvent if ODP Event is valid", async () => {
     const browserOdpManager = new BrowserOdpManager({
       odpOptions: {
         eventManager: fakeEventManager,
@@ -253,16 +253,16 @@ describe('OdpManager', () => {
 
     const validOdpEvent = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.INITIALIZED, validIdentifiers);
 
-    browserOdpManager.sendEvent(validOdpEvent);
+    await browserOdpManager.sendEvent(validOdpEvent);
     verify(mockEventManager.sendEvent(anything())).once();
 
     // Test Invalid OdpEvents - logs error and short circuits
     // Does not include `vuid` in identifiers does not have a local this.vuid populated in BrowserOdpManager
+    browserOdpManager.vuid = undefined;
     const invalidOdpEvent = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.INITIALIZED, undefined);
 
-    expect(() => {
-      browserOdpManager.sendEvent(invalidOdpEvent);
-    }).toThrow(ERROR_MESSAGES.ODP_SEND_EVENT_FAILED_VUID_MISSING);
+    await expect(browserOdpManager.sendEvent(invalidOdpEvent))
+      .rejects.toThrow(ERROR_MESSAGES.ODP_SEND_EVENT_FAILED_VUID_MISSING)
   });
 
   describe('Populates BrowserOdpManager correctly with all odpOptions', () => {


### PR DESCRIPTION
## Summary
Changed the behavior of sendOdpEvent in the browser to utilize the ODP Pixel API ([https://jumbe.zaius.com/v2/zaius.gif) ](https://jumbe.zaius.com/v2/zaius.gif) via GET call.
- Key/value pairs from data and identifiers as well as apiKey, type and action are shifted to to the URL query parameters of the GET request.
- Pixel API does not support batching

## Test plan
- added tests to index.browser.tests.js
- existing tests pass
## Ticket
[FSSDK-8993](https://jira.sso.episerver.net/browse/FSSDK-8993)