### PR TITLE
FSSDK-9843: Add infinity check

### DIFF
--- a/lib/utils/event_tag_utils/index.ts
+++ b/lib/utils/event_tag_utils/index.ts
@@ -41,7 +41,7 @@ export function getRevenueValue(eventTags: EventTags, logger: LoggerFacade): num
     let parsedRevenueValue;
     if (typeof rawValue === 'string') {
       parsedRevenueValue = parseInt(rawValue);
-      if (isNaN(parsedRevenueValue)) {
+      if (!isFinite(parsedRevenueValue)) {
         logger.log(LOG_LEVEL.INFO, LOG_MESSAGES.FAILED_TO_PARSE_REVENUE, MODULE_NAME, rawValue);
         return null;
       }
@@ -70,7 +70,7 @@ export function getEventValue(eventTags: EventTags, logger: LoggerFacade): numbe
     let parsedEventValue;
     if (typeof rawValue === 'string') {
       parsedEventValue = parseFloat(rawValue);
-      if (isNaN(parsedEventValue)) {
+      if (!isFinite(parsedEventValue)) {
         logger.log(LOG_LEVEL.INFO, LOG_MESSAGES.FAILED_TO_PARSE_VALUE, MODULE_NAME, rawValue);
         return null;
       }


### PR DESCRIPTION
A customer in [BUG-7104](https://jira.sso.episerver.net/browse/BUG-7104) was sending 1/0 values in the tags for their events. Because the NodeJS SDK [doesn't have a check](https://github.com/optimizely/javascript-sdk/blob/master/lib/utils/event_tag_utils/index.ts#L67) against infinity, this allowed the value to be passed through subsequently broke the results API calculations. 

Other SDKs ([python](https://github.com/optimizely/python-sdk/blob/master/optimizely/helpers/event_tag_utils.py#L106), [java](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/internal/EventTagUtils.java#L64)) have this check, so we should add it to Node.

`isNaN()` can be simplified to just `!isFinite()` which checks for +/- infinity as well as NaN