### PR TITLE
[FSSDK-9562] set pixel api endpoint dynamically

### DIFF
--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -26,7 +26,7 @@ import configValidator from './utils/config_validator';
 import eventProcessorConfigValidator from './utils/event_processor_config_validator';
 import OptimizelyUserContext from './optimizely_user_context';
 
-import { LOG_MESSAGES, ODP_EVENT_ACTION, ODP_EVENT_BROWSER_ENDPOINT } from './utils/enums';
+import { LOG_MESSAGES, ODP_EVENT_ACTION } from './utils/enums';
 import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
 import { OdpConfig } from './core/odp/odp_config';
 import { BrowserOdpEventManager } from './plugins/odp/event_manager/index.browser';
@@ -1031,6 +1031,7 @@ describe('javascript-sdk (Browser)', function() {
 
       it('should send an odp event to the browser endpoint', async () => {
         const odpConfig = new OdpConfig();
+
         const apiManager = new BrowserOdpEventApiManager(mockRequestHandler, logger);
         const eventManager = new BrowserOdpEventManager({
           odpConfig,
@@ -1065,8 +1066,9 @@ describe('javascript-sdk (Browser)', function() {
 
         let publicKey = datafile.integrations[0].publicKey;
 
+        const pixelApiEndpoint = 'https://jumbe.zaius.com/v2/zaius.gif';
         let requestEndpoint = new URL(requestParams.get('endpoint'));
-        assert.equal(requestEndpoint.origin + requestEndpoint.pathname, ODP_EVENT_BROWSER_ENDPOINT);
+        assert.equal(requestEndpoint.origin + requestEndpoint.pathname, pixelApiEndpoint);
         assert.equal(requestParams.get('method'), 'GET');
 
         let searchParams = requestEndpoint.searchParams;

--- a/lib/plugins/odp/event_api_manager/index.browser.ts
+++ b/lib/plugins/odp/event_api_manager/index.browser.ts
@@ -1,10 +1,11 @@
 import { OdpEvent } from '../../../core/odp/odp_event';
 import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';
 import { LogLevel } from '../../../modules/logging';
-import { ODP_EVENT_BROWSER_ENDPOINT } from '../../../utils/enums';
 import { ODP_CONFIG_NOT_READY_MESSAGE } from '../../../core/odp/odp_event_api_manager';
 
 const EVENT_SENDING_FAILURE_MESSAGE = 'ODP event send failed';
+
+const pixelApiPath = 'v2/zaius.gif';
 
 export class BrowserOdpEventApiManager extends OdpEventApiManager {
   protected shouldSendEvents(events: OdpEvent[]): boolean {
@@ -15,6 +16,15 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
     return false;
   }
 
+  private getPixelApiEndpoint(): string {
+    if (!this.odpConfig?.isReady()) {
+      throw new Error(ODP_CONFIG_NOT_READY_MESSAGE);
+    }
+    const apiHost = this.odpConfig.apiHost;
+    const pixelApiEndpoint = new URL(pixelApiPath, apiHost.replace('api', 'jumbe')).href;
+    return pixelApiEndpoint;
+  }
+
   protected generateRequestData(
     events: OdpEvent[]
   ): { method: string; endpoint: string; headers: { [key: string]: string }; data: string } {
@@ -23,11 +33,17 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
       this.getLogger().log(LogLevel.ERROR, ODP_CONFIG_NOT_READY_MESSAGE);
       throw new Error(ODP_CONFIG_NOT_READY_MESSAGE);
     }
+    
+    // this cannot be cached cause OdpConfig is mutable
+    // and can be updated in place and it is done so in odp
+    // manager. We should make OdpConfig immutable and
+    // refacator later
+    const pixelApiEndpoint = this.getPixelApiEndpoint();
 
     const apiKey = this.odpConfig.apiKey;
     const method = 'GET';
     const event = events[0];
-    const url = new URL(ODP_EVENT_BROWSER_ENDPOINT);
+    const url = new URL(pixelApiEndpoint!);
     event.identifiers.forEach((v, k) => {
       url.searchParams.append(k, v);
     });

--- a/lib/plugins/odp/event_api_manager/index.browser.ts
+++ b/lib/plugins/odp/event_api_manager/index.browser.ts
@@ -43,7 +43,7 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
     const apiKey = this.odpConfig.apiKey;
     const method = 'GET';
     const event = events[0];
-    const url = new URL(pixelApiEndpoint!);
+    const url = new URL(pixelApiEndpoint);
     event.identifiers.forEach((v, k) => {
       url.searchParams.append(k, v);
     });

--- a/lib/plugins/odp_manager/index.node.ts
+++ b/lib/plugins/odp_manager/index.node.ts
@@ -114,7 +114,7 @@ export class NodeOdpManager extends OdpManager {
       });
     }
 
-    this.eventManager!.start();
+    this.eventManager.start();
 
     this.initPromise = Promise.resolve();
   }

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -357,7 +357,6 @@ export enum ODP_USER_KEY {
 export const FS_USER_ID_ALIAS = 'fs-user-id';
 
 export const ODP_DEFAULT_EVENT_TYPE = 'fullstack';
-export const ODP_EVENT_BROWSER_ENDPOINT = 'https://jumbe.zaius.com/v2/zaius.gif';
 
 /**
  * ODP Event Action Options


### PR DESCRIPTION
## Summary
- Previously, pixel api endpoint was fixed. Now pixel api endpoint is generated dynamically from odp apiHost. This is needed cause pixel api endpoints are different for different odp regions.

## Test plan
- All existing tests should pass. 

## Issues
- FSSDK-9562
