### PR TITLE
[FSSDK-9032] enhancement: Add VUID instantiation to browser client promise dependencies

### DIFF
--- a/packages/optimizely-sdk/lib/plugins/odp/event_api_manager/index.browser.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp/event_api_manager/index.browser.ts
@@ -1,6 +1,6 @@
-import { OdpEvent } from "../../../core/odp/odp_event";
-import { OdpEventApiManager } from "../../../core/odp/odp_event_api_manager";
-import { LogHandler, LogLevel } from '../../../modules/logging';
+import { OdpEvent } from '../../../core/odp/odp_event';
+import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';
+import { LogLevel } from '../../../modules/logging';
 import { ODP_EVENT_BROWSER_ENDPOINT } from '../../../utils/enums';
 
 const EVENT_SENDING_FAILURE_MESSAGE = 'ODP event send failed';
@@ -14,15 +14,19 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
     return false;
   }
 
-  protected generateRequestData(apiHost: string, apiKey: string, events: OdpEvent[]): { method: string; endpoint: string; headers: { [key: string]: string; }; data: string; } {
-    const method = 'GET'; 
+  protected generateRequestData(
+    apiHost: string,
+    apiKey: string,
+    events: OdpEvent[]
+  ): { method: string; endpoint: string; headers: { [key: string]: string }; data: string } {
+    const method = 'GET';
     const event = events[0];
     const url = new URL(ODP_EVENT_BROWSER_ENDPOINT);
-    event.identifiers.forEach((v, k) =>{
-        url.searchParams.append(k, v);
+    event.identifiers.forEach((v, k) => {
+      url.searchParams.append(k, v);
     });
-    event.data.forEach((v, k) =>{
-        url.searchParams.append(k, v as string);
+    event.data.forEach((v, k) => {
+      url.searchParams.append(k, v as string);
     });
     url.searchParams.append('tracker_id', apiKey);
     url.searchParams.append('event_type', event.type);
@@ -32,7 +36,7 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
       method,
       endpoint,
       headers: {},
-      data: "",
+      data: '',
     };
   }
 }

--- a/packages/optimizely-sdk/lib/plugins/odp/event_api_manager/index.node.ts
+++ b/packages/optimizely-sdk/lib/plugins/odp/event_api_manager/index.node.ts
@@ -1,21 +1,25 @@
-import { OdpEvent } from "../../../core/odp/odp_event";
-import { OdpEventApiManager } from "../../../core/odp/odp_event_api_manager";
+import { OdpEvent } from '../../../core/odp/odp_event';
+import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';
 
 export class NodeOdpEventApiManager extends OdpEventApiManager {
   protected shouldSendEvents(events: OdpEvent[]): boolean {
     return true;
   }
 
-  protected generateRequestData(apiHost: string, apiKey: string, events: OdpEvent[]): { method: string; endpoint: string; headers: { [key: string]: string; }; data: string; } {
+  protected generateRequestData(
+    apiHost: string,
+    apiKey: string,
+    events: OdpEvent[]
+  ): { method: string; endpoint: string; headers: { [key: string]: string }; data: string } {
     return {
       method: 'POST',
       endpoint: `${apiHost}/v3/events`,
       headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
       },
       data: JSON.stringify(events, this.replacer),
-    }
+    };
   }
 
   private replacer(_: unknown, value: unknown) {

--- a/packages/optimizely-sdk/lib/utils/fns/index.ts
+++ b/packages/optimizely-sdk/lib/utils/fns/index.ts
@@ -51,7 +51,7 @@ function isSafeInteger(number: unknown): boolean {
 
 export function keyBy<K>(arr: K[], key: string): { [key: string]: K } {
   if (!arr) return {};
-  return keyByUtil(arr, function (item) {
+  return keyByUtil(arr, function(item) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (item as any)[key];
   });
@@ -62,84 +62,84 @@ function isNumber(value: unknown): boolean {
 }
 
 export function uuid(): string {
-  return v4()
+  return v4();
 }
 
-export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export function getTimestamp(): number {
-  return new Date().getTime()
+  return new Date().getTime();
 }
 
 /**
-* Validates a value is a valid TypeScript enum
-*
-* @export
-* @param {object} enumToCheck
-* @param {*} value
-* @returns {boolean}
-*/
+ * Validates a value is a valid TypeScript enum
+ *
+ * @export
+ * @param {object} enumToCheck
+ * @param {*} value
+ * @returns {boolean}
+ */
 // TODO[OASIS-6649]: Don't use any type
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isValidEnum(enumToCheck: { [key: string]: any }, value: number | string): boolean {
-  let found = false
+  let found = false;
 
-  const keys = Object.keys(enumToCheck)
+  const keys = Object.keys(enumToCheck);
   for (let index = 0; index < keys.length; index++) {
     if (value === enumToCheck[keys[index]]) {
-      found = true
-      break
+      found = true;
+      break;
     }
   }
-  return found
+  return found;
 }
 
 export function groupBy<K>(arr: K[], grouperFn: (item: K) => string): Array<K[]> {
-  const grouper: { [key: string]: K[] } = {}
+  const grouper: { [key: string]: K[] } = {};
 
   arr.forEach(item => {
-    const key = grouperFn(item)
-    grouper[key] = grouper[key] || []
-    grouper[key].push(item)
-  })
+    const key = grouperFn(item);
+    grouper[key] = grouper[key] || [];
+    grouper[key].push(item);
+  });
 
-  return objectValues(grouper)
+  return objectValues(grouper);
 }
 
 export function objectValues<K>(obj: { [key: string]: K }): K[] {
-  return Object.keys(obj).map(key => obj[key])
+  return Object.keys(obj).map(key => obj[key]);
 }
 
 export function objectEntries<K>(obj: { [key: string]: K }): [string, K][] {
-  return Object.keys(obj).map(key => [key, obj[key]])
+  return Object.keys(obj).map(key => [key, obj[key]]);
 }
 
 export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
-  let found
+  let found;
 
   for (const item of arr) {
     if (cond(item)) {
-      found = item
-      break
+      found = item;
+      break;
     }
   }
 
-  return found
+  return found;
 }
 
 export function keyByUtil<K>(arr: K[], keyByFn: (item: K) => string): { [key: string]: K } {
-  const map: { [key: string]: K } = {}
+  const map: { [key: string]: K } = {};
   arr.forEach(item => {
-    const key = keyByFn(item)
-    map[key] = item
-  })
-  return map
+    const key = keyByFn(item);
+    map[key] = item;
+  });
+  return map;
 }
 
 // TODO[OASIS-6649]: Don't use any type
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function sprintf(format: string, ...args: any[]): string {
-  let i = 0
+  let i = 0;
   return format.replace(/%s/g, function() {
     const arg = args[i++];
     const type = typeof arg;
@@ -150,10 +150,8 @@ export function sprintf(format: string, ...args: any[]): string {
     } else {
       return String(arg);
     }
-  })
+  });
 }
-
-
 
 /**
  * Checks two string arrays for equality.
@@ -163,6 +161,18 @@ export function sprintf(format: string, ...args: any[]): string {
  */
 export function checkArrayEquality(arrayA: string[], arrayB: string[]): boolean {
   return arrayA.length === arrayB.length && arrayA.every((item, index) => item === arrayB[index]);
+}
+
+/**
+ * Checks the current running context
+ * @returns {boolean} True if window object exists.
+ */
+export function isBrowser(): boolean {
+  if (typeof window === 'object' && typeof process !== 'object' && typeof require !== 'function') {
+    return true;
+  }
+
+  return false;
 }
 
 export default {
@@ -181,4 +191,5 @@ export default {
   find,
   keyByUtil,
   sprintf,
+  isBrowser,
 };


### PR DESCRIPTION
## Summary
- For browser clients, adds VUID instantiation promise to the client's onReady promise dependencies.

This helps ensure VUID successfully populates before the onReady promise returns for the client, preventing calls to other VUID-dependent functions from failing if VUID hasn't been initialized yet.

- Also adds `isBrowser` utility and includes various formatting cleanup.

## Test plan
- All existing tests should pass.

## Issues
- [FSSDK-9032](https://jira.sso.episerver.net/browse/FSSDK-9032)
