### PR TITLE
[FSSDK-8950] change identifiers to be required for sendOdpEvent

### DIFF
--- a/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
+++ b/packages/optimizely-sdk/lib/core/odp/odp_event_manager.ts
@@ -243,6 +243,11 @@ export abstract class OdpEventManager implements IOdpEventManager {
       return;
     }
 
+    if (!this.hasNecessaryIdentifiers(event)) {
+      this.logger.log(LogLevel.ERROR, 'ODP events should have at least one key-value pair in identifiers.');
+      return;
+    }
+
     if (this.queue.length >= this.queueSize) {
       this.logger.log(
         LogLevel.WARNING,
@@ -256,6 +261,8 @@ export abstract class OdpEventManager implements IOdpEventManager {
 
     this.processQueue();
   }
+
+  protected abstract hasNecessaryIdentifiers(event: OdpEvent): boolean;
 
   /**
    * Process events in the main queue

--- a/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.browser.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.browser.ts
@@ -1,5 +1,6 @@
 import { IOdpEventManager, OdpEventManager } from '../../../../lib/core/odp/odp_event_manager';
 import { LogLevel } from '../../../modules/logging';
+import {OdpEvent} from "../../../core/odp/odp_event";
 
 const DEFAULT_BROWSER_QUEUE_SIZE = 100;
 
@@ -28,4 +29,6 @@ export class BrowserOdpEventManager extends OdpEventManager implements IOdpEvent
     // in Browser/client-side context, give debug message but leave events in queue
     this.getLogger().log(LogLevel.DEBUG, 'ODPConfig not ready. Leaving events in queue.');
   }
+
+  protected hasNecessaryIdentifiers = (event: OdpEvent): boolean => event.identifiers.size >= 0;
 }

--- a/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.browser.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.browser.ts
@@ -1,6 +1,6 @@
 import { IOdpEventManager, OdpEventManager } from '../../../../lib/core/odp/odp_event_manager';
 import { LogLevel } from '../../../modules/logging';
-import {OdpEvent} from "../../../core/odp/odp_event";
+import { OdpEvent } from "../../../core/odp/odp_event";
 
 const DEFAULT_BROWSER_QUEUE_SIZE = 100;
 

--- a/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.node.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp/event_manager/index.node.ts
@@ -29,4 +29,6 @@ export class NodeOdpEventManager extends OdpEventManager implements IOdpEventMan
     this.getLogger().log(LogLevel.WARNING, 'ODPConfig not ready. Discarding events in queue.');
     this.queue = new Array<OdpEvent>();
   }
+
+  protected hasNecessaryIdentifiers = (event: OdpEvent): boolean => event.identifiers.size >= 1;
 }

--- a/packages/optimizely-sdk/tests/odpEventManager.spec.ts
+++ b/packages/optimizely-sdk/tests/odpEventManager.spec.ts
@@ -94,25 +94,21 @@ const EVENT_WITH_EMPTY_IDENTIFIER  = new OdpEvent(
     't4',
     'a4',
     new Map(),
-    new Map(
-        Object.entries({
-          'key-53f3': true,
-          'key-a04a': 123,
-          'key-2ab4': "Linus Torvalds",
-        })
-    )
+    new Map<string, unknown>([
+      ['key-53f3', true],
+      ['key-a04a', 123],
+      ['key-2ab4', 'Linus Torvalds'],
+    ]),
 );
 const EVENT_WITH_UNDEFINED_IDENTIFIER  = new OdpEvent(
     't4',
     'a4',
     undefined,
-    new Map(
-        Object.entries({
-          'key-53f3': false,
-          'key-a04a': 456,
-          'key-2ab4': "Bill Gates",
-        })
-    )
+    new Map<string, unknown>([
+      ['key-53f3', false],
+      ['key-a04a', 456],
+      ['key-2ab4', 'Bill Gates']
+    ]),
 );
 const makeEvent = (id: number) => {
   const identifiers = new Map<string, string>();

--- a/packages/optimizely-sdk/tests/odpEventManager.spec.ts
+++ b/packages/optimizely-sdk/tests/odpEventManager.spec.ts
@@ -33,14 +33,12 @@ const EVENTS: OdpEvent[] = [
     't1',
     'a1',
     new Map([['id-key-1', 'id-value-1']]),
-    new Map(
-      Object.entries({
-        'key-1': 'value1',
-        'key-2': null,
-        'key-3': 3.3,
-        'key-4': true,
-      })
-    )
+    new Map<string, unknown>([
+        ['key-1', 'value1'],
+        ['key-2', null],
+        ['key-3', 3.3],
+        ['key-4', true],
+    ]),
   ),
   new OdpEvent(
     't2',
@@ -205,12 +203,10 @@ describe('OdpEventManager', () => {
       't3',
       'a3',
       new Map([['id-key-3', 'id-value-3']]),
-      new Map(
-        Object.entries({
-          'key-1': false,
-          'key-2': { random: 'object', whichShouldFail: true },
-        })
-      )
+      new Map<string, unknown>([
+          ['key-1', false],
+          ['key-2', { random: 'object', whichShouldFail: true }],
+      ]),
     );
     eventManager.sendEvent(badEvent);
 


### PR DESCRIPTION
## Summary
- SendODPEvent API has "identifiers" parameter as optional. For server-sdks (aka Node context), this should be changed to required (at least one key-value pair).

## Test plan

- 2 new unit tests added
- Existing unit tests should continue to pass
- FSC tests should pass

## Issues
- [FSSDK-8950](https://jira.sso.episerver.net/browse/FSSDK-8950)
