### PR TITLE
[FSSDK-9416] Refactor dependent promises typing in client onReady

### DIFF
--- a/packages/optimizely-sdk/lib/modules/event_processor/eventQueue.ts
+++ b/packages/optimizely-sdk/lib/modules/event_processor/eventQueue.ts
@@ -67,8 +67,9 @@ export class SingleEventQueue<K> implements EventQueue<K> {
     this.sink = sink
   }
 
-  start(): void {
+  start(): Promise<any> {
     // no-op
+    return Promise.resolve()
   }
 
   stop(): Promise<any> {
@@ -114,9 +115,11 @@ export class DefaultEventQueue<K> implements EventQueue<K> {
     this.started = false
   }
 
-  start(): void {
+  start(): Promise<any> {
     this.started = true
     // dont start the timer until the first event is enqueued
+
+    return Promise.resolve();
   }
 
   stop(): Promise<any> {

--- a/packages/optimizely-sdk/lib/modules/event_processor/managed.ts
+++ b/packages/optimizely-sdk/lib/modules/event_processor/managed.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export interface Managed {
-  start(): void
+  start(): Promise<any>
 
   stop(): Promise<any>
 }

--- a/packages/optimizely-sdk/lib/modules/event_processor/v1/v1EventProcessor.react_native.ts
+++ b/packages/optimizely-sdk/lib/modules/event_processor/v1/v1EventProcessor.react_native.ts
@@ -205,7 +205,7 @@ export class LogTierV1EventProcessor implements EventProcessor {
   }
 
   public async start(): Promise<void> {
-    this.queue.start()
+    await this.queue.start()
     this.unsubscribeNetInfo = addConnectionListener(this.connectionListener.bind(this))
 
     await this.processPendingEvents()

--- a/packages/optimizely-sdk/lib/modules/event_processor/v1/v1EventProcessor.ts
+++ b/packages/optimizely-sdk/lib/modules/event_processor/v1/v1EventProcessor.ts
@@ -97,6 +97,6 @@ export class LogTierV1EventProcessor implements EventProcessor {
   }
 
   async start(): Promise<void> {
-    this.queue.start()
+    await this.queue.start()
   }
 }

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -179,12 +179,15 @@ export default class Optimizely implements Client {
 
     const eventProcessorStartedPromise = this.eventProcessor.start();
 
-    const dependentPromises: Array<Promise<any> | void> = [
+    const dependentPromises: Array<Promise<any>> = [
       projectConfigManagerReadyPromise,
       eventProcessorStartedPromise,
-      config.odpManager?.initPromise,
     ];
 
+    if (config.odpManager && config.odpManager.initPromise) {
+      dependentPromises.push(config.odpManager.initPromise);
+    }
+    
     this.readyPromise = Promise.all(dependentPromises).then(promiseResults => {
       // If no odpManager exists yet, creates a new one
       if (config.odpManager != null) {

--- a/packages/optimizely-sdk/lib/optimizely/index.ts
+++ b/packages/optimizely-sdk/lib/optimizely/index.ts
@@ -184,7 +184,7 @@ export default class Optimizely implements Client {
       eventProcessorStartedPromise,
     ];
 
-    if (config.odpManager && config.odpManager.initPromise) {
+    if (config.odpManager?.initPromise) {
       dependentPromises.push(config.odpManager.initPromise);
     }
     

--- a/packages/optimizely-sdk/lib/plugins/event_processor/forwarding_event_processor.ts
+++ b/packages/optimizely-sdk/lib/plugins/event_processor/forwarding_event_processor.ts
@@ -44,7 +44,9 @@ class ForwardingEventProcessor implements EventProcessor {
     }
   }
   
-  start(): void {}
+  start(): Promise<any> {
+    return Promise.resolve();
+  }
   
   stop(): Promise<unknown> {
     return Promise.resolve();


### PR DESCRIPTION
## Summary
- eventProcessorStartedPromise actually is typed as void in the Managed interface, but has a Promise<void> implementation in the extended EventProcessor interface. This PR fixes that.

## Test plan
- All existing tests should pass

## Issues
- [FSSDK-9416](https://jira.sso.episerver.net/browse/FSSDK-9416)
