### PR TITLE
[FSSDK-9586] restore node engine to >=14

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['16', '18', '20']
+        node: ['14', 16', '18', '20']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Node ${{ matrix.node }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', 16', '18', '20']
+        node: ['14', '16', '18', '20']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Node ${{ matrix.node }}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=14.0.0"
   },
   "keywords": [
     "optimizely"


### PR DESCRIPTION
also add back unit test ci for node14

v5.0.0 was released with engine.node >=14.0.0. So updating this technically constitutes a breaking change.

## Test plan

## Issues
- FSSDK-9586
