### PR TITLE
feat(ats): [FSSDK-8793] add support for disabling odp event batching

### DIFF
--- a/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
@@ -153,7 +153,13 @@ export class OdpEventManager implements IOdpEventManager {
 
     this.queueSize = queueSize || defaultQueueSize;
     this.batchSize = batchSize || DEFAULT_BATCH_SIZE;
-    this.flushInterval = flushInterval || DEFAULT_FLUSH_INTERVAL_MSECS;
+    if (flushInterval === 0) {
+      // disable event batching
+      this.batchSize = 1;
+      this.flushInterval = 0;
+    } else {
+      this.flushInterval = flushInterval || DEFAULT_FLUSH_INTERVAL_MSECS;
+    }
 
     this.state = STATE.STOPPED;
   }

--- a/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
+++ b/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
@@ -444,6 +444,34 @@ describe('OdpManager', () => {
       expect(browserOdpManager.eventManager.flushInterval).toBe(4000);
     });
 
+    it('Default ODP event flush interval is used when odpOptions does not include eventFlushInterval', () => {
+      const odpOptions: OdpOptions = {};
+
+      const browserOdpManager = new BrowserOdpManager({
+        odpOptions,
+      });
+
+      // @ts-ignore
+      expect(browserOdpManager.eventManager.flushInterval).toBe(1000);
+    });
+
+    it('ODP event batch size set to one when odpOptions.eventFlushInterval set to 0', () => {
+      const odpOptions: OdpOptions = {
+        eventFlushInterval: 0,
+      };
+
+      const browserOdpManager = new BrowserOdpManager({
+        odpOptions,
+      });
+
+      // @ts-ignore
+      expect(browserOdpManager.eventManager.flushInterval).toBe(0);
+
+      // @ts-ignore
+      expect(browserOdpManager.eventManager.batchSize).toBe(1);
+    });
+
+
     it('Custom odpOptions.eventBatchSize overrides default Event Manager batch size', () => {
       const odpOptions: OdpOptions = {
         eventBatchSize: 2,

--- a/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
+++ b/packages/optimizely-sdk/tests/odpManager.browser.spec.ts
@@ -471,7 +471,6 @@ describe('OdpManager', () => {
       expect(browserOdpManager.eventManager.batchSize).toBe(1);
     });
 
-
     it('Custom odpOptions.eventBatchSize overrides default Event Manager batch size', () => {
       const odpOptions: OdpOptions = {
         eventBatchSize: 2,


### PR DESCRIPTION
## Summary
Allow to disable ODP event batching by setting flushInterval to zero.

## Test plan
- Test flushInterval and batchSize when configured with odpOptions.flushInterval = 0

## Issues
- [FSSDK-8793](https://jira.sso.episerver.net/browse/FSSDK-8793)
