### PR TITLE
[FSSDK-8983] Specify package entry point using exports field 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,27 @@
   "browser": "dist/optimizely.browser.min.js",
   "react-native": "dist/optimizely.react_native.min.js",
   "typings": "dist/index.browser.d.ts",
+  "exports": {
+    ".": {
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/optimizely.node.min.js"
+      },
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/optimizely.browser.min.js"
+      },
+      "react-native": {
+        "types": "./dist/index.react_native.d.ts",
+        "default": "./dist/optimizely.react_native.min.js"
+      },
+      "default": "./dist/optimizely.node.min.js"
+    },
+    "./lite":  {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.es.js"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "clean:win": "(if exist dist rd /s/q dist)",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       },
       "browser": {
         "types": "./dist/index.browser.d.ts",
+        "import": "./dist/optimizely.browser.es.min.js",
         "default": "./dist/optimizely.browser.min.js"
       },
       "react-native": {
@@ -25,9 +26,36 @@
     },
     "./lite":  {
       "types": "./dist/index.lite.d.ts",
+      "node": "./dist/optimizely.lite.min.js",     
+      "import": "./dist/optimizely.lite.es.min.js",
+      "default": "./dist/optimizely.lite.min.js"
+    },
+    "./dist/optimizely.lite.es": {
+      "types": "./dist/index.lite.d.ts",
       "default": "./dist/optimizely.lite.es.js"
+    },
+    "./dist/optimizely.lite.es.js": {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.es.js"
+    },
+    "./dist/optimizely.lite.es.min": {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.es.min.js"
+    },
+    "./dist/optimizely.lite.es.min.js": {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.es.min.js"
+    },
+    "./dist/optimizely.lite.min": {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.min.js"
+    },
+    "./dist/optimizely.lite.min.js": {
+      "types": "./dist/index.lite.d.ts",
+      "default": "./dist/optimizely.lite.min.js"
     }
   },
+
   "scripts": {
     "clean": "rm -rf dist",
     "clean:win": "(if exist dist rd /s/q dist)",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
       },
       "default": "./dist/optimizely.node.min.js"
     },
-    "./lite":  {
+    "./lite": {
       "types": "./dist/index.lite.d.ts",
-      "node": "./dist/optimizely.lite.min.js",     
+      "node": "./dist/optimizely.lite.min.js",
       "import": "./dist/optimizely.lite.es.min.js",
       "default": "./dist/optimizely.lite.min.js"
     },
@@ -53,9 +53,13 @@
     "./dist/optimizely.lite.min.js": {
       "types": "./dist/index.lite.d.ts",
       "default": "./dist/optimizely.lite.min.js"
-    }
+    },
+    "./dist/*.js": "./dist/*.js",
+    "./dist/*.ts": "./dist/*.ts",
+    "./dist/*": ["./dist/*.js", "./dist/*/index.js", "./dist/*/index.ts"],
+    "./lib/*.ts": "./lib/*.ts",
+    "./lib/*": ["./lib/*.ts", "./lib/*/index.ts"]
   },
-
   "scripts": {
     "clean": "rm -rf dist",
     "clean:win": "(if exist dist rd /s/q dist)",

--- a/package.json
+++ b/package.json
@@ -13,21 +13,21 @@
         "types": "./dist/index.node.d.ts",
         "default": "./dist/optimizely.node.min.js"
       },
-      "browser": {
-        "types": "./dist/index.browser.d.ts",
-        "import": "./dist/optimizely.browser.es.min.js",
-        "default": "./dist/optimizely.browser.min.js"
-      },
       "react-native": {
         "types": "./dist/index.react_native.d.ts",
         "default": "./dist/optimizely.react_native.min.js"
       },
-      "default": "./dist/optimizely.node.min.js"
+      "default": {
+        "types": "./dist/index.browser.d.ts",
+        "require": "./dist/optimizely.browser.min.js",
+        "import": "./dist/optimizely.browser.es.js",
+        "default": "./dist/optimizely.browser.es.min.js"
+      }
     },
     "./lite": {
       "types": "./dist/index.lite.d.ts",
       "node": "./dist/optimizely.lite.min.js",
-      "import": "./dist/optimizely.lite.es.min.js",
+      "import": "./dist/optimizely.lite.es.js",
       "default": "./dist/optimizely.lite.min.js"
     },
     "./dist/optimizely.lite.es": {
@@ -53,12 +53,7 @@
     "./dist/optimizely.lite.min.js": {
       "types": "./dist/index.lite.d.ts",
       "default": "./dist/optimizely.lite.min.js"
-    },
-    "./dist/*.js": "./dist/*.js",
-    "./dist/*.ts": "./dist/*.ts",
-    "./dist/*": ["./dist/*.js", "./dist/*/index.js", "./dist/*/index.ts"],
-    "./lib/*.ts": "./lib/*.ts",
-    "./lib/*": ["./lib/*.ts", "./lib/*/index.ts"]
+    }
   },
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- specified package entry points  using the modern [exports field in package.json](https://nodejs.org/api/packages.html#package-entry-points)
- added an export for lite bundle. lite bundle can be now imported using `import optimizely from '@optimizely/optimizely-sdk/lite`

## Test plan
- Tested that the new export entry points are working as expected. Added specific logs to the built files in the dist folder for each specific variant. Then tested that the specific variant is being loaded by installing that locally built sdk in a test project and inspecting the console log. Tested for both browser and node. 

## Issues
- FSSDK-8983
