### PR TITLE
[FSSDK-9588] export logging types and values

### DIFF
--- a/lib/common_exports.ts
+++ b/lib/common_exports.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { LogLevel, LogHandler, getLogger, setLogHandler } from './modules/logging';
+export { LOG_LEVEL } from './utils/enums';
+export { createLogger } from './plugins/logger';

--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -30,6 +30,7 @@ import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
 import Optimizely from './optimizely';
 import { IUserAgentParser } from './core/odp/user_agent_parser';
 import { getUserAgentParser } from './plugins/odp/user_agent_parser/index.browser';
+import * as commonExports from './common_exports';
 
 const logger = getLogger();
 logHelper.setLogHandler(loggerPlugin.createLogger());
@@ -181,7 +182,10 @@ export {
   getUserAgentParser,
 };
 
+export * from './common_exports';
+
 export default {
+  ...commonExports,
   logging: loggerPlugin,
   errorHandler: defaultErrorHandler,
   eventDispatcher: defaultEventDispatcher,

--- a/lib/index.lite.ts
+++ b/lib/index.lite.ts
@@ -31,6 +31,7 @@ import { createNotificationCenter } from './core/notification_center';
 import { createForwardingEventProcessor } from './plugins/event_processor/forwarding_event_processor';
 import { OptimizelyDecideOption, Client, ConfigLite } from './shared_types';
 import { createNoOpDatafileManager } from './plugins/datafile_manager/no_op_datafile_manager';
+import * as commonExports from './common_exports';
   
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -102,7 +103,10 @@ export {
   OptimizelyDecideOption,
 };
 
+export * from './common_exports';
+
 export default {
+  ...commonExports,
   logging: loggerPlugin,
   errorHandler: defaultErrorHandler,
   eventDispatcher: noOpEventDispatcher,

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -26,6 +26,7 @@ import { createEventProcessor } from './plugins/event_processor';
 import { OptimizelyDecideOption, Client, Config } from './shared_types';
 import { createHttpPollingDatafileManager } from './plugins/datafile_manager/http_polling_datafile_manager';
 import { NodeOdpManager } from './plugins/odp_manager/index.node';
+import * as commonExports from './common_exports';
 
 const logger = getLogger();
 setLogLevel(LogLevel.ERROR);
@@ -136,7 +137,10 @@ export {
   OptimizelyDecideOption,
 };
 
+export * from './common_exports';
+
 export default {
+  ...commonExports,
   logging: loggerPlugin,
   errorHandler: defaultErrorHandler,
   eventDispatcher: defaultEventDispatcher,

--- a/lib/index.react_native.ts
+++ b/lib/index.react_native.ts
@@ -34,6 +34,7 @@ import { OptimizelyDecideOption, Client, Config } from './shared_types';
 import { createHttpPollingDatafileManager } from
     './plugins/datafile_manager/react_native_http_polling_datafile_manager';
 import { BrowserOdpManager } from './plugins/odp_manager/index.browser';
+import * as commonExports from './common_exports';
 
 const logger = getLogger();
 setLogHandler(loggerPlugin.createLogger());
@@ -142,7 +143,10 @@ export {
   OptimizelyDecideOption,
 };
 
+export * from './common_exports';
+
 export default {
+  ...commonExports,
   logging: loggerPlugin,
   errorHandler: defaultErrorHandler,
   eventDispatcher: defaultEventDispatcher,


### PR DESCRIPTION
## Summary
- Clients like the testapp and react-sdk needs logging types and values, currently they have to import it from deep paths from the lib directory. this PR will allow imports directly for the entrypoint. We will eventually remove lib directory from the published  package bundle.

## Test plan
- All existing tests should pass

## Issues
- FSSDK-9588
