### PR TITLE
[FSSDK-9585] remove lib directory from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
     "access": "public"
   },
   "files": [
-    "dist/",
-    "lib/"
+    "dist/"
   ],
   "nyc": {
     "temp-dir": "coverage/raw"


### PR DESCRIPTION
## Summary
- remove lib directory from package

## Test plan
- existing tests should pass
- manually created package using `npm pack` and installed and tested in a test project.

## Issues
- FSSDK-9585
