### PR TITLE
[FSSDK-9126] fix(ats): handle INVALID_IDENTIFIER_EXCEPTION error

### DIFF
--- a/packages/optimizely-sdk/lib/core/odp/odp_segment_api_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_segment_api_manager.ts
@@ -108,9 +108,13 @@ export class OdpSegmentApiManager implements IOdpSegmentApiManager {
     }
 
     if (parsedSegments.errors?.length > 0) {
-      const errors = parsedSegments.errors.map(e => e.message).join('; ');
+      const { code, classification } = parsedSegments.errors[0].extensions;
 
-      this.logger.log(LogLevel.ERROR, `${AUDIENCE_FETCH_FAILURE_MESSAGE} (${errors})`);
+      if (code == "INVALID_IDENTIFIER_EXCEPTION") {
+        this.logger.log(LogLevel.ERROR, `${AUDIENCE_FETCH_FAILURE_MESSAGE} (invalid identifier)`);
+      } else {
+        this.logger.log(LogLevel.ERROR, `${AUDIENCE_FETCH_FAILURE_MESSAGE} (${classification})`);
+      }
 
       return null;
     }

--- a/packages/optimizely-sdk/lib/core/odp/odp_types.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_types.ts
@@ -58,6 +58,7 @@ export interface Location {
  * Extended error information
  */
 export interface Extension {
+  code: string;
   classification: string;
 }
 

--- a/packages/optimizely-sdk/tests/odpSegmentApiManager.spec.ts
+++ b/packages/optimizely-sdk/tests/odpSegmentApiManager.spec.ts
@@ -185,6 +185,32 @@ describe('OdpSegmentApiManager', () => {
       '"Exception while fetching data (/customer) : ' +
       `Exception: could not resolve _fs_user_id = ${INVALID_USER_ID}",` +
       '"locations":[{"line":1,"column":8}],"path":["customer"],' +
+      '"extensions":{"code": "INVALID_IDENTIFIER_EXCEPTION","classification":"DataFetchingException"}}],' +
+      '"data":{"customer":null}}';
+    when(mockRequestHandler.makeRequest(anything(), anything(), anything(), anything())).thenReturn(
+      abortableRequest(200, errorJsonResponse)
+    );
+    const manager = managerInstance();
+
+    const segments = await manager.fetchSegments(
+      API_key,
+      GRAPHQL_ENDPOINT,
+      USER_KEY,
+      INVALID_USER_ID,
+      SEGMENTS_TO_CHECK
+    );
+
+    expect(segments).toBeNull();
+    verify(mockLogger.log(LogLevel.ERROR, 'Audience segments fetch failed (invalid identifier)')).once();
+  });
+
+  it('should handle other fetch error responses', async () => {
+    const INVALID_USER_ID = 'invalid-user';
+    const errorJsonResponse =
+      '{"errors":[{"message":' +
+      '"Exception while fetching data (/customer) : ' +
+      `Exception: could not resolve _fs_user_id = ${INVALID_USER_ID}",` +
+      '"locations":[{"line":1,"column":8}],"path":["customer"],' +
       '"extensions":{"classification":"DataFetchingException"}}],' +
       '"data":{"customer":null}}';
     when(mockRequestHandler.makeRequest(anything(), anything(), anything(), anything())).thenReturn(
@@ -201,7 +227,7 @@ describe('OdpSegmentApiManager', () => {
     );
 
     expect(segments).toBeNull();
-    verify(mockLogger.log(anything(), anyString())).once();
+    verify(mockLogger.log(LogLevel.ERROR, 'Audience segments fetch failed (DataFetchingException)')).once();
   });
 
   it('should handle unrecognized JSON responses', async () => {


### PR DESCRIPTION
## Summary
Handle INVALID_IDENTIFIER_EXCEPTION error code for fetchQualifiedSegment API call to log a proper error message.

## Test plan
- Fix tests validating fetchQualifiedSegment error codes.

## Issues
- [FSSDK-9126](https://jira.sso.episerver.net/browse/FSSDK-9126)
- [FSSDK-9133](https://jira.sso.episerver.net/browse/FSSDK-9133)
