### PR TITLE
[FSSDK-9987] chore: prep for 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.0.1] - February 20, 2024
+
+### Bug fixes
+- Improved conditional ODP instantiation when `odpOptions.disabled: true` is used ([#902](https://github.com/optimizely/javascript-sdk/pull/902)) 
+
+### Changed
+- Updated Dependabot alerts ([#896](https://github.com/optimizely/javascript-sdk/pull/896))
+- Updated several devDependencies ([#898](https://github.com/optimizely/javascript-sdk/pull/898), [#900](https://github.com/optimizely/javascript-sdk/pull/900), [#901](https://github.com/optimizely/javascript-sdk/pull/901))
+
+
 ## [5.0.0] - January 19, 2024
 
 ### New Features  

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -193,7 +193,7 @@ describe('javascript-sdk (Browser)', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '5.0.0');
+        assert.equal(optlyInstance.clientVersion, '5.0.1');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/lib/index.lite.tests.js
+++ b/lib/index.lite.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2023 Optimizely
+ * Copyright 2021-2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/index.lite.tests.js
+++ b/lib/index.lite.tests.js
@@ -76,7 +76,7 @@ describe('optimizelyFactory', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '5.0.0');
+        assert.equal(optlyInstance.clientVersion, '5.0.1');
       });
     });
   });

--- a/lib/index.node.tests.js
+++ b/lib/index.node.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020, 2022-2023 Optimizely
+ * Copyright 2016-2020, 2022-2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/index.node.tests.js
+++ b/lib/index.node.tests.js
@@ -90,7 +90,7 @@ describe('optimizelyFactory', function() {
         optlyInstance.onReady().catch(function() {});
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '5.0.0');
+        assert.equal(optlyInstance.clientVersion, '5.0.1');
       });
 
       describe('event processor configuration', function() {

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -223,8 +223,8 @@ export const NODE_CLIENT_ENGINE = 'node-sdk';
 export const REACT_CLIENT_ENGINE = 'react-sdk';
 export const REACT_NATIVE_CLIENT_ENGINE = 'react-native-sdk';
 export const REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
-export const BROWSER_CLIENT_VERSION = '5.0.0';
-export const NODE_CLIENT_VERSION = '5.0.0';
+export const BROWSER_CLIENT_VERSION = '5.0.1';
+export const NODE_CLIENT_VERSION = '5.0.1';
 
 export const DECISION_NOTIFICATION_TYPES = {
   AB_TEST: 'ab-test',

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2023, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2024 Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@optimizely/optimizely-sdk",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "decompress-response": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "JavaScript SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "module": "dist/optimizely.browser.es.js",
   "main": "dist/optimizely.node.min.js",

--- a/tests/index.react_native.spec.ts
+++ b/tests/index.react_native.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020, 2022-2023 Optimizely
+ * Copyright 2019-2020, 2022-2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/index.react_native.spec.ts
+++ b/tests/index.react_native.spec.ts
@@ -90,7 +90,7 @@ describe('javascript-sdk/react-native', () => {
 
         expect(optlyInstance).toBeInstanceOf(Optimizely);
         // @ts-ignore
-        expect(optlyInstance.clientVersion).toEqual('5.0.0');
+        expect(optlyInstance.clientVersion).toEqual('5.0.1');
       });
 
       it('should set the React Native JS client engine and javascript SDK version', () => {


### PR DESCRIPTION
## Summary
- Bump version to 5.0.1
- Update changelog

## Test plan
- Unit and end-to-end test suite are expected to pass

## Issues
- FSSDK-9987
