### PR TITLE
[FSSDK-9417] refactor: improve OptimizelyConfig instantiation performance

### DIFF
--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021, Optimizely
+ * Copyright 2020-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
@@ -74,9 +74,13 @@ export class OptimizelyConfig {
       return resultMap;
     }, {});
 
+    const variableIdMap = OptimizelyConfig.getVariableIdMap(configObj);
+
     const experimentsMapById = OptimizelyConfig.getExperimentsMapById(configObj, featureIdVariablesMap);
     this.experimentsMap = OptimizelyConfig.getExperimentsKeyMap(experimentsMapById);
-    this.featuresMap = OptimizelyConfig.getFeaturesMap(configObj, featureIdVariablesMap, experimentsMapById);
+    this.featuresMap = OptimizelyConfig.getFeaturesMap(
+      configObj, featureIdVariablesMap, experimentsMapById, variableIdMap
+    );
     this.datafile = datafile;
   }
 
@@ -302,9 +306,9 @@ export class OptimizelyConfig {
     configObj: ProjectConfig,
     featureVariableIdMap: FeatureVariablesMap,
     featureId: string,
-    experiments: Experiment[]
+    experiments: Experiment[],
+    variableIdMap: {[id: string]: FeatureVariable}
   ): OptimizelyExperiment[] {
-    const variableIdMap = OptimizelyConfig.getVariableIdMap(configObj);
     return experiments.map((experiment) => {
       return {
         id: experiment.id,
@@ -399,7 +403,8 @@ export class OptimizelyConfig {
   static getFeaturesMap(
     configObj: ProjectConfig,
     featureVariableIdMap: FeatureVariablesMap,
-    experimentsMapById: OptimizelyExperimentsMap
+    experimentsMapById: OptimizelyExperimentsMap,
+    variableIdMap: {[id: string]: FeatureVariable}
   ): OptimizelyFeaturesMap {
     const featuresMap: OptimizelyFeaturesMap = {};
     configObj.featureFlags.forEach((featureFlag) => {
@@ -428,7 +433,8 @@ export class OptimizelyConfig {
           configObj,
           featureVariableIdMap,
           featureFlag.id,
-          rollout.experiments
+          rollout.experiments,
+          variableIdMap,
         );
       }
       featuresMap[featureFlag.key] = {

--- a/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
+++ b/packages/optimizely-sdk/lib/core/optimizely_config/index.ts
@@ -76,7 +76,9 @@ export class OptimizelyConfig {
 
     const variableIdMap = OptimizelyConfig.getVariableIdMap(configObj);
 
-    const experimentsMapById = OptimizelyConfig.getExperimentsMapById(configObj, featureIdVariablesMap);
+    const experimentsMapById = OptimizelyConfig.getExperimentsMapById(
+      configObj, featureIdVariablesMap, variableIdMap
+    );
     this.experimentsMap = OptimizelyConfig.getExperimentsKeyMap(experimentsMapById);
     this.featuresMap = OptimizelyConfig.getFeaturesMap(
       configObj, featureIdVariablesMap, experimentsMapById, variableIdMap
@@ -246,7 +248,7 @@ export class OptimizelyConfig {
    * Gets Map of all experiment variations and variables including rollouts
    * @param       {Variation[]}                           variations
    * @param       {FeatureVariablesMap}                   featureIdVariableMap
-   * @param       {[id: string]: FeatureVariable}         variableIdMap
+   * @param       {{[id: string]: FeatureVariable}}       variableIdMap
    * @param       {string}                                featureId
    * @returns     {[key: string]: Variation}              Variations mapped by key
    */
@@ -296,11 +298,12 @@ export class OptimizelyConfig {
 
   /**
    * Gets list of rollout experiments
-   * @param       {ProjectConfig}               configObj
-   * @param       {FeatureVariablesMap}         featureVariableIdMap
-   * @param       {string}                      featureId
-   * @param       {Experiment[]}                experiments
-   * @returns     {OptimizelyExperiment[]}      List of Optimizely rollout experiments
+   * @param       {ProjectConfig}                     configObj
+   * @param       {FeatureVariablesMap}               featureVariableIdMap
+   * @param       {string}                            featureId
+   * @param       {Experiment[]}                      experiments
+   * @param       {{[id: string]: FeatureVariable}}   variableIdMap
+   * @returns     {OptimizelyExperiment[]}            List of Optimizely rollout experiments
    */
   static getDeliveryRules(
     configObj: ProjectConfig,
@@ -343,13 +346,14 @@ export class OptimizelyConfig {
    * Get experiments mapped by their id's which are not part of a rollout
    * @param       {ProjectConfig}                           configObj
    * @param       {FeatureVariablesMap}                     featureIdVariableMap
+   * @param       {{[id: string]: FeatureVariable}}         variableIdMap
    * @returns     {[id: string]: OptimizelyExperiment}      Experiments mapped by id
    */
   static getExperimentsMapById(
     configObj: ProjectConfig,
-    featureIdVariableMap: FeatureVariablesMap
+    featureIdVariableMap: FeatureVariablesMap,
+    variableIdMap: {[id: string]: FeatureVariable}
   ): { [id: string]: OptimizelyExperiment } {
-    const variableIdMap = OptimizelyConfig.getVariableIdMap(configObj);
     const rolloutExperimentIds = this.getRolloutExperimentIds(configObj.rollouts);
 
     const experiments = configObj.experiments;
@@ -395,10 +399,11 @@ export class OptimizelyConfig {
 
   /**
    * Gets Map of all FeatureFlags and associated experiment map inside it
-   * @param       {ProjectConfig}              configObj
-   * @param       {FeatureVariablesMap}        featureVariableIdMap
-   * @param       {OptimizelyExperimentsMap}   experimentsMapById
-   * @returns     {OptimizelyFeaturesMap}      OptimizelyFeature mapped by key
+   * @param       {ProjectConfig}                     configObj
+   * @param       {FeatureVariablesMap}               featureVariableIdMap
+   * @param       {OptimizelyExperimentsMap}          experimentsMapById
+   * @param       {{[id: string]: FeatureVariable}}   variableIdMap
+   * @returns     {OptimizelyFeaturesMap}             OptimizelyFeature mapped by key
    */
   static getFeaturesMap(
     configObj: ProjectConfig,


### PR DESCRIPTION
## Summary

- Previously, OptimizleyConfig instantiation was `O(n^2)` where n = number of feature flags. This has been improved to `O(n)`

## Test plan

- All existing tests should pass. No new test is needed.

## Issues

- [FSSDK-9417](https://jira.sso.episerver.net/browse/FSSDK-9417)