### PR TITLE
[FSSDK-9607] add pixelUrl to OdpConfig

### DIFF
--- a/lib/core/odp/odp_config.ts
+++ b/lib/core/odp/odp_config.ts
@@ -46,6 +46,20 @@ export class OdpConfig {
   }
 
   /**
+   * Url for sending events via pixel.
+   * @private
+   */
+  private _pixelUrl: string;
+
+  /**
+   * Getter to retrieve the ODP pixel URL
+   * @public
+   */
+  get pixelUrl(): string {
+    return this._pixelUrl;
+  }
+
+  /**
    * All ODP segments used in the current datafile (associated with apiHost/apiKey).
    * @private
    */
@@ -59,9 +73,10 @@ export class OdpConfig {
     return this._segmentsToCheck;
   }
 
-  constructor(apiKey?: string, apiHost?: string, segmentsToCheck?: string[]) {
+  constructor(apiKey?: string, apiHost?: string, pixelUrl?: string, segmentsToCheck?: string[]) {
     this._apiKey = apiKey ?? '';
     this._apiHost = apiHost ?? '';
+    this._pixelUrl = pixelUrl ?? '';
     this._segmentsToCheck = segmentsToCheck ?? [];
   }
 
@@ -76,6 +91,7 @@ export class OdpConfig {
     } else {
       if (config.apiKey) this._apiKey = config.apiKey;
       if (config.apiHost) this._apiHost = config.apiHost;
+      if (config.pixelUrl) this._pixelUrl = config.pixelUrl;
       if (config.segmentsToCheck) this._segmentsToCheck = config.segmentsToCheck;
 
       return true;
@@ -98,6 +114,7 @@ export class OdpConfig {
     return (
       this._apiHost === configToCompare._apiHost &&
       this._apiKey === configToCompare._apiKey &&
+      this._pixelUrl === configToCompare._pixelUrl &&
       checkArrayEquality(this.segmentsToCheck, configToCompare._segmentsToCheck)
     );
   }

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -40,7 +40,7 @@ export interface IOdpManager {
 
   eventManager: IOdpEventManager | undefined;
 
-  updateSettings({ apiKey, apiHost, segmentsToCheck }: OdpConfig): boolean;
+  updateSettings({ apiKey, apiHost, pixelUrl, segmentsToCheck }: OdpConfig): boolean;
 
   close(): void;
 
@@ -97,7 +97,7 @@ export abstract class OdpManager implements IOdpManager {
   /**
    * Provides a method to update ODP Manager's ODP Config API Key, API Host, and Audience Segments
    */
-  updateSettings({ apiKey, apiHost, segmentsToCheck }: OdpConfig): boolean {
+  updateSettings({ apiKey, apiHost, pixelUrl, segmentsToCheck }: OdpConfig): boolean {
     if (!this.enabled) {
       return false;
     }
@@ -114,7 +114,7 @@ export abstract class OdpManager implements IOdpManager {
 
     this.eventManager.flush();
 
-    const newConfig = new OdpConfig(apiKey, apiHost, segmentsToCheck);
+    const newConfig = new OdpConfig(apiKey, apiHost, pixelUrl, segmentsToCheck);
     const configDidUpdate = this.odpConfig.update(newConfig);
 
     if (configDidUpdate) {

--- a/lib/core/project_config/index.tests.js
+++ b/lib/core/project_config/index.tests.js
@@ -821,6 +821,10 @@ describe('lib/core/project_config', function() {
         assert.exists(config.hostForOdp);
       });
 
+      it('should populate the pixelUrl value from the odp integration', () => {
+        assert.exists(config.pixelUrlForOdp);
+      });
+
       it('should contain all expected unique odp segments in allSegments', () => {
         assert.equal(config.allSegments.length, 3);
         assert.deepEqual(config.allSegments, ['odp-segment-1', 'odp-segment-2', 'odp-segment-3']);
@@ -846,6 +850,11 @@ describe('lib/core/project_config', function() {
       it('should populate the host value from the odp integration', () => {
         assert.exists(config.hostForOdp);
         assert.equal(config.hostForOdp, 'https://api.zaius.com');
+      });
+
+      it('should populate the pixelUrl value from the odp integration', () => {
+        assert.exists(config.pixelUrlForOdp);
+        assert.equal(config.pixelUrlForOdp, 'https://jumbe.zaius.com');
       });
 
       it('should contain all expected unique odp segments in all segments', () => {

--- a/lib/core/project_config/index.ts
+++ b/lib/core/project_config/index.ts
@@ -92,6 +92,7 @@ export interface ProjectConfig {
   integrationKeyMap?: { [key: string]: Integration };
   publicKeyForOdp?: string;
   hostForOdp?: string;
+  pixelUrlForOdp?: string;
   allSegments: string[];
 }
 
@@ -202,6 +203,10 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
 
         if (integration.host && !projectConfig.hostForOdp) {
           projectConfig.hostForOdp = integration.host;
+        }
+
+        if (integration.pixelUrl && !projectConfig.pixelUrlForOdp) {
+          projectConfig.pixelUrlForOdp = integration.pixelUrl;
         }
       }
     });

--- a/lib/core/project_config/project_config_schema.ts
+++ b/lib/core/project_config/project_config_schema.ts
@@ -290,6 +290,9 @@ var schemaDefinition = {
           },
           publicKey: {
             type: 'string'
+          },
+          pixelUrl: {
+            type: 'string'
           }
         }
       }

--- a/lib/core/project_config/project_config_schema.ts
+++ b/lib/core/project_config/project_config_schema.ts
@@ -293,10 +293,10 @@ var schemaDefinition = {
           },
           pixelUrl: {
             type: 'string'
-          }
-        }
-      }
-    }
+          },
+        },
+      },
+    },
   },
 };
 

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -1116,9 +1116,9 @@ describe('javascript-sdk (Browser)', function() {
         clock.tick(100);
 
         let publicKey = datafile.integrations[0].publicKey;
-        let pixelHost = datafile.integrations[0].pixelUrl;
+        let pixelUrl = datafile.integrations[0].pixelUrl;
 
-        const pixelApiEndpoint = `${pixelHost}/v2/zaius.gif`;
+        const pixelApiEndpoint = `${pixelUrl}/v2/zaius.gif`;
         let requestEndpoint = new URL(requestParams.get('endpoint'));
         assert.equal(requestEndpoint.origin + requestEndpoint.pathname, pixelApiEndpoint);
         assert.equal(requestParams.get('method'), 'GET');

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -879,7 +879,7 @@ describe('javascript-sdk (Browser)', function() {
 
         client.sendOdpEvent('test', '', new Map([['eamil', 'test@test.test']]), new Map([['key', 'value']]));
         clock.tick(10000);
-        
+
         const eventRequestUrl = new URL(fakeRequestHandler.makeRequest.lastCall.args[0]);
         const searchParams = eventRequestUrl.searchParams;
 
@@ -1116,8 +1116,9 @@ describe('javascript-sdk (Browser)', function() {
         clock.tick(100);
 
         let publicKey = datafile.integrations[0].publicKey;
+        let pixelHost = datafile.integrations[0].pixelUrl;
 
-        const pixelApiEndpoint = 'https://jumbe.zaius.com/v2/zaius.gif';
+        const pixelApiEndpoint = `${pixelHost}/v2/zaius.gif`;
         let requestEndpoint = new URL(requestParams.get('endpoint'));
         assert.equal(requestEndpoint.origin + requestEndpoint.pathname, pixelApiEndpoint);
         assert.equal(requestParams.get('method'), 'GET');

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -148,7 +148,7 @@ export default class Optimizely implements Client {
       NotificationRegistry.getNotificationCenter(config.sdkKey)?.sendNotifications(
         NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE
       );
-      
+
       this.updateOdpSettings();
     });
 
@@ -186,7 +186,7 @@ export default class Optimizely implements Client {
     if (config.odpManager?.initPromise) {
       dependentPromises.push(config.odpManager.initPromise);
     }
-    
+
     this.readyPromise = Promise.all(dependentPromises).then(promiseResults => {
       // If no odpManager exists yet, creates a new one
       if (config.odpManager != null) {
@@ -1678,13 +1678,13 @@ export default class Optimizely implements Client {
   }
 
   /**
-   * Updates ODP Config with most recent ODP key, host, and segments from the project config
+   * Updates ODP Config with most recent ODP key, host, pixelUrl, and segments from the project config
    */
   private updateOdpSettings(): void {
     const projectConfig = this.projectConfigManager.getConfig();
     if (this.odpManager != null && projectConfig != null) {
       this.odpManager.updateSettings(
-        new OdpConfig(projectConfig.publicKeyForOdp, projectConfig.hostForOdp, projectConfig.allSegments)
+        new OdpConfig(projectConfig.publicKeyForOdp, projectConfig.hostForOdp, projectConfig.pixelUrlForOdp, projectConfig.allSegments)
       );
     }
   }

--- a/lib/plugins/odp/event_api_manager/index.browser.ts
+++ b/lib/plugins/odp/event_api_manager/index.browser.ts
@@ -20,8 +20,8 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
     if (!this.odpConfig?.isReady()) {
       throw new Error(ODP_CONFIG_NOT_READY_MESSAGE);
     }
-    const apiHost = this.odpConfig.apiHost;
-    const pixelApiEndpoint = new URL(pixelApiPath, apiHost.replace('api', 'jumbe')).href;
+    const pixelUrl = this.odpConfig.pixelUrl;
+    const pixelApiEndpoint = new URL(pixelApiPath, pixelUrl).href;
     return pixelApiEndpoint;
   }
 
@@ -33,7 +33,7 @@ export class BrowserOdpEventApiManager extends OdpEventApiManager {
       this.getLogger().log(LogLevel.ERROR, ODP_CONFIG_NOT_READY_MESSAGE);
       throw new Error(ODP_CONFIG_NOT_READY_MESSAGE);
     }
-    
+
     // this cannot be cached cause OdpConfig is mutable
     // and can be updated in place and it is done so in odp
     // manager. We should make OdpConfig immutable and

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -221,6 +221,7 @@ export interface Integration {
   key: string;
   host?: string;
   publicKey?: string;
+  pixelUrl?: string;
 }
 
 export interface TrafficAllocation {

--- a/lib/tests/test_data.js
+++ b/lib/tests/test_data.js
@@ -3225,11 +3225,13 @@ var odpIntegratedConfigWithSegments = {
       key: 'odp',
       host: 'https://api.zaius.com',
       publicKey: 'W4WzcEs-ABgXorzY7h1LCQ',
+      pixelUrl: 'https://jumbe.zaius.com',
     },
     {
       key: 'odp',
       host: 'https://api.zzzzaius.com',
       publicKey: 'W4WzcEs-ABgXorzssssY7h1LCQ',
+      pixelUrl: 'https://jumbe.zzzzaius.com',
     },
     {
       key: 'odp',
@@ -3359,6 +3361,7 @@ var odpIntegratedConfigWithoutSegments = {
       key: 'odp',
       host: 'https://api.zaius.com',
       publicKey: 'W4WzcEs-ABgXorzY7h1LCQ',
+      pixelUrl: 'https://jumbe.zaius.com',
     },
     {
       key: 'odp',
@@ -3394,6 +3397,7 @@ var odpIntegratedConfigWithoutKey = {
     {
       host: 'https://api.zaius.com',
       publicKey: 'W4WzcEs-ABgXorzY7h1LCQ',
+      pixelUrl: 'https://jumbe.zaius.com',
     },
   ],
   revision: '100',

--- a/tests/odpEventApiManager.spec.ts
+++ b/tests/odpEventApiManager.spec.ts
@@ -37,8 +37,9 @@ const ODP_EVENTS = [
 
 const API_KEY = 'test-api-key';
 const API_HOST = 'https://odp.example.com';
+const PIXEL_URL = 'https://odp.pixel.com';
 
-const odpConfig = new OdpConfig(API_KEY, API_HOST, []);
+const odpConfig = new OdpConfig(API_KEY, API_HOST, PIXEL_URL, []);
 
 describe('NodeOdpEventApiManager', () => {
   let mockLogger: LogHandler;
@@ -133,9 +134,10 @@ describe('NodeOdpEventApiManager', () => {
     const updatedOdpConfig = new OdpConfig(
       'updated-key',
       'https://updatedhost.test',
+      'https://updatedpixel.test',
       ['updated-seg'],
     )
-    
+
     manager.updateSettings(updatedOdpConfig);
     await manager.sendEvents(ODP_EVENTS);
 

--- a/tests/odpEventManager.spec.ts
+++ b/tests/odpEventManager.spec.ts
@@ -28,6 +28,7 @@ import { UserAgentInfo } from '../lib/core/odp/user_agent_info';
 
 const API_KEY = 'test-api-key';
 const API_HOST = 'https://odp.example.com';
+const PIXEL_URL = 'https://odp.pixel.com';
 const MOCK_IDEMPOTENCE_ID = 'c1dc758e-f095-4f09-9b49-172d74c53880';
 const EVENTS: OdpEvent[] = [
   new OdpEvent(
@@ -145,7 +146,7 @@ describe('OdpEventManager', () => {
   beforeAll(() => {
     mockLogger = mock<LogHandler>();
     mockApiManager = mock<IOdpEventApiManager>();
-    odpConfig = new OdpConfig(API_KEY, API_HOST, []);
+    odpConfig = new OdpConfig(API_KEY, API_HOST, PIXEL_URL, []);
     logger = instance(mockLogger);
     apiManager = instance(mockApiManager);
   });
@@ -159,7 +160,7 @@ describe('OdpEventManager', () => {
     when(mockApiManager.sendEvents(anything())).thenResolve(false);
     when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
 
-    const apiManager = instance(mockApiManager); 
+    const apiManager = instance(mockApiManager);
 
     const eventManager = new OdpEventManager({
       odpConfig,
@@ -172,12 +173,12 @@ describe('OdpEventManager', () => {
     const [passedConfig] = capture(mockApiManager.updateSettings).last();
     expect(passedConfig).toEqual(odpConfig);
   });
-  
+
   it('should update api manager setting with updatetd odp config on updateSettings', () => {
     when(mockApiManager.sendEvents(anything())).thenResolve(false);
     when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
 
-    const apiManager = instance(mockApiManager); 
+    const apiManager = instance(mockApiManager);
 
     const eventManager = new OdpEventManager({
       odpConfig,
@@ -190,9 +191,10 @@ describe('OdpEventManager', () => {
     const updatedOdpConfig = new OdpConfig(
       'updated-key',
       'https://updatedhost.test',
+      'https://pixel.test',
       ['updated-seg'],
     )
-    
+
     eventManager.updateSettings(updatedOdpConfig);
 
     verify(mockApiManager.updateSettings(anything())).twice();
@@ -541,13 +543,15 @@ describe('OdpEventManager', () => {
     });
     const apiKey = 'testing-api-key';
     const apiHost = 'https://some.other.example.com';
+    const pixelUrl = 'https://some.other.pixel.com';
     const segmentsToCheck = ['empty-cart', '1-item-cart'];
-    const differentOdpConfig = new OdpConfig(apiKey, apiHost, segmentsToCheck);
+    const differentOdpConfig = new OdpConfig(apiKey, apiHost, pixelUrl, segmentsToCheck);
 
     eventManager.updateSettings(differentOdpConfig);
 
     expect(eventManager['odpConfig'].apiKey).toEqual(apiKey);
     expect(eventManager['odpConfig'].apiHost).toEqual(apiHost);
+    expect(eventManager['odpConfig'].pixelUrl).toEqual(pixelUrl);
     expect(eventManager['odpConfig'].segmentsToCheck).toContain(Array.from(segmentsToCheck)[0]);
     expect(eventManager['odpConfig'].segmentsToCheck).toContain(Array.from(segmentsToCheck)[1]);
   });

--- a/tests/odpManager.browser.spec.ts
+++ b/tests/odpManager.browser.spec.ts
@@ -38,17 +38,19 @@ import { OdpEvent } from '../lib/core/odp/odp_event';
 
 const keyA = 'key-a';
 const hostA = 'host-a';
+const pixelA = 'pixel-a';
 const segmentsA = ['a'];
 const userA = 'fs-user-a';
 const vuidA = 'vuid_a';
-const odpConfigA = new OdpConfig(keyA, hostA, segmentsA);
+const odpConfigA = new OdpConfig(keyA, hostA, pixelA, segmentsA);
 
 const keyB = 'key-b';
 const hostB = 'host-b';
+const pixelB = 'pixel-b';
 const segmentsB = ['b'];
 const userB = 'fs-user-b';
 const vuidB = 'vuid_b';
-const odpConfigB = new OdpConfig(keyB, hostB, segmentsB);
+const odpConfigB = new OdpConfig(keyB, hostB, pixelB, segmentsB);
 
 describe('OdpManager', () => {
   let odpConfig: OdpConfig;
@@ -122,7 +124,7 @@ describe('OdpManager', () => {
 
     verify(mockLogger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED)).once();
 
-    browserOdpManager.updateSettings(new OdpConfig('valid', 'host', []));
+    browserOdpManager.updateSettings(new OdpConfig('valid', 'host', 'pixel-url', []));
     expect(browserOdpManager.odpConfig).toBeUndefined;
 
     await browserOdpManager.fetchQualifiedSegments('vuid_user1', []);
@@ -201,7 +203,7 @@ describe('OdpManager', () => {
       },
     });
 
-    const didUpdateA = browserOdpManager.updateSettings(new OdpConfig(keyA, hostA, segmentsA));
+    const didUpdateA = browserOdpManager.updateSettings(new OdpConfig(keyA, hostA, pixelA, segmentsA));
     expect(didUpdateA).toBe(true);
 
     browserOdpManager.fetchQualifiedSegments(vuidA);
@@ -213,7 +215,7 @@ describe('OdpManager', () => {
     const fetchQualifiedSegmentsArgsA = capture(mockSegmentApiManager.fetchSegments).last();
     expect(fetchQualifiedSegmentsArgsA).toStrictEqual([keyA, hostA, ODP_USER_KEY.VUID, vuidA, segmentsA]);
 
-    const didUpdateB = browserOdpManager.updateSettings(new OdpConfig(keyB, hostB, segmentsB));
+    const didUpdateB = browserOdpManager.updateSettings(new OdpConfig(keyB, hostB, pixelB, segmentsB));
     expect(didUpdateB).toBe(true);
 
     browserOdpManager.fetchQualifiedSegments(vuidB);

--- a/tests/odpManager.spec.ts
+++ b/tests/odpManager.spec.ts
@@ -34,11 +34,13 @@ import { ServerLRUCache } from '../lib/utils/lru_cache';
 
 const keyA = 'key-a';
 const hostA = 'host-a';
+const pixelA = 'pixel-a';
 const segmentsA = ['a'];
 const userA = 'fs-user-a';
 
 const keyB = 'key-b';
 const hostB = 'host-b';
+const pixelB = 'pixel-b';
 const segmentsB = ['b'];
 const userB = 'fs-user-b';
 
@@ -108,7 +110,7 @@ describe('OdpManager', () => {
     });
     verify(mockLogger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED)).once();
 
-    odpManager.updateSettings(new OdpConfig('valid', 'host', []));
+    odpManager.updateSettings(new OdpConfig('valid', 'host', 'pixel-url', []));
     expect(odpManager.odpConfig).toBeUndefined;
 
     await odpManager.fetchQualifiedSegments('user1', []);
@@ -152,18 +154,20 @@ describe('OdpManager', () => {
       },
     });
 
-    odpManager.updateSettings(new OdpConfig(keyA, hostA, segmentsA));
+    odpManager.updateSettings(new OdpConfig(keyA, hostA, pixelA, segmentsA));
 
     expect(odpManager.odpConfig.apiKey).toBe(keyA);
     expect(odpManager.odpConfig.apiHost).toBe(hostA);
+    expect(odpManager.odpConfig.pixelUrl).toBe(pixelA);
 
     // odpManager.identifyUser(userA);
 
     // verify(mockEventApiManager.sendEvents(keyA, hostA, anything())).once();
 
-    odpManager.updateSettings(new OdpConfig(keyB, hostB, segmentsB));
+    odpManager.updateSettings(new OdpConfig(keyB, hostB, pixelB, segmentsB));
     expect(odpManager.odpConfig.apiKey).toBe(keyB);
     expect(odpManager.odpConfig.apiHost).toBe(hostB);
+    expect(odpManager.odpConfig.pixelUrl).toBe(pixelB);
 
     // odpManager.identifyUser(userB);
 
@@ -179,17 +183,19 @@ describe('OdpManager', () => {
       },
     });
 
-    odpManager.updateSettings(new OdpConfig(keyA, hostA, segmentsA));
+    odpManager.updateSettings(new OdpConfig(keyA, hostA, pixelA, segmentsA));
 
     expect(odpManager.odpConfig.apiKey).toBe(keyA);
     expect(odpManager.odpConfig.apiHost).toBe(hostA);
+    expect(odpManager.odpConfig.pixelUrl).toBe(pixelA);
 
     await odpManager.fetchQualifiedSegments(userA);
     verify(mockSegmentApiManager.fetchSegments(keyA, hostA, ODP_USER_KEY.FS_USER_ID, userA, anything())).once();
 
-    odpManager.updateSettings(new OdpConfig(keyB, hostB, segmentsB));
+    odpManager.updateSettings(new OdpConfig(keyB, hostB, pixelB, segmentsB));
     expect(odpManager.odpConfig.apiKey).toBe(keyB);
     expect(odpManager.odpConfig.apiHost).toBe(hostB);
+    expect(odpManager.odpConfig.pixelUrl).toBe(pixelB);
 
     await odpManager.fetchQualifiedSegments(userB);
     verify(mockSegmentApiManager.fetchSegments(keyB, hostB, ODP_USER_KEY.FS_USER_ID, userB, anything())).once();

--- a/tests/odpSegmentManager.spec.ts
+++ b/tests/odpSegmentManager.spec.ts
@@ -54,8 +54,8 @@ describe('OdpSegmentManager', () => {
   const userKey: ODP_USER_KEY = ODP_USER_KEY.VUID;
   const userValue = 'test-user';
 
-  const validTestOdpConfig = new OdpConfig('valid-key', 'host', ['new-customer']);
-  const invalidTestOdpConfig = new OdpConfig('invalid-key', 'host', ['new-customer']);
+  const validTestOdpConfig = new OdpConfig('valid-key', 'host', 'pixel-url', ['new-customer']);
+  const invalidTestOdpConfig = new OdpConfig('invalid-key', 'host', 'pixel-url', ['new-customer']);
 
   beforeEach(() => {
     resetCalls(mockLogHandler);
@@ -63,7 +63,8 @@ describe('OdpSegmentManager', () => {
 
     const API_KEY = 'test-api-key';
     const API_HOST = 'https://odp.example.com';
-    odpConfig = new OdpConfig(API_KEY, API_HOST, []);
+    const PIXEL_URL = 'https://odp.pixel.com';
+    odpConfig = new OdpConfig(API_KEY, API_HOST, PIXEL_URL, []);
     const segmentsCache = new LRUCache<string, string[]>({
       maxSize: 1000,
       timeout: 1000,


### PR DESCRIPTION
## Summary
- Changed the ODP pixelUrl to be read from the datafile instead of being hard coded in the SDK.

## Ticket
[FSSDK-9607](https://jira.sso.episerver.net/browse/FSSDK-9607)
