### PR TITLE
[FSSDK-9361] fix failing fsc tests for odp config update

### DIFF
--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -149,6 +149,8 @@ export default class Optimizely implements Client {
       NotificationRegistry.getNotificationCenter(config.sdkKey)?.sendNotifications(
         NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE
       );
+      
+      this.updateOdpSettings();
     });
 
     const projectConfigManagerReadyPromise = this.projectConfigManager.onReady();


### PR DESCRIPTION
## Summary
On odp config update:

- All queued odp events should be flushed
- Cache should be reset 

These tests were previously failing because on datafile update, odp config was not being updated. That is fixed in this PR.

## Test plan
- All existing tests should pass

## Issues
- [FSSDK-9361](https://jira.sso.episerver.net/browse/FSSDK-9361)
