### PR TITLE
[FSSDK-9984] fix: Empty fetched qualified segments validity

### DIFF
--- a/lib/optimizely_user_context/index.tests.js
+++ b/lib/optimizely_user_context/index.tests.js
@@ -991,7 +991,7 @@ describe('lib/optimizely_user_context', function() {
     });
 
     describe('fetchQualifiedSegments', () => {
-      it('should successfully call fetch qualified segments', async () => {
+      it('should successfully get segments', async () => {
         fakeOptimizely = {
           fetchQualifiedSegments: sinon.stub().returns(['a']),
         };
@@ -1001,12 +1001,40 @@ describe('lib/optimizely_user_context', function() {
           userId,
         });
 
-        const fetchedQualifiedSegments = await user.fetchQualifiedSegments();
-        assert.deepEqual(fetchedQualifiedSegments, true);
+        const successfullyFetched = await user.fetchQualifiedSegments();
+        assert.deepEqual(successfullyFetched, true);
 
         sinon.assert.calledWithExactly(fakeOptimizely.fetchQualifiedSegments, userId, undefined);
 
         assert.deepEqual(user.qualifiedSegments, ['a']);
+      });
+
+      it('should return true empty returned segements', async () => {
+        fakeOptimizely = {
+          fetchQualifiedSegments: sinon.stub().returns([]),
+        };
+        const user = new OptimizelyUserContext({
+          shouldIdentifyUser: false,
+          optimizely: fakeOptimizely,
+          userId,
+        });
+
+        const successfullyFetched = await user.fetchQualifiedSegments();
+        assert.deepEqual(successfullyFetched, true);
+      });
+
+      it('should return false in other cases', async () => {
+        fakeOptimizely = {
+          fetchQualifiedSegments: sinon.stub().returns(null),
+        };
+        const user = new OptimizelyUserContext({
+          shouldIdentifyUser: false,
+          optimizely: fakeOptimizely,
+          userId,
+        });
+
+        const successfullyFetched = await user.fetchQualifiedSegments();
+        assert.deepEqual(successfullyFetched, false);
       });
     });
 

--- a/lib/optimizely_user_context/index.ts
+++ b/lib/optimizely_user_context/index.ts
@@ -258,7 +258,7 @@ export default class OptimizelyUserContext implements IOptimizelyUserContext {
 
     this.qualifiedSegments = segments;
 
-    return !!segments;
+    return segments !== null;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `fetchQualifiedSegments` returning and empty array `[ ]` is valid

## Test plan

- Added test cases

## Issues
- FSSDK-9984