### PR TITLE
[FSSDK-10090] Refactor ODP integration

### DIFF
--- a/lib/core/odp/odp_config.ts
+++ b/lib/core/odp/odp_config.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { config } from 'chai';
 import { checkArrayEquality } from '../../utils/fns';
 
 export class OdpConfig {

--- a/lib/core/odp/odp_config.ts
+++ b/lib/core/odp/odp_config.ts
@@ -68,7 +68,7 @@ export type OdpIntegratedConfig = {
   readonly odpConfig: OdpConfig;
 }
 
-export const odpIntegrationEquals = (config1: OdpIntegrationConfig, config2: OdpIntegrationConfig): boolean => {
+export const odpIntegrationsAreEqual = (config1: OdpIntegrationConfig, config2: OdpIntegrationConfig): boolean => {
   if (config1.integrated !== config2.integrated) {
     return false;
   }

--- a/lib/core/odp/odp_config.ts
+++ b/lib/core/odp/odp_config.ts
@@ -60,11 +60,11 @@ export class OdpConfig {
   }
 }
 
-type OdpNotIntegratedConfig = {
+export type OdpNotIntegratedConfig = {
   readonly integrated: false;
 }
 
-type OdpIntegratedConfig = {
+export type OdpIntegratedConfig = {
   readonly integrated: true;
   readonly odpConfig: OdpConfig;
 }

--- a/lib/core/odp/odp_config.ts
+++ b/lib/core/odp/odp_config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,106 +16,164 @@
 
 import { checkArrayEquality } from '../../utils/fns';
 
-export class OdpConfig {
-  /**
-   * Host of ODP audience segments API.
-   * @private
-   */
-  private _apiHost: string;
+export type NoOdpIntegrationConfig = {
+  readonly integrated: false;
+}
 
-  /**
-   * Getter to retrieve the ODP server host
-   * @public
-   */
-  get apiHost(): string {
-    return this._apiHost;
+export type OdpIntegrationConfig = {
+  readonly integrated: true;
+  readonly apiHost: string;
+  readonly apiKey: string;
+  readonly pixelUrl?: string;
+  readonly segmentsToCheck?: string[];
+}
+
+export type OdpConfig = (NoOdpIntegrationConfig | OdpIntegrationConfig) & {
+  equals(odpConfig: OdpConfig): boolean;
+}
+
+function areOdpConfigsEqual(config1: OdpConfig, config2: OdpConfig): boolean {
+  if (config1.integrated !== config2.integrated) {
+    return false;
   }
-
-  /**
-   * Public API key for the ODP account from which the audience segments will be fetched (optional).
-   * @private
-   */
-  private _apiKey: string;
-
-  /**
-   * Getter to retrieve the ODP API key
-   * @public
-   */
-  get apiKey(): string {
-    return this._apiKey;
-  }
-
-  /**
-   * Url for sending events via pixel.
-   * @private
-   */
-  private _pixelUrl: string;
-
-  /**
-   * Getter to retrieve the ODP pixel URL
-   * @public
-   */
-  get pixelUrl(): string {
-    return this._pixelUrl;
-  }
-
-  /**
-   * All ODP segments used in the current datafile (associated with apiHost/apiKey).
-   * @private
-   */
-  private _segmentsToCheck: string[];
-
-  /**
-   * Getter for ODP segments to check
-   * @public
-   */
-  get segmentsToCheck(): string[] {
-    return this._segmentsToCheck;
-  }
-
-  constructor(apiKey?: string, apiHost?: string, pixelUrl?: string, segmentsToCheck?: string[]) {
-    this._apiKey = apiKey ?? '';
-    this._apiHost = apiHost ?? '';
-    this._pixelUrl = pixelUrl ?? '';
-    this._segmentsToCheck = segmentsToCheck ?? [];
-  }
-
-  /**
-   * Update the ODP configuration details
-   * @param {OdpConfig} config New ODP Config to potentially update self with
-   * @returns true if configuration was updated successfully
-   */
-  update(config: OdpConfig): boolean {
-    if (this.equals(config)) {
-      return false;
-    } else {
-      if (config.apiKey) this._apiKey = config.apiKey;
-      if (config.apiHost) this._apiHost = config.apiHost;
-      if (config.pixelUrl) this._pixelUrl = config.pixelUrl;
-      if (config.segmentsToCheck) this._segmentsToCheck = config.segmentsToCheck;
-
-      return true;
-    }
-  }
-
-  /**
-   * Determines if ODP configuration has the minimum amount of information
-   */
-  isReady(): boolean {
-    return !!this._apiKey && !!this._apiHost;
-  }
-
-  /**
-   * Detects if there are any changes between the current and incoming ODP Configs
-   * @param configToCompare ODP Configuration to check self against for equality
-   * @returns Boolean based on if the current ODP Config is equivalent to the incoming ODP Config
-   */
-  equals(configToCompare: OdpConfig): boolean {
+  if (config1.integrated && config2.integrated) {
     return (
-      this._apiHost === configToCompare._apiHost &&
-      this._apiKey === configToCompare._apiKey &&
-      this._pixelUrl === configToCompare._pixelUrl &&
-      checkArrayEquality(this.segmentsToCheck, configToCompare._segmentsToCheck)
+      config1.apiHost === config2.apiHost &&
+      config1.apiKey === config2.apiKey &&
+      config1.pixelUrl === config2.pixelUrl &&
+      checkArrayEquality(config1.segmentsToCheck || [], config2.segmentsToCheck || [])
     );
   }
+  return true;
 }
+
+export function createOdpIntegrationConfig(
+  apiHost: string,
+  apiKey: string,
+  pixelUrl?: string,
+  segmentsToCheck?: string[]
+): OdpConfig {
+  return {
+    integrated: true,
+    apiHost,
+    apiKey,
+    pixelUrl,
+    segmentsToCheck,
+    equals: function(odpConfig: OdpConfig) {
+      return areOdpConfigsEqual(this, odpConfig)
+    }
+  };
+}
+
+export function createNoOdpIntegrationConfig(): OdpConfig {
+  return {
+    integrated: false,
+    equals: function (odpConfig: OdpConfig) {
+      return areOdpConfigsEqual(this, odpConfig)
+    }
+  };
+}
+
+// export class OdpConfig {
+//   /**
+//    * Host of ODP audience segments API.
+//    * @private
+//    */
+//   private _apiHost: string;
+
+//   /**
+//    * Getter to retrieve the ODP server host
+//    * @public
+//    */
+//   get apiHost(): string {
+//     return this._apiHost;
+//   }
+
+//   /**
+//    * Public API key for the ODP account from which the audience segments will be fetched (optional).
+//    * @private
+//    */
+//   private _apiKey: string;
+
+//   /**
+//    * Getter to retrieve the ODP API key
+//    * @public
+//    */
+//   get apiKey(): string {
+//     return this._apiKey;
+//   }
+
+//   /**
+//    * Url for sending events via pixel.
+//    * @private
+//    */
+//   private _pixelUrl: string;
+
+//   /**
+//    * Getter to retrieve the ODP pixel URL
+//    * @public
+//    */
+//   get pixelUrl(): string {
+//     return this._pixelUrl;
+//   }
+
+//   /**
+//    * All ODP segments used in the current datafile (associated with apiHost/apiKey).
+//    * @private
+//    */
+//   private _segmentsToCheck: string[];
+
+//   /**
+//    * Getter for ODP segments to check
+//    * @public
+//    */
+//   get segmentsToCheck(): string[] {
+//     return this._segmentsToCheck;
+//   }
+
+//   constructor(apiKey?: string, apiHost?: string, pixelUrl?: string, segmentsToCheck?: string[]) {
+//     this._apiKey = apiKey ?? '';
+//     this._apiHost = apiHost ?? '';
+//     this._pixelUrl = pixelUrl ?? '';
+//     this._segmentsToCheck = segmentsToCheck ?? [];
+//   }
+
+//   /**
+//    * Update the ODP configuration details
+//    * @param {OdpConfig} config New ODP Config to potentially update self with
+//    * @returns true if configuration was updated successfully
+//    */
+//   update(config: OdpConfig): boolean {
+//     if (this.equals(config)) {
+//       return false;
+//     } else {
+//       if (config.apiKey) this._apiKey = config.apiKey;
+//       if (config.apiHost) this._apiHost = config.apiHost;
+//       if (config.pixelUrl) this._pixelUrl = config.pixelUrl;
+//       if (config.segmentsToCheck) this._segmentsToCheck = config.segmentsToCheck;
+
+//       return true;
+//     }
+//   }
+
+//   /**
+//    * Determines if ODP configuration has the minimum amount of information
+//    */
+//   isReady(): boolean {
+//     return !!this._apiKey && !!this._apiHost;
+//   }
+
+//   /**
+//    * Detects if there are any changes between the current and incoming ODP Configs
+//    * @param configToCompare ODP Configuration to check self against for equality
+//    * @returns Boolean based on if the current ODP Config is equivalent to the incoming ODP Config
+//    */
+//   equals(configToCompare: OdpConfig): boolean {
+//     return (
+//       this._apiHost === configToCompare._apiHost &&
+//       this._apiKey === configToCompare._apiKey &&
+//       this._pixelUrl === configToCompare._pixelUrl &&
+//       checkArrayEquality(this.segmentsToCheck, configToCompare._segmentsToCheck)
+//     );
+//   }
+// }

--- a/lib/core/odp/odp_event_api_manager.ts
+++ b/lib/core/odp/odp_event_api_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -305,7 +305,6 @@ export abstract class OdpEventManager implements IOdpEventManager {
       this.logger.log(LogLevel.WARNING, 'Failed to Process ODP Event. ODPEventManager is not running.');
       return;
     }
-    const hasNecessaryIdentifiers = this.hasNecessaryIdentifiers;
 
     if (!this.hasNecessaryIdentifiers(event)) {
       this.logger.log(LogLevel.ERROR, 'ODP events should have at least one key-value pair in identifiers.');
@@ -347,7 +346,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
     } else if (this.queueHasBatches()) {
       // Check if queue has a full batch available
       this.clearCurrentTimeout();
-      
+
       while (this.queueHasBatches()) {
         this.makeAndSend1Batch();
       }

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -204,7 +204,6 @@ export abstract class OdpEventManager implements IOdpEventManager {
     this.flush(false);
 
     this.odpConfig = odpConfig;
-    this.apiManager.updateSettings(odpConfig);
   }
 
   /**
@@ -381,6 +380,11 @@ export abstract class OdpEventManager implements IOdpEventManager {
    * @private
    */
   private makeAndSend1Batch({ retry = true } : { retry: boolean }): void {
+    if (!this.odpConfig) {
+      return;
+    }
+
+    const odpConfig = this.odpConfig;
     const batch = new Array<OdpEvent>();
     
     // remove a batch from the queue
@@ -395,7 +399,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
 
     if (batch.length > 0) {
       if (!retry) {
-        this.apiManager.sendEvents(batch);
+        this.apiManager.sendEvents(odpConfig, batch);
         return;
       }
 
@@ -404,7 +408,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
         let shouldRetry: boolean;
         let attemptNumber = 0;
         do {
-          shouldRetry = await this.apiManager.sendEvents(batch);
+          shouldRetry = await this.apiManager.sendEvents(odpConfig, batch);
           attemptNumber += 1;
         } while (shouldRetry && attemptNumber < MAX_RETRIES);
       });

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -157,7 +157,6 @@ export abstract class OdpEventManager implements IOdpEventManager {
     flushInterval?: number;
     userAgentParser?: IUserAgentParser;
   }) {
-    this.odpConfig = odpConfig;
     this.apiManager = apiManager;
     this.logger = logger;
     this.clientEngine = clientEngine;
@@ -336,10 +335,6 @@ export abstract class OdpEventManager implements IOdpEventManager {
       return;
     }
 
-    if (!this.odpConfig) {
-      return;
-    }
-
     if (shouldFlush) {
       // clear the queue completely
       this.clearCurrentTimeout();
@@ -456,5 +451,9 @@ export abstract class OdpEventManager implements IOdpEventManager {
 
   protected getLogger(): LogHandler {
     return this.logger;
+  }
+
+  getQueue(): OdpEvent[] {
+    return this.queue;
   }
 }

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -227,7 +227,11 @@ export abstract class OdpEventManager implements IOdpEventManager {
     }
 
     this.status = Status.Running;
-    this.setNewTimeout();
+
+    // no need of periodic flush if batchSize is 1
+    if (this.batchSize > 1) {
+      this.setNewTimeout();
+    }
   }
 
   /**
@@ -301,6 +305,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
       this.logger.log(LogLevel.WARNING, 'Failed to Process ODP Event. ODPEventManager is not running.');
       return;
     }
+    const hasNecessaryIdentifiers = this.hasNecessaryIdentifiers;
 
     if (!this.hasNecessaryIdentifiers(event)) {
       this.logger.log(LogLevel.ERROR, 'ODP events should have at least one key-value pair in identifiers.');
@@ -317,7 +322,6 @@ export abstract class OdpEventManager implements IOdpEventManager {
     }
 
     this.queue.push(event);
-
     this.processQueue();
   }
 
@@ -347,7 +351,10 @@ export abstract class OdpEventManager implements IOdpEventManager {
       }
     }
 
-    this.setNewTimeout();
+    // no need for periodic flush if batchSize is 1
+    if (this.batchSize > 1) {
+      this.setNewTimeout();
+    }
   }
 
   /**

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -336,16 +336,18 @@ export abstract class OdpEventManager implements IOdpEventManager {
     if (this.status !== Status.Running) {
       return;
     }
-
-    this.clearCurrentTimeout();
     
     if (shouldFlush) {
       // clear the queue completely
+      this.clearCurrentTimeout();
+
       while (this.queueContainsItems()) {
         this.makeAndSend1Batch();
       }
     } else if (this.queueHasBatches()) {
       // Check if queue has a full batch available
+      this.clearCurrentTimeout();
+      
       while (this.queueHasBatches()) {
         this.makeAndSend1Batch();
       }

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -129,7 +129,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
    */
   private readonly userAgentParser?: IUserAgentParser;
 
-  private retires: number;
+  private retries: number;
 
 
   /**
@@ -168,7 +168,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
     this.initParams(batchSize, queueSize, flushInterval);
     this.status = Status.Stopped;
     this.userAgentParser = userAgentParser;
-    this.retires = retries || MAX_RETRIES;
+    this.retries = retries || MAX_RETRIES;
 
     if (userAgentParser) {
       const { os, device } = userAgentParser.parseUserAgentInfo();
@@ -398,7 +398,7 @@ export abstract class OdpEventManager implements IOdpEventManager {
         do {
           shouldRetry = await this.apiManager.sendEvents(odpConfig, batch);
           attemptNumber += 1;
-        } while (shouldRetry && attemptNumber < this.retires);
+        } while (shouldRetry && attemptNumber < this.retries);
       });
     }
   }

--- a/lib/core/odp/odp_event_manager.ts
+++ b/lib/core/odp/odp_event_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -288,10 +288,6 @@ export abstract class OdpManager implements IOdpManager {
       throw new Error(ERROR_MESSAGES.ODP_INVALID_DATA);
     }
 
-    if (!this.eventManager) {
-      throw new Error(ERROR_MESSAGES.ODP_SEND_EVENT_FAILED_EVENT_MANAGER_MISSING);
-    }
-
     if (typeof action !== 'string' || action === '') {
       throw new Error('ODP action is not valid (cannot be empty).');
     }

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -20,30 +20,26 @@ import { ERROR_MESSAGES, ODP_USER_KEY } from '../../utils/enums';
 
 import { VuidManager } from '../../plugins/vuid_manager';
 
-import { OdpConfig } from './odp_config';
+import { OdpConfig, OdpIntegrationConfig, odpIntegrationEquals } from './odp_config';
 import { IOdpEventManager } from './odp_event_manager';
 import { IOdpSegmentManager } from './odp_segment_manager';
 import { OptimizelySegmentOption } from './optimizely_segment_option';
 import { invalidOdpDataFound } from './odp_utils';
 import { OdpEvent } from './odp_event';
+import { resolvablePromise, ResolvablePromise } from '../../utils/promise/resolvablePromise';
 
 /**
  * Manager for handling internal all business logic related to
  * Optimizely Data Platform (ODP) / Advanced Audience Targeting (AAT)
  */
 export interface IOdpManager {
-  onInit(): Promise<void>;
-  // initPromise?: Promise<void>;
+  onReady(): Promise<unknown>;
 
-  enabled: boolean;
+  isReady(): boolean;
 
-  segmentManager: IOdpSegmentManager | undefined;
+  updateSettings(odpIntegrationConfig: OdpIntegrationConfig): boolean;
 
-  eventManager: IOdpEventManager | undefined;
-
-  updateSettings(odpConfig: OdpConfig): boolean;
-
-  close(): void;
+  stop(): void;
 
   fetchQualifiedSegments(userId: string, options?: Array<OptimizelySegmentOption>): Promise<string[] | null>;
 
@@ -53,9 +49,12 @@ export interface IOdpManager {
 
   isVuidEnabled(): boolean;
 
-  initializeVuid(): Promise<void>;
-
   getVuid(): string | undefined;
+}
+
+enum Status {
+  Running,
+  Stopped,
 }
 
 /**
@@ -65,118 +64,140 @@ export abstract class OdpManager implements IOdpManager {
   /**
    * Promise that returns when the OdpManager is finished initializing
    */
-  initPromise?: Promise<void>;
+  private initPromise: Promise<unknown>;
+  
+  private ready: boolean = false;
 
   /**
-   * Switch to enable/disable ODP Manager functionality
+   * Promise that resolves when odpConfig becomes available
    */
-  enabled: boolean;
+  private configPromise: ResolvablePromise<void>;
 
-  vuidManger: VuidManager;
-  
+  private status: Status = Status.Stopped;
+
   /**
    * ODP Segment Manager which provides an interface to the remote ODP server (GraphQL API) for audience segments mapping.
    * It fetches all qualified segments for the given user context and manages the segments cache for all user contexts.
    */
-  segmentManager: IOdpSegmentManager;
+  private segmentManager: IOdpSegmentManager;
 
   /**
    * ODP Event Manager which provides an interface to the remote ODP server (REST API) for events.
    * It will queue all pending events (persistent) and send them (in batches of up to 10 events) to the ODP server when possible.
    */
-  eventManager: IOdpEventManager;
+  private eventManager: IOdpEventManager;
 
   /**
    * Handler for recording execution logs
    * @protected
    */
-  protected logger: LogHandler = getLogger(); // TODO: Consider making private and moving instantiation to constructor
+  protected logger: LogHandler;
 
   /**
    * ODP configuration settings for identifying the target API and segments
    */
-  // odpConfig: OdpConfig = new OdpConfig(); // TODO: Consider making private and adding public accessors
-  odpConfig?: OdpConfig;
+  odpIntegrationConfig?: OdpIntegrationConfig;
 
   // TODO: Consider accepting logger as a parameter and initializing it in constructor instead
-  private constructor({
-    odpConfig,
-    vuidManager,
-    segmentManger,
+  constructor({
+    odpIntegrationConfig,
+    segmentManager,
     eventManager,
+    logger,
   }: {
-    odpConfig?: OdpConfig;
-    vuidManager: VuidManager;
-    segmentManger: IOdpSegmentManager;
+    odpIntegrationConfig?: OdpIntegrationConfig;
+    segmentManager: IOdpSegmentManager;
     eventManager: IOdpEventManager;
+    logger: LogHandler;
   }) {
-    this.enabled = !!odpConfig;
-    this.odpConfig = odpConfig;
-    this.vuidManger = vuidManager;
-    this.segmentManager = segmentManger;
+    this.odpIntegrationConfig = odpIntegrationConfig;
+    this.segmentManager = segmentManager;
     this.eventManager = eventManager;
+    this.logger = logger;
 
+    this.configPromise = resolvablePromise();
+
+    const readineessDependencies: PromiseLike<unknown>[] = [this.configPromise];
+
+    if (this.isVuidEnabled()) {
+      readineessDependencies.push(this.initializeVuid());
+    }
+
+    this.initPromise = Promise.all(readineessDependencies);
+
+    this.onReady().then(() => {
+      this.ready = true;
+      if(this.isVuidEnabled()) {
+        this.registerVuid();
+      }
+    });
+
+    if (odpIntegrationConfig) {
+      this.updateSettings(odpIntegrationConfig);
+    }
   }
 
-
-
-  // start(): Promise<void> {
-  //   return Promise.resolve();
-  // }
-
-  // stop(): Promise<void> {
-  //   return Promise.resolve();
-  // }
-
-  onInit(): Promise<void> {
-    return this.initPromise;
-  }
-
-  /**
-   * Provides a method to update ODP Manager's ODP Config API Key, API Host, and Audience Segments
-   */
-  updateSettings(odpConfig: OdpConfig): boolean {
-    if (!odpConfig.integrated) {
-      this.close();
-    }
-
-    if (!this.enabled) {
-      return false;
-    }
-
-    if (!this.eventManager) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_MANAGER_UPDATE_SETTINGS_FAILED_EVENT_MANAGER_MISSING);
-      return false;
-    }
-
-    if (!this.segmentManager) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_MANAGER_UPDATE_SETTINGS_FAILED_SEGMENTS_MANAGER_MISSING);
-      return false;
-    }
-
-    this.eventManager.flush();
-
-    const newConfig = new OdpConfig(apiKey, apiHost, pixelUrl, segmentsToCheck);
-    const configDidUpdate = this.odpConfig.update(newConfig);
-
-    if (configDidUpdate) {
-      this.odpConfig.update(newConfig);
-      this.segmentManager?.reset();
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Attempts to stop the current instance of ODP Manager's event manager, if it exists and is running.
-   */
-  close(): void {
-    if (!this.enabled) {
+  async start(): Promise<void> {
+    if (this.status === Status.Running) {
       return;
     }
 
-    this.eventManager?.stop();
+    if (!this.odpIntegrationConfig) {
+      return Promise.reject(new Error('cannot start without ODP config'));      
+    }
+
+    if (!this.odpIntegrationConfig.integrated) {
+      return Promise.reject(new Error('start() called when ODP is not integrated'));
+    }
+
+    this.status = Status.Running;
+    this.segmentManager.updateSettings(this.odpIntegrationConfig.odpConfig);
+    this.eventManager.updateSettings(this.odpIntegrationConfig.odpConfig);
+    this.eventManager.start();
+    return Promise.resolve();
+  }
+
+  async stop(): Promise<void> {
+    if (this.status === Status.Stopped) {
+      return;
+    }
+    this.status = Status.Stopped;
+    await this.eventManager.stop();
+  }
+
+  onReady(): Promise<unknown> {
+    return this.initPromise;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  /**
+   * Provides a method to update ODP Manager's ODP Config
+   */
+  updateSettings(odpIntegrationConfig: OdpIntegrationConfig): boolean {
+    this.configPromise.resolve();
+
+    // do nothing if config did not change
+    if (this.odpIntegrationConfig && odpIntegrationEquals(this.odpIntegrationConfig, odpIntegrationConfig)) {
+      return false;
+    }
+
+    this.odpIntegrationConfig = odpIntegrationConfig;
+
+    if (odpIntegrationConfig.integrated) {
+      // already running, just propagate updated config to children;
+      if (this.status === Status.Running) {
+        this.segmentManager.updateSettings(odpIntegrationConfig.odpConfig);
+        this.eventManager.updateSettings(odpIntegrationConfig.odpConfig);
+      } else {
+        this.start();
+      }
+    } else {
+      this.stop();
+    }
+    return true;
   }
 
   /**
@@ -187,13 +208,13 @@ export abstract class OdpManager implements IOdpManager {
    * @returns {Promise<string[] | null>}      A promise holding either a list of qualified segments or null.
    */
   async fetchQualifiedSegments(userId: string, options: Array<OptimizelySegmentOption> = []): Promise<string[] | null> {
-    if (!this.enabled) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_ENABLED);
+    if (!this.odpIntegrationConfig) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
       return null;
     }
 
-    if (!this.segmentManager) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_FETCH_QUALIFIED_SEGMENTS_SEGMENTS_MANAGER_MISSING);
+    if (!this.odpIntegrationConfig.integrated) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_INTEGRATED);
       return null;
     }
 
@@ -211,18 +232,13 @@ export abstract class OdpManager implements IOdpManager {
    * @returns
    */
   identifyUser(userId?: string, vuid?: string): void {
-    if (!this.enabled) {
-      this.logger.log(LogLevel.DEBUG, LOG_MESSAGES.ODP_IDENTIFY_FAILED_ODP_DISABLED);
+    if (!this.odpIntegrationConfig) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
       return;
     }
 
-    if (!this.odpConfig.isReady()) {
-      this.logger.log(LogLevel.DEBUG, LOG_MESSAGES.ODP_IDENTIFY_FAILED_ODP_NOT_INTEGRATED);
-      return;
-    }
-
-    if (!this.eventManager) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_IDENTIFY_FAILED_EVENT_MANAGER_MISSING);
+    if (!this.odpIntegrationConfig.integrated) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_INTEGRATED);
       return;
     }
 
@@ -245,12 +261,14 @@ export abstract class OdpManager implements IOdpManager {
       mType = 'fullstack';
     }
 
-    if (!this.enabled) {
-      throw new Error(ERROR_MESSAGES.ODP_NOT_ENABLED);
+    if (!this.odpIntegrationConfig) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
+      return;
     }
 
-    if (!this.odpConfig.isReady()) {
-      throw new Error(ERROR_MESSAGES.ODP_NOT_INTEGRATED);
+    if (!this.odpIntegrationConfig.integrated) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_INTEGRATED);
+      return;
     }
 
     if (invalidOdpDataFound(data)) {
@@ -277,4 +295,21 @@ export abstract class OdpManager implements IOdpManager {
    * Returns VUID value if it exists
    */
   abstract getVuid(): string | undefined;
+
+  protected initializeVuid(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private registerVuid() {
+    const vuid = this.getVuid();
+    if (!vuid) {
+      return;
+    }
+
+    try {
+      this.eventManager.registerVuid(vuid);
+    } catch (e) {
+      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_VUID_REGISTRATION_FAILED);
+    }
+  }
 }

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -81,17 +81,7 @@ export abstract class OdpManager implements IOdpManager {
    */
   private segmentManager: IOdpSegmentManager;
 
-  /**constructor({
-    odpIntegrationConfig,
-    segmentManager,
-    eventManager,
-    logger,
-  }: {
-    odpIntegrationConfig?: OdpIntegrationConfig;
-    segmentManager: IOdpSegmentManager;
-    eventManager: IOdpEventManager;
-    logger: LogHandler;
-  })
+  /**
    * ODP Event Manager which provides an interface to the remote ODP server (REST API) for events.
    * It will queue all pending events (persistent) and send them (in batches of up to 10 events) to the ODP server when possible.
    */

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, Optimizely
+ * Copyright 2023-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -110,7 +110,6 @@ export abstract class OdpManager implements IOdpManager {
     eventManager: IOdpEventManager;
     logger: LogHandler;
   }) {
-    this.odpIntegrationConfig = odpIntegrationConfig;
     this.segmentManager = segmentManager;
     this.eventManager = eventManager;
     this.logger = logger;

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -20,7 +20,7 @@ import { ERROR_MESSAGES, ODP_USER_KEY } from '../../utils/enums';
 
 import { VuidManager } from '../../plugins/vuid_manager';
 
-import { OdpConfig, OdpIntegrationConfig, odpIntegrationEquals } from './odp_config';
+import { OdpConfig, OdpIntegrationConfig, odpIntegrationsAreEqual } from './odp_config';
 import { IOdpEventManager } from './odp_event_manager';
 import { IOdpSegmentManager } from './odp_segment_manager';
 import { OptimizelySegmentOption } from './optimizely_segment_option';
@@ -183,7 +183,7 @@ export abstract class OdpManager implements IOdpManager {
     this.configPromise.resolve();
 
     // do nothing if config did not change
-    if (this.odpIntegrationConfig && odpIntegrationEquals(this.odpIntegrationConfig, odpIntegrationConfig)) {
+    if (this.odpIntegrationConfig && odpIntegrationsAreEqual(this.odpIntegrationConfig, odpIntegrationConfig)) {
       return false;
     }
 

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -211,16 +211,13 @@ export abstract class OdpManager implements IOdpManager {
    * @returns {Promise<string[] | null>}      A promise holding either a list of qualified segments or null.
    */
   async fetchQualifiedSegments(userId: string, options: Array<OptimizelySegmentOption> = []): Promise<string[] | null> {
-    console.log('fetch woot');
-    if (!this.odpIntegrationConfig) {
-      console.log('wat no config ');
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
+     if (!this.odpIntegrationConfig) {
+       this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
       return null;
     }
 
     if (!this.odpIntegrationConfig.integrated) {
-      console.log('wat no integration ');
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_INTEGRATED);
+       this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_INTEGRATED);
       return null;
     }
 
@@ -228,9 +225,7 @@ export abstract class OdpManager implements IOdpManager {
       return this.segmentManager.fetchQualifiedSegments(ODP_USER_KEY.VUID, userId, options);
     }
 
-    const foo = await this.segmentManager.fetchQualifiedSegments(ODP_USER_KEY.FS_USER_ID, userId, options);
-    console.log('foo is ', foo);
-    return foo;
+    return this.segmentManager.fetchQualifiedSegments(ODP_USER_KEY.FS_USER_ID, userId, options);   
   }
 
   /**

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -52,7 +52,7 @@ export interface IOdpManager {
   getVuid(): string | undefined;
 }
 
-enum Status {
+export enum Status {
   Running,
   Stopped,
 }
@@ -73,7 +73,7 @@ export abstract class OdpManager implements IOdpManager {
    */
   private configPromise: ResolvablePromise<void>;
 
-  private status: Status = Status.Stopped;
+  status: Status = Status.Stopped;
 
   /**
    * ODP Segment Manager which provides an interface to the remote ODP server (GraphQL API) for audience segments mapping.
@@ -81,7 +81,17 @@ export abstract class OdpManager implements IOdpManager {
    */
   private segmentManager: IOdpSegmentManager;
 
-  /**
+  /**constructor({
+    odpIntegrationConfig,
+    segmentManager,
+    eventManager,
+    logger,
+  }: {
+    odpIntegrationConfig?: OdpIntegrationConfig;
+    segmentManager: IOdpSegmentManager;
+    eventManager: IOdpEventManager;
+    logger: LogHandler;
+  })
    * ODP Event Manager which provides an interface to the remote ODP server (REST API) for events.
    * It will queue all pending events (persistent) and send them (in batches of up to 10 events) to the ODP server when possible.
    */
@@ -134,6 +144,10 @@ export abstract class OdpManager implements IOdpManager {
     if (odpIntegrationConfig) {
       this.updateSettings(odpIntegrationConfig);
     }
+  }
+
+  public getStatus(): Status {
+    return this.status;
   }
 
   async start(): Promise<void> {

--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -110,21 +110,23 @@ export abstract class OdpManager implements IOdpManager {
     eventManager: IOdpEventManager;
     logger: LogHandler;
   }) {
+    console.log('odp manager constructor', odpIntegrationConfig);
     this.segmentManager = segmentManager;
     this.eventManager = eventManager;
     this.logger = logger;
 
     this.configPromise = resolvablePromise();
 
-    const readineessDependencies: PromiseLike<unknown>[] = [this.configPromise];
+    const readinessDependencies: PromiseLike<unknown>[] = [this.configPromise];
 
     if (this.isVuidEnabled()) {
-      readineessDependencies.push(this.initializeVuid());
+      readinessDependencies.push(this.initializeVuid());
     }
 
-    this.initPromise = Promise.all(readineessDependencies);
+    this.initPromise = Promise.all(readinessDependencies);
 
     this.onReady().then(() => {
+      console.log('odp got ready');
       this.ready = true;
       if(this.isVuidEnabled()) {
         this.registerVuid();

--- a/lib/core/odp/odp_segment_manager.ts
+++ b/lib/core/odp/odp_segment_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/odp/odp_segment_manager.ts
+++ b/lib/core/odp/odp_segment_manager.ts
@@ -40,7 +40,7 @@ export class OdpSegmentManager implements IOdpSegmentManager {
    * ODP configuration settings in used
    * @private
    */
-  private odpConfig: OdpConfig;
+  private odpConfig?: OdpConfig;
 
   /**
    * Holds cached audience segments
@@ -69,10 +69,10 @@ export class OdpSegmentManager implements IOdpSegmentManager {
   private readonly logger: LogHandler;
 
   constructor(
-    odpConfig: OdpConfig,
     segmentsCache: ICache<string, string[]>,
     odpSegmentApiManager: IOdpSegmentApiManager,
-    logger?: LogHandler
+    logger?: LogHandler,
+    odpConfig?: OdpConfig,
   ) {
     this.odpConfig = odpConfig;
     this._segmentsCache = segmentsCache;
@@ -93,11 +93,15 @@ export class OdpSegmentManager implements IOdpSegmentManager {
     userValue: string,
     options: Array<OptimizelySegmentOption>
   ): Promise<string[] | null> {
-    const { apiHost: odpApiHost, apiKey: odpApiKey } = this.odpConfig;
+    // const { apiHost: odpApiHost, apiKey: odpApiKey } = this.odpConfig;
 
-    if (!odpApiKey || !odpApiHost) {
-      this.logger.log(LogLevel.WARNING, ERROR_MESSAGES.FETCH_SEGMENTS_FAILED_INVALID_IDENTIFIER);
-      return null;
+    // if (!odpApiKey || !odpApiHost) {
+    //   this.logger.log(LogLevel.WARNING, ERROR_MESSAGES.FETCH_SEGMENTS_FAILED_INVALID_IDENTIFIER);
+    //   return null;
+    // }
+    if (!this.odpConfig) {
+      this.logger.log(LogLevel.WARNING, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
+      return null;      
     }
 
     const segmentsToCheck = this.odpConfig.segmentsToCheck;
@@ -127,8 +131,8 @@ export class OdpSegmentManager implements IOdpSegmentManager {
     this.logger.log(LogLevel.DEBUG, `Making a call to ODP server.`);
 
     const segments = await this.odpSegmentApiManager.fetchSegments(
-      odpApiKey,
-      odpApiHost,
+      this.odpConfig.apiKey,
+      this.odpConfig.apiHost,
       userKey,
       userValue,
       segmentsToCheck
@@ -164,6 +168,6 @@ export class OdpSegmentManager implements IOdpSegmentManager {
    */
   updateSettings(config: OdpConfig): void {
     this.odpConfig = config;
-    this._segmentsCache.reset();
+    this.reset();
   }
 }

--- a/lib/core/odp/odp_segment_manager.ts
+++ b/lib/core/odp/odp_segment_manager.ts
@@ -93,12 +93,6 @@ export class OdpSegmentManager implements IOdpSegmentManager {
     userValue: string,
     options: Array<OptimizelySegmentOption>
   ): Promise<string[] | null> {
-    // const { apiHost: odpApiHost, apiKey: odpApiKey } = this.odpConfig;
-
-    // if (!odpApiKey || !odpApiHost) {
-    //   this.logger.log(LogLevel.WARNING, ERROR_MESSAGES.FETCH_SEGMENTS_FAILED_INVALID_IDENTIFIER);
-    //   return null;
-    // }
     if (!this.odpConfig) {
       this.logger.log(LogLevel.WARNING, ERROR_MESSAGES.ODP_CONFIG_NOT_AVAILABLE);
       return null;      

--- a/lib/core/project_config/index.tests.js
+++ b/lib/core/project_config/index.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2023, Optimizely
+ * Copyright 2016-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/project_config/index.tests.js
+++ b/lib/core/project_config/index.tests.js
@@ -813,21 +813,12 @@ describe('lib/core/project_config', function() {
         assert.equal(config.integrations.length, 4);
       });
 
-      it('should populate the public key value from the odp integration', () => {
-        assert.exists(config.publicKeyForOdp);
-      });
-
-      it('should populate the host value from the odp integration', () => {
-        assert.exists(config.hostForOdp);
-      });
-
-      it('should populate the pixelUrl value from the odp integration', () => {
-        assert.exists(config.pixelUrlForOdp);
-      });
-
-      it('should contain all expected unique odp segments in allSegments', () => {
-        assert.equal(config.allSegments.length, 3);
-        assert.deepEqual(config.allSegments, ['odp-segment-1', 'odp-segment-2', 'odp-segment-3']);
+      it('should populate odpIntegrationConfig', () => {
+        assert.isTrue(config.odpIntegrationConfig.integrated);
+        assert.equal(config.odpIntegrationConfig.odpConfig.apiKey, 'W4WzcEs-ABgXorzY7h1LCQ');
+        assert.equal(config.odpIntegrationConfig.odpConfig.apiHost, 'https://api.zaius.com');
+        assert.equal(config.odpIntegrationConfig.odpConfig.pixelUrl, 'https://jumbe.zaius.com');
+        assert.deepEqual(config.odpIntegrationConfig.odpConfig.segmentsToCheck, ['odp-segment-1', 'odp-segment-2', 'odp-segment-3']);
       });
     });
 
@@ -842,23 +833,12 @@ describe('lib/core/project_config', function() {
         assert.equal(config.integrations.length, 3);
       });
 
-      it('should populate the public key value from the odp integration', () => {
-        assert.exists(config.publicKeyForOdp);
-        assert.equal(config.publicKeyForOdp, 'W4WzcEs-ABgXorzY7h1LCQ');
-      });
-
-      it('should populate the host value from the odp integration', () => {
-        assert.exists(config.hostForOdp);
-        assert.equal(config.hostForOdp, 'https://api.zaius.com');
-      });
-
-      it('should populate the pixelUrl value from the odp integration', () => {
-        assert.exists(config.pixelUrlForOdp);
-        assert.equal(config.pixelUrlForOdp, 'https://jumbe.zaius.com');
-      });
-
-      it('should contain all expected unique odp segments in all segments', () => {
-        assert.equal(config.allSegments.length, 0);
+      it('should populate odpIntegrationConfig', () => {
+        assert.isTrue(config.odpIntegrationConfig.integrated);
+        assert.equal(config.odpIntegrationConfig.odpConfig.apiKey, 'W4WzcEs-ABgXorzY7h1LCQ');
+        assert.equal(config.odpIntegrationConfig.odpConfig.apiHost, 'https://api.zaius.com');
+        assert.equal(config.odpIntegrationConfig.odpConfig.pixelUrl, 'https://jumbe.zaius.com');
+        assert.deepEqual(config.odpIntegrationConfig.odpConfig.segmentsToCheck, []);
       });
     });
 
@@ -881,6 +861,11 @@ describe('lib/core/project_config', function() {
 
       it('should convert integrations from the datafile into the project config', () => {
         assert.equal(config.integrations.length, 0);
+      });
+
+      it('should populate odpIntegrationConfig', () => {
+        assert.isFalse(config.odpIntegrationConfig.integrated);
+        assert.isUndefined(config.odpIntegrationConfig.odpConfig);
       });
     });
   });

--- a/lib/core/project_config/index.ts
+++ b/lib/core/project_config/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2023, Optimizely
+ * Copyright 2016-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/project_config/index.ts
+++ b/lib/core/project_config/index.ts
@@ -200,9 +200,9 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
 
       if (integration.key === 'odp') {
         odpIntegrated = true;
-        odpApiKey = integration.publicKey || '';
-        odpApiHost = integration.host || '';
-        odpPixelUrl = integration.pixelUrl || '';
+        odpApiKey = odpApiKey || integration.publicKey || '';
+        odpApiHost = odpApiHost || integration.host || '';
+        odpPixelUrl = odpPixelUrl || integration.pixelUrl || '';
       }
     });
   }

--- a/lib/core/project_config/project_config_manager.tests.js
+++ b/lib/core/project_config/project_config_manager.tests.js
@@ -165,7 +165,7 @@ describe('lib/core/project_config/project_config_manager', function() {
     });
   });
 
-  it('does not call onUpdate listeners after becoming ready when constructed with a valid datafile and without sdkKey', function() {
+  it('calls onUpdate listeners once when constructed with a valid datafile and without sdkKey', function() {
     var configWithFeatures = testData.getTestProjectConfigWithFeatures();
     var manager = projectConfigManager.createProjectConfigManager({
       datafile: configWithFeatures,      
@@ -173,7 +173,7 @@ describe('lib/core/project_config/project_config_manager', function() {
     var onUpdateSpy = sinon.spy();
     manager.onUpdate(onUpdateSpy);
     return manager.onReady().then(function() {
-      sinon.assert.notCalled(onUpdateSpy);
+      sinon.assert.calledOnce(onUpdateSpy);
     });
   });
 
@@ -242,7 +242,7 @@ describe('lib/core/project_config/project_config_manager', function() {
         });
       });
 
-      it('calls onUpdate listeners after becoming ready, and after the datafile manager emits updates', function() {
+      it('calls onUpdate listeners after becoming ready, and after the datafile manager emits updates', async function() {
         datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
@@ -256,21 +256,20 @@ describe('lib/core/project_config/project_config_manager', function() {
         });
         var onUpdateSpy = sinon.spy();
         manager.onUpdate(onUpdateSpy);
-        return manager.onReady().then(function() {
-          sinon.assert.calledOnce(onUpdateSpy);
-
-          var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
-          var updateListener = fakeDatafileManager.on.getCall(0).args[1];
-          var newDatafile = testData.getTestProjectConfigWithFeatures();
-          newDatafile.revision = '36';
-          fakeDatafileManager.get.returns(newDatafile);
-
-          updateListener({ datafile: newDatafile });
-          sinon.assert.calledTwice(onUpdateSpy);
-        });
+        await manager.onReady();
+        sinon.assert.calledOnce(onUpdateSpy);
+        var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
+        var updateListener = fakeDatafileManager.on.getCall(0).args[1];
+        var newDatafile = testData.getTestProjectConfigWithFeatures();
+        newDatafile.revision = '36';
+        fakeDatafileManager.get.returns(newDatafile);
+        updateListener({ datafile: newDatafile });
+        
+        await Promise.resolve();
+        sinon.assert.calledTwice(onUpdateSpy);
       });
 
-      it('can remove onUpdate listeners using the function returned from onUpdate', function() {
+      it('can remove onUpdate listeners using the function returned from onUpdate', async function() {
         datafileManager.HttpPollingDatafileManager.returns({
           start: sinon.stub(),
           stop: sinon.stub(),
@@ -282,29 +281,29 @@ describe('lib/core/project_config/project_config_manager', function() {
           sdkKey: '12345',
           datafileManager: createHttpPollingDatafileManager('12345', logger),
         });
-        return manager.onReady().then(function() {
-          var onUpdateSpy = sinon.spy();
-          var unsubscribe = manager.onUpdate(onUpdateSpy);
+        await manager.onReady();
+        var onUpdateSpy = sinon.spy();
+        var unsubscribe = manager.onUpdate(onUpdateSpy);
+        var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
+        var updateListener = fakeDatafileManager.on.getCall(0).args[1];
 
-          var fakeDatafileManager = datafileManager.HttpPollingDatafileManager.getCall(0).returnValue;
-          var updateListener = fakeDatafileManager.on.getCall(0).args[1];
-          var newDatafile = testData.getTestProjectConfigWithFeatures();
-          newDatafile.revision = '36';
-          fakeDatafileManager.get.returns(newDatafile);
-          updateListener({ datafile: newDatafile });
+        var newDatafile = testData.getTestProjectConfigWithFeatures();
+        newDatafile.revision = '36';
+        fakeDatafileManager.get.returns(newDatafile);
 
-          sinon.assert.calledOnce(onUpdateSpy);
-
-          unsubscribe();
-
-          newDatafile = testData.getTestProjectConfigWithFeatures();
-          newDatafile.revision = '37';
-          fakeDatafileManager.get.returns(newDatafile);
-          updateListener({ datafile: newDatafile });
-          // // Should not call onUpdateSpy again since we unsubscribed
-          updateListener({ datafile: testData.getTestProjectConfigWithFeatures() });
-          sinon.assert.calledOnce(onUpdateSpy);
-        });
+        updateListener({ datafile: newDatafile });
+        // allow queued micortasks to run
+        await Promise.resolve();
+        
+        sinon.assert.calledOnce(onUpdateSpy);
+        unsubscribe();
+        newDatafile = testData.getTestProjectConfigWithFeatures();
+        newDatafile.revision = '37';
+        fakeDatafileManager.get.returns(newDatafile);
+        updateListener({ datafile: newDatafile });
+        // // Should not call onUpdateSpy again since we unsubscribed
+        updateListener({ datafile: testData.getTestProjectConfigWithFeatures() });
+        sinon.assert.calledOnce(onUpdateSpy);
       });
 
       it('fulfills its ready promise with an unsuccessful result when the datafile manager emits an invalid datafile', function() {

--- a/lib/core/project_config/project_config_manager.tests.js
+++ b/lib/core/project_config/project_config_manager.tests.js
@@ -368,58 +368,92 @@ describe('lib/core/project_config/project_config_manager', function() {
     });
 
     describe('when constructed with sdkKey and with a valid datafile object', function() {
-      it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners after becoming ready', function() {
-        datafileManager.HttpPollingDatafileManager.returns({
-          start: sinon.stub(),
-          stop: sinon.stub(),
-          get: sinon.stub().returns(JSON.stringify(testData.getTestProjectConfigWithFeatures())),
-          on: sinon.stub().returns(function() {}),
-          onReady: sinon.stub().returns(Promise.resolve()),
-        });
+      it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners if datafile does not change', async function() {
         var configWithFeatures = testData.getTestProjectConfigWithFeatures();
+
+        const handlers = [];
+        const mockDatafileManager = {
+          start: () => {},
+          get: () => JSON.stringify(configWithFeatures),
+          on: (event, fn) => handlers.push(fn),
+          onReady: () => Promise.resolve(),
+          pushUpdate: (datafile) => handlers.forEach(handler => handler({ datafile })),
+        };
+
         var manager = projectConfigManager.createProjectConfigManager({
           datafile: configWithFeatures,
           sdkKey: '12345',
-          datafileManager: createHttpPollingDatafileManager('12345', logger, configWithFeatures),
+          datafileManager: mockDatafileManager,
         });
         var onUpdateSpy = sinon.spy();
         manager.onUpdate(onUpdateSpy);
-        return manager.onReady().then(function(result) {
-          assert.include(result, {
-            success: true,
-          });
-          // Datafile is the same as what it was constructed with, so should
-          // not have called update listener
-          sinon.assert.notCalled(onUpdateSpy);
+
+        const result = await manager.onReady();
+        assert.include(result, {
+          success: true,
         });
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        // allow queued microtasks to run
+        await Promise.resolve();
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+
+        configWithFeatures.revision = '99';
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+        sinon.assert.callCount(onUpdateSpy, 2);
       });
     });
 
     describe('when constructed with sdkKey and with a valid datafile string', function() {
-      it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners after becoming ready', function() {
-        datafileManager.HttpPollingDatafileManager.returns({
-          start: sinon.stub(),
-          stop: sinon.stub(),
-          get: sinon.stub().returns(JSON.stringify(testData.getTestProjectConfigWithFeatures())),
-          on: sinon.stub().returns(function() {}),
-          onReady: sinon.stub().returns(Promise.resolve()),
-        });
+      it('fulfills its onReady promise with a successful result, and does not call onUpdate listeners if datafile does not change', async function() {
         var configWithFeatures = testData.getTestProjectConfigWithFeatures();
+
+        const handlers = [];
+        const mockDatafileManager = {
+          start: () => {},
+          get: () => JSON.stringify(configWithFeatures),
+          on: (event, fn) => handlers.push(fn),
+          onReady: () => Promise.resolve(),
+          pushUpdate: (datafile) => handlers.forEach(handler => handler({ datafile })),
+        };
+
         var manager = projectConfigManager.createProjectConfigManager({
           datafile: JSON.stringify(configWithFeatures),
           sdkKey: '12345',
-          datafileManager: createHttpPollingDatafileManager('12345', logger, JSON.stringify(configWithFeatures)),
+          datafileManager: mockDatafileManager,
         });
         var onUpdateSpy = sinon.spy();
         manager.onUpdate(onUpdateSpy);
-        return manager.onReady().then(function(result) {
-          assert.include(result, {
-            success: true,
-          });
-          // Datafile is the same as what it was constructed with, so should
-          // not have called update listener
-          sinon.assert.notCalled(onUpdateSpy);
+
+        const result = await manager.onReady();
+        assert.include(result, {
+          success: true,
         });
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        // allow queued microtasks to run
+        await Promise.resolve();
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+
+        configWithFeatures.revision = '99';
+        mockDatafileManager.pushUpdate(JSON.stringify(configWithFeatures));
+        await Promise.resolve();
+
+        sinon.assert.callCount(onUpdateSpy, 2);
       });
     });
 

--- a/lib/core/project_config/project_config_manager.tests.js
+++ b/lib/core/project_config/project_config_manager.tests.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020, 2022, Optimizely
+ * Copyright 2019-2020, 2022, 2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/core/project_config/project_config_manager.ts
+++ b/lib/core/project_config/project_config_manager.ts
@@ -89,6 +89,7 @@ export class ProjectConfigManager {
       if (config.sdkKey && config.datafileManager) {
         this.datafileManager = config.datafileManager;
         this.datafileManager.start();
+
         this.readyPromise = this.datafileManager
           .onReady()
           .then(this.onDatafileManagerReadyFulfill.bind(this), this.onDatafileManagerReadyReject.bind(this));
@@ -188,7 +189,10 @@ export class ProjectConfigManager {
       if (configObj && oldRevision !== configObj.revision) {
         this.configObj = configObj;
         this.optimizelyConfigObj = null;
-        this.updateListeners.forEach(listener => listener(configObj));
+        
+        queueMicrotask(() => {
+          this.updateListeners.forEach(listener => listener(configObj));
+        });
       }
     }
 

--- a/lib/core/project_config/project_config_manager.ts
+++ b/lib/core/project_config/project_config_manager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2022, Optimizely
+ * Copyright 2019-2022, 2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -759,7 +759,7 @@ describe('javascript-sdk (Browser)', function() {
         };
 
         const client = optimizelyFactory.createInstance({
-          datafile: testData.getTestProjectConfigWithFeatures(),
+          datafile: testData.getOdpIntegratedConfigWithSegments(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
@@ -769,9 +769,10 @@ describe('javascript-sdk (Browser)', function() {
           },
         });
 
+        const readyData = await client.onReady();
+        
         sinon.assert.called(fakeSegmentManager.updateSettings);
 
-        const readyData = await client.onReady();
         assert.equal(readyData.success, true);
         assert.isUndefined(readyData.reason);
 
@@ -794,7 +795,7 @@ describe('javascript-sdk (Browser)', function() {
         };
 
         const client = optimizelyFactory.createInstance({
-          datafile: testData.getTestProjectConfigWithFeatures(),
+          datafile: testData.getOdpIntegratedConfigWithSegments(),
           errorHandler: fakeErrorHandler,
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
@@ -1143,7 +1144,7 @@ describe('javascript-sdk (Browser)', function() {
       });
 
       it('should send odp client_initialized on client instantiation', async () => {
-        const odpConfig = new OdpConfig();
+        const odpConfig = new OdpConfig('key', 'host', 'pixel', []);
         const apiManager = new BrowserOdpEventApiManager(mockRequestHandler, logger);
         sinon.spy(apiManager, 'sendEvents');
         const eventManager = new BrowserOdpEventManager({
@@ -1170,7 +1171,8 @@ describe('javascript-sdk (Browser)', function() {
 
         clock.tick(100);
 
-        const [events] = apiManager.sendEvents.getCall(0).args;
+        const [_, events] = apiManager.sendEvents.getCall(0).args;
+
         const [firstEvent] = events;
         assert.equal(firstEvent.action, 'client_initialized');
         assert.equal(firstEvent.type, 'fullstack');

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -639,7 +639,7 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
+          odpManager: BrowserOdpManager.createInstance({
             logger,
             odpOptions: {
               disabled: true,
@@ -657,7 +657,7 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
+          odpManager: BrowserOdpManager.createInstance({
             logger,
           }),
         });
@@ -689,7 +689,7 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
+          odpManager: BrowserOdpManager.createInstance({
             logger,
             odpOptions: {
               segmentsCacheSize: 10,
@@ -711,7 +711,7 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
-          odpManager: new BrowserOdpManager({
+          odpManager: BrowserOdpManager.createInstance({
             logger,
             odpOptions: {
               segmentsCacheTimeout: 10,

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -582,6 +582,7 @@ describe('javascript-sdk (Browser)', function() {
       var sandbox = sinon.sandbox.create();
 
       const fakeOptimizely = {
+        onReady: () => Promise.resolve({ success: true }),
         identifyUser: sinon.stub().returns(),
       };
 
@@ -621,11 +622,13 @@ describe('javascript-sdk (Browser)', function() {
         requestParams.clear();
       });
 
-      it('should send identify event by default when initialized', () => {
+      it('should send identify event by default when initialized', async () => {
         new OptimizelyUserContext({
           optimizely: fakeOptimizely,
           userId: testFsUserId,
         });
+
+        await fakeOptimizely.onReady();
 
         sinon.assert.calledOnce(fakeOptimizely.identifyUser);
 
@@ -639,6 +642,7 @@ describe('javascript-sdk (Browser)', function() {
           eventDispatcher: fakeEventDispatcher,
           eventBatchSize: null,
           logger,
+          odpOptions: { disabled: true },
           odpManager: BrowserOdpManager.createInstance({
             logger,
             odpOptions: {

--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -131,6 +131,8 @@ const createInstance = function(config: Config): Client | null {
       logger.info(enums.LOG_MESSAGES.ODP_DISABLED);
     }
 
+    const { clientEngine, clientVersion } = config;
+
     const optimizelyOptions: OptimizelyOptions = {
       clientEngine: enums.JAVASCRIPT_CLIENT_ENGINE,
       ...config,
@@ -142,7 +144,8 @@ const createInstance = function(config: Config): Client | null {
         : undefined,
       notificationCenter,
       isValidInstance,
-      odpManager: odpExplicitlyOff ? undefined : new BrowserOdpManager({ logger, odpOptions: config.odpOptions }),
+      odpManager: odpExplicitlyOff ? undefined
+        : BrowserOdpManager.createInstance({ logger, odpOptions: config.odpOptions, clientEngine, clientVersion }),
     };
 
     const optimizely = new Optimizely(optimizelyOptions);

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -107,6 +107,8 @@ const createInstance = function(config: Config): Client | null {
       logger.info(enums.LOG_MESSAGES.ODP_DISABLED);
     }
 
+    const { clientEngine, clientVersion } = config;
+
     const optimizelyOptions = {
       clientEngine: enums.NODE_CLIENT_ENGINE,
       ...config,
@@ -118,7 +120,8 @@ const createInstance = function(config: Config): Client | null {
         : undefined,
       notificationCenter,
       isValidInstance,
-      odpManager: odpExplicitlyOff ? undefined : new NodeOdpManager({ logger, odpOptions: config.odpOptions }),
+      odpManager: odpExplicitlyOff ? undefined
+        : NodeOdpManager.createInstance({ logger, odpOptions: config.odpOptions, clientEngine, clientVersion }),
     };
 
     return new Optimizely(optimizelyOptions);

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2017, 2019-2024 Optimizely, Inc. and contributors        *
+ * Copyright 2016-2017, 2019-2024 Optimizely, Inc. and contributors         *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/lib/index.react_native.ts
+++ b/lib/index.react_native.ts
@@ -103,6 +103,8 @@ const createInstance = function(config: Config): Client | null {
       logger.info(enums.LOG_MESSAGES.ODP_DISABLED);
     }
 
+    const { clientEngine, clientVersion } = config;
+
     const optimizelyOptions = {
       clientEngine: enums.REACT_NATIVE_JS_CLIENT_ENGINE,
       ...config,
@@ -120,7 +122,8 @@ const createInstance = function(config: Config): Client | null {
         : undefined,
       notificationCenter,
       isValidInstance: isValidInstance,
-      odpManager: odpExplicitlyOff ? undefined : new BrowserOdpManager({ logger, odpOptions: config.odpOptions }),
+      odpManager: odpExplicitlyOff ? undefined
+        :BrowserOdpManager.createInstance({ logger, odpOptions: config.odpOptions, clientEngine, clientVersion }),
     };
 
     // If client engine is react, convert it to react native.

--- a/lib/optimizely/index.tests.js
+++ b/lib/optimizely/index.tests.js
@@ -10144,29 +10144,6 @@ describe('lib/optimizely', function() {
       fns.uuid.restore();
     });
 
-    it('should call logger with log level of "info" when odp disabled', () => {
-      new Optimizely({
-        clientEngine: 'node-sdk',
-        datafile: testData.getTestProjectConfig(),
-        errorHandler: errorHandler,
-        eventDispatcher: eventDispatcher,
-        jsonSchemaValidator: jsonSchemaValidator,
-        logger: createdLogger,
-        isValidInstance: true,
-        eventBatchSize: 1,
-        eventProcessor,
-        notificationCenter,
-        odpManager: new NodeOdpManager({
-          logger: createdLogger,
-          odpOptions: {
-            disabled: true,
-          },
-        }),
-      });
-
-      sinon.assert.calledWith(createdLogger.log, LOG_LEVEL.INFO, LOG_MESSAGES.ODP_DISABLED);
-    });
-
     it('should send an identify event when called with odp enabled', () => {
       // TODO
     });

--- a/lib/optimizely/index.tests.js
+++ b/lib/optimizely/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2023, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2024, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -136,7 +136,6 @@ export default class Optimizely implements Client {
     });
 
     this.disposeOnUpdate = this.projectConfigManager.onUpdate((configObj: projectConfig.ProjectConfig) => {
-      console.log('config updated');
       this.logger.log(
         LOG_LEVEL.INFO,
         LOG_MESSAGES.UPDATED_OPTIMIZELY_CONFIG,
@@ -1443,7 +1442,7 @@ export default class Optimizely implements Client {
    *                                       null if provided inputs are invalid
    */
   createUserContext(userId?: string, attributes?: UserAttributes): OptimizelyUserContext | null {
-    let userIdentifier = userId ?? this.odpManager?.getVuid();
+    const userIdentifier = userId ?? this.odpManager?.getVuid();
 
     if (
       userIdentifier === undefined ||

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -110,6 +110,7 @@ export default class Optimizely implements Client {
     this.errorHandler = config.errorHandler;
     this.isOptimizelyConfigValid = config.isValidInstance;
     this.logger = config.logger;
+    this.odpManager = config.odpManager;
 
     let decideOptionsArray = config.defaultDecideOptions ?? [];
     if (!Array.isArray(decideOptionsArray)) {
@@ -135,6 +136,7 @@ export default class Optimizely implements Client {
     });
 
     this.disposeOnUpdate = this.projectConfigManager.onUpdate((configObj: projectConfig.ProjectConfig) => {
+      console.log('config updated');
       this.logger.log(
         LOG_LEVEL.INFO,
         LOG_MESSAGES.UPDATED_OPTIMIZELY_CONFIG,
@@ -1441,7 +1443,7 @@ export default class Optimizely implements Client {
    *                                       null if provided inputs are invalid
    */
   createUserContext(userId?: string, attributes?: UserAttributes): OptimizelyUserContext | null {
-    let userIdentifier = userId || this.odpManager?.getVuid();
+    let userIdentifier = userId ?? this.odpManager?.getVuid();
 
     if (
       userIdentifier === undefined ||

--- a/lib/optimizely_user_context/index.ts
+++ b/lib/optimizely_user_context/index.ts
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020-2023, Optimizely, Inc. and contributors                   *
+ * Copyright 2020-2024, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/lib/optimizely_user_context/index.ts
+++ b/lib/optimizely_user_context/index.ts
@@ -64,8 +64,10 @@ export default class OptimizelyUserContext implements IOptimizelyUserContext {
     this.forcedDecisionsMap = {};
 
     if (shouldIdentifyUser) {
-      this.optimizely.onReady().then(() => {
-        this.identifyUser();
+      this.optimizely.onReady().then(({ success }) => {
+        if (success) {
+          this.identifyUser();
+        }
       });
     }
   }

--- a/lib/optimizely_user_context/index.ts
+++ b/lib/optimizely_user_context/index.ts
@@ -64,7 +64,9 @@ export default class OptimizelyUserContext implements IOptimizelyUserContext {
     this.forcedDecisionsMap = {};
 
     if (shouldIdentifyUser) {
-      this.identifyUser();
+      this.optimizely.onReady().then(() => {
+        this.identifyUser();
+      });
     }
   }
 

--- a/lib/plugins/odp/event_api_manager/index.browser.ts
+++ b/lib/plugins/odp/event_api_manager/index.browser.ts
@@ -1,3 +1,19 @@
+/****************************************************************************
+ * Copyright 2024, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
 import { OdpEvent } from '../../../core/odp/odp_event';
 import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';
 import { LogLevel } from '../../../modules/logging';

--- a/lib/plugins/odp/event_api_manager/index.node.ts
+++ b/lib/plugins/odp/event_api_manager/index.node.ts
@@ -1,3 +1,19 @@
+/****************************************************************************
+ * Copyright 2024, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
 import { OdpConfig, OdpIntegrationConfig } from '../../../core/odp/odp_config';
 import { OdpEvent } from '../../../core/odp/odp_event';
 import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';

--- a/lib/plugins/odp/event_api_manager/index.node.ts
+++ b/lib/plugins/odp/event_api_manager/index.node.ts
@@ -1,23 +1,18 @@
+import { OdpConfig, OdpIntegrationConfig } from '../../../core/odp/odp_config';
 import { OdpEvent } from '../../../core/odp/odp_event';
 import { OdpEventApiManager } from '../../../core/odp/odp_event_api_manager';
 import { LogLevel } from '../../../modules/logging';
-import { ODP_CONFIG_NOT_READY_MESSAGE } from '../../../core/odp/odp_event_api_manager';
 export class NodeOdpEventApiManager extends OdpEventApiManager {
   protected shouldSendEvents(events: OdpEvent[]): boolean {
     return true;
   }
 
   protected generateRequestData(
+    odpConfig: OdpConfig,
     events: OdpEvent[]
   ): { method: string; endpoint: string; headers: { [key: string]: string }; data: string } {
-    // the caller should ensure odpConfig is ready before calling
-    if (!this.odpConfig?.isReady()) {
-      this.getLogger().log(LogLevel.ERROR, ODP_CONFIG_NOT_READY_MESSAGE);
-      throw new Error(ODP_CONFIG_NOT_READY_MESSAGE);
-    }
-    
-    const apiHost = this.odpConfig.apiHost;
-    const apiKey = this.odpConfig.apiKey;
+
+    const { apiHost, apiKey } = odpConfig;
     
     return {
       method: 'POST',

--- a/lib/plugins/odp_manager/index.browser.ts
+++ b/lib/plugins/odp_manager/index.browser.ts
@@ -40,6 +40,7 @@ import { BrowserOdpEventApiManager } from '../odp/event_api_manager/index.browse
 import { BrowserOdpEventManager } from '../odp/event_manager/index.browser';
 import { OdpSegmentManager } from '../../core/odp/odp_segment_manager';
 import { OdpSegmentApiManager } from '../../core/odp/odp_segment_api_manager';
+import { OdpConfig } from 'lib/core/odp/odp_config';
 
 interface BrowserOdpManagerConfig {
   logger?: LogHandler;
@@ -51,10 +52,100 @@ export class BrowserOdpManager extends OdpManager {
   static cache = new BrowserAsyncStorageCache();
   vuid?: string;
 
-  constructor({ logger, odpOptions }: BrowserOdpManagerConfig) {
-    super();
+  // constructor({ logger, odpOptions }: BrowserOdpManagerConfig) {
+  //   super();
 
-    this.logger = logger || getLogger();
+  //   this.logger = logger || getLogger();
+
+  //   if (odpOptions?.disabled) {
+  //     this.initPromise = Promise.resolve();
+  //     this.enabled = false;
+  //     this.logger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED);
+  //     return;
+  //   }
+
+  //   const browserClientEngine = JAVASCRIPT_CLIENT_ENGINE;
+  //   const browserClientVersion = CLIENT_VERSION;
+
+  //   let customSegmentRequestHandler;
+
+  //   if (odpOptions?.segmentsRequestHandler) {
+  //     customSegmentRequestHandler = odpOptions.segmentsRequestHandler;
+  //   } else {
+  //     customSegmentRequestHandler = new BrowserRequestHandler(
+  //       this.logger,
+  //       odpOptions?.segmentsApiTimeout || REQUEST_TIMEOUT_ODP_SEGMENTS_MS
+  //     );
+  //   }
+
+  //   // Set up Segment Manager (Audience Segments GraphQL API Interface)
+  //   if (odpOptions?.segmentManager) {
+  //     this.segmentManager = odpOptions.segmentManager;
+  //     this.segmentManager.updateSettings(this.odpConfig);
+  //   } else {
+  //     this.segmentManager = new OdpSegmentManager(
+  //       this.odpConfig,
+  //       odpOptions?.segmentsCache ||
+  //         new BrowserLRUCache<string, string[]>({
+  //           maxSize: odpOptions?.segmentsCacheSize,
+  //           timeout: odpOptions?.segmentsCacheTimeout,
+  //         }),
+  //       new OdpSegmentApiManager(customSegmentRequestHandler, this.logger)
+  //     );
+  //   }
+
+  //   let customEventRequestHandler;
+
+  //   if (odpOptions?.eventRequestHandler) {
+  //     customEventRequestHandler = odpOptions.eventRequestHandler;
+  //   } else {
+  //     customEventRequestHandler = new BrowserRequestHandler(
+  //       this.logger,
+  //       odpOptions?.eventApiTimeout || REQUEST_TIMEOUT_ODP_EVENTS_MS
+  //     );
+  //   }
+
+  //   // Set up Events Manager (Events REST API Interface)
+  //   if (odpOptions?.eventManager) {
+  //     this.eventManager = odpOptions.eventManager;
+  //     this.eventManager.updateSettings(this.odpConfig);
+  //   } else {
+  //     this.eventManager = new BrowserOdpEventManager({
+  //       odpConfig: this.odpConfig,
+  //       apiManager: new BrowserOdpEventApiManager(customEventRequestHandler, this.logger),
+  //       logger: this.logger,
+  //       clientEngine: browserClientEngine,
+  //       clientVersion: browserClientVersion,
+  //       flushInterval: odpOptions?.eventFlushInterval,
+  //       batchSize: odpOptions?.eventBatchSize,
+  //       queueSize: odpOptions?.eventQueueSize,
+  //       userAgentParser: odpOptions?.userAgentParser,
+  //     });
+  //   }
+
+  //   this.eventManager!.start();
+
+  //   this.initPromise = this.initializeVuid(BrowserOdpManager.cache).catch(e => {
+  //     this.logger.log(this.enabled ? LogLevel.ERROR : LogLevel.DEBUG, e);
+  //   });
+  // }
+
+  private constructor({
+    odpConfig,
+    vuidManager,
+    segmentManger,
+    eventManager,
+  }: {
+    odpConfig?: OdpConfig;
+    vuidManager: VuidManager;
+    segmentManger: OdpSegmentManager;
+    eventManager: BrowserOdpEventManager;
+  }) {
+    super();
+  }
+
+  static createInstance({ logger, odpOptions }: BrowserOdpManagerConfig): BrowserOdpManager {
+    logger = logger || getLogger();
 
     if (odpOptions?.disabled) {
       this.initPromise = Promise.resolve();

--- a/lib/plugins/odp_manager/index.browser.ts
+++ b/lib/plugins/odp_manager/index.browser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, Optimizely
+ * Copyright 2023-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/plugins/odp_manager/index.browser.ts
+++ b/lib/plugins/odp_manager/index.browser.ts
@@ -35,127 +35,48 @@ import { VuidManager } from './../vuid_manager/index';
 
 import { OdpManager } from '../../core/odp/odp_manager';
 import { OdpEvent } from '../../core/odp/odp_event';
-import { OdpOptions } from '../../shared_types';
+import { IOdpEventManager, OdpOptions } from '../../shared_types';
 import { BrowserOdpEventApiManager } from '../odp/event_api_manager/index.browser';
 import { BrowserOdpEventManager } from '../odp/event_manager/index.browser';
-import { OdpSegmentManager } from '../../core/odp/odp_segment_manager';
+import { IOdpSegmentManager, OdpSegmentManager } from '../../core/odp/odp_segment_manager';
 import { OdpSegmentApiManager } from '../../core/odp/odp_segment_api_manager';
-import { OdpConfig } from 'lib/core/odp/odp_config';
+import { OdpConfig, OdpIntegrationConfig } from '../../core/odp/odp_config';
 
 interface BrowserOdpManagerConfig {
+  clientEngine?: string,
+  clientVersion?: string,
   logger?: LogHandler;
   odpOptions?: OdpOptions;
+  odpIntegrationConfig?: OdpIntegrationConfig;
 }
 
 // Client-side Browser Plugin for ODP Manager
 export class BrowserOdpManager extends OdpManager {
   static cache = new BrowserAsyncStorageCache();
+  vuidManager?: VuidManager; 
   vuid?: string;
 
-  // constructor({ logger, odpOptions }: BrowserOdpManagerConfig) {
-  //   super();
-
-  //   this.logger = logger || getLogger();
-
-  //   if (odpOptions?.disabled) {
-  //     this.initPromise = Promise.resolve();
-  //     this.enabled = false;
-  //     this.logger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED);
-  //     return;
-  //   }
-
-  //   const browserClientEngine = JAVASCRIPT_CLIENT_ENGINE;
-  //   const browserClientVersion = CLIENT_VERSION;
-
-  //   let customSegmentRequestHandler;
-
-  //   if (odpOptions?.segmentsRequestHandler) {
-  //     customSegmentRequestHandler = odpOptions.segmentsRequestHandler;
-  //   } else {
-  //     customSegmentRequestHandler = new BrowserRequestHandler(
-  //       this.logger,
-  //       odpOptions?.segmentsApiTimeout || REQUEST_TIMEOUT_ODP_SEGMENTS_MS
-  //     );
-  //   }
-
-  //   // Set up Segment Manager (Audience Segments GraphQL API Interface)
-  //   if (odpOptions?.segmentManager) {
-  //     this.segmentManager = odpOptions.segmentManager;
-  //     this.segmentManager.updateSettings(this.odpConfig);
-  //   } else {
-  //     this.segmentManager = new OdpSegmentManager(
-  //       this.odpConfig,
-  //       odpOptions?.segmentsCache ||
-  //         new BrowserLRUCache<string, string[]>({
-  //           maxSize: odpOptions?.segmentsCacheSize,
-  //           timeout: odpOptions?.segmentsCacheTimeout,
-  //         }),
-  //       new OdpSegmentApiManager(customSegmentRequestHandler, this.logger)
-  //     );
-  //   }
-
-  //   let customEventRequestHandler;
-
-  //   if (odpOptions?.eventRequestHandler) {
-  //     customEventRequestHandler = odpOptions.eventRequestHandler;
-  //   } else {
-  //     customEventRequestHandler = new BrowserRequestHandler(
-  //       this.logger,
-  //       odpOptions?.eventApiTimeout || REQUEST_TIMEOUT_ODP_EVENTS_MS
-  //     );
-  //   }
-
-  //   // Set up Events Manager (Events REST API Interface)
-  //   if (odpOptions?.eventManager) {
-  //     this.eventManager = odpOptions.eventManager;
-  //     this.eventManager.updateSettings(this.odpConfig);
-  //   } else {
-  //     this.eventManager = new BrowserOdpEventManager({
-  //       odpConfig: this.odpConfig,
-  //       apiManager: new BrowserOdpEventApiManager(customEventRequestHandler, this.logger),
-  //       logger: this.logger,
-  //       clientEngine: browserClientEngine,
-  //       clientVersion: browserClientVersion,
-  //       flushInterval: odpOptions?.eventFlushInterval,
-  //       batchSize: odpOptions?.eventBatchSize,
-  //       queueSize: odpOptions?.eventQueueSize,
-  //       userAgentParser: odpOptions?.userAgentParser,
-  //     });
-  //   }
-
-  //   this.eventManager!.start();
-
-  //   this.initPromise = this.initializeVuid(BrowserOdpManager.cache).catch(e => {
-  //     this.logger.log(this.enabled ? LogLevel.ERROR : LogLevel.DEBUG, e);
-  //   });
-  // }
-
-  private constructor({
-    odpConfig,
-    vuidManager,
-    segmentManger,
-    eventManager,
-  }: {
-    odpConfig?: OdpConfig;
-    vuidManager: VuidManager;
-    segmentManger: OdpSegmentManager;
-    eventManager: BrowserOdpEventManager;
+  constructor(options: {
+    odpIntegrationConfig?: OdpIntegrationConfig;
+    segmentManager: IOdpSegmentManager;
+    eventManager: IOdpEventManager;
+    logger: LogHandler;
   }) {
-    super();
+    super(options);
   }
 
-  static createInstance({ logger, odpOptions }: BrowserOdpManagerConfig): BrowserOdpManager {
+  static createInstance({
+    logger, odpOptions, odpIntegrationConfig, clientEngine, clientVersion
+  }: BrowserOdpManagerConfig): BrowserOdpManager {
     logger = logger || getLogger();
 
-    if (odpOptions?.disabled) {
-      this.initPromise = Promise.resolve();
-      this.enabled = false;
-      this.logger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED);
-      return;
-    }
+    clientEngine = clientEngine || JAVASCRIPT_CLIENT_ENGINE;
+    clientVersion = clientVersion || CLIENT_VERSION;
 
-    const browserClientEngine = JAVASCRIPT_CLIENT_ENGINE;
-    const browserClientVersion = CLIENT_VERSION;
+    let odpConfig : OdpConfig | undefined = undefined;
+    if (odpIntegrationConfig?.integrated) {
+      odpConfig = odpIntegrationConfig.odpConfig;
+    }
 
     let customSegmentRequestHandler;
 
@@ -163,24 +84,25 @@ export class BrowserOdpManager extends OdpManager {
       customSegmentRequestHandler = odpOptions.segmentsRequestHandler;
     } else {
       customSegmentRequestHandler = new BrowserRequestHandler(
-        this.logger,
+        logger,
         odpOptions?.segmentsApiTimeout || REQUEST_TIMEOUT_ODP_SEGMENTS_MS
       );
     }
 
-    // Set up Segment Manager (Audience Segments GraphQL API Interface)
+    let segmentManager: IOdpSegmentManager;
+
     if (odpOptions?.segmentManager) {
-      this.segmentManager = odpOptions.segmentManager;
-      this.segmentManager.updateSettings(this.odpConfig);
+      segmentManager = odpOptions.segmentManager;
     } else {
-      this.segmentManager = new OdpSegmentManager(
-        this.odpConfig,
+      segmentManager = new OdpSegmentManager(
         odpOptions?.segmentsCache ||
           new BrowserLRUCache<string, string[]>({
             maxSize: odpOptions?.segmentsCacheSize,
             timeout: odpOptions?.segmentsCacheTimeout,
           }),
-        new OdpSegmentApiManager(customSegmentRequestHandler, this.logger)
+        new OdpSegmentApiManager(customSegmentRequestHandler, logger),
+        logger,
+        odpConfig
       );
     }
 
@@ -190,22 +112,22 @@ export class BrowserOdpManager extends OdpManager {
       customEventRequestHandler = odpOptions.eventRequestHandler;
     } else {
       customEventRequestHandler = new BrowserRequestHandler(
-        this.logger,
+        logger,
         odpOptions?.eventApiTimeout || REQUEST_TIMEOUT_ODP_EVENTS_MS
       );
     }
 
-    // Set up Events Manager (Events REST API Interface)
+    let eventManager: IOdpEventManager;
+
     if (odpOptions?.eventManager) {
-      this.eventManager = odpOptions.eventManager;
-      this.eventManager.updateSettings(this.odpConfig);
+      eventManager = odpOptions.eventManager;
     } else {
-      this.eventManager = new BrowserOdpEventManager({
-        odpConfig: this.odpConfig,
-        apiManager: new BrowserOdpEventApiManager(customEventRequestHandler, this.logger),
-        logger: this.logger,
-        clientEngine: browserClientEngine,
-        clientVersion: browserClientVersion,
+      eventManager = new BrowserOdpEventManager({
+        odpConfig,
+        apiManager: new BrowserOdpEventApiManager(customEventRequestHandler, logger),
+        logger: logger,
+        clientEngine,
+        clientVersion,
         flushInterval: odpOptions?.eventFlushInterval,
         batchSize: odpOptions?.eventBatchSize,
         queueSize: odpOptions?.eventQueueSize,
@@ -213,34 +135,21 @@ export class BrowserOdpManager extends OdpManager {
       });
     }
 
-    this.eventManager!.start();
-
-    this.initPromise = this.initializeVuid(BrowserOdpManager.cache).catch(e => {
-      this.logger.log(this.enabled ? LogLevel.ERROR : LogLevel.DEBUG, e);
+    return new BrowserOdpManager({
+      odpIntegrationConfig,
+      segmentManager,
+      eventManager,
+      logger,
     });
   }
 
   /**
-   * Upon initializing BrowserOdpManager, accesses or creates new VUID from Browser cache and registers it via the Event Manager
-   * @private
+   * @override
+   * accesses or creates new VUID from Browser cache and registers it via the Event Manager
    */
-  private async initializeVuid(cache: PersistentKeyValueCache): Promise<void> {
-    const vuidManager = await VuidManager.instance(cache);
+  protected async initializeVuid(): Promise<void> {
+    const vuidManager = await VuidManager.instance(BrowserOdpManager.cache);
     this.vuid = vuidManager.vuid;
-    this.registerVuid(this.vuid);
-  }
-
-  private registerVuid(vuid: string) {
-    if (!this.eventManager) {
-      this.logger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_VUID_REGISTRATION_FAILED_EVENT_MANAGER_MISSING);
-      return;
-    }
-
-    try {
-      this.eventManager.registerVuid(vuid);
-    } catch (e) {
-      this.logger.log(this.enabled ? LogLevel.ERROR : LogLevel.DEBUG, ERROR_MESSAGES.ODP_VUID_REGISTRATION_FAILED);
-    }
   }
 
   /**

--- a/lib/plugins/odp_manager/index.browser.ts
+++ b/lib/plugins/odp_manager/index.browser.ts
@@ -145,7 +145,7 @@ export class BrowserOdpManager extends OdpManager {
 
   /**
    * @override
-   * accesses or creates new VUID from Browser cache and registers it via the Event Manager
+   * accesses or creates new VUID from Browser cache
    */
   protected async initializeVuid(): Promise<void> {
     const vuidManager = await VuidManager.instance(BrowserOdpManager.cache);

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -37,6 +37,7 @@ import { IOdpEventManager } from './core/odp/odp_event_manager';
 import { IOdpManager } from './core/odp/odp_manager';
 import { IUserAgentParser } from './core/odp/user_agent_parser';
 import PersistentCache from './plugins/key_value_cache/persistentKeyValueCache';
+import { ProjectConfig } from './core/project_config';
 
 export interface BucketerParams {
   experimentId: string;
@@ -369,6 +370,7 @@ export interface Client {
   onReady(options?: { timeout?: number }): Promise<{ success: boolean; reason?: string }>;
   close(): Promise<{ success: boolean; reason?: string }>;
   sendOdpEvent(action: string, type?: string, identifiers?: Map<string, string>, data?: Map<string, unknown>): void;
+  getProjectConfig(): ProjectConfig | null;
 }
 
 export interface ActivateListenerPayload extends ListenerPayload {

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -31,7 +31,6 @@ export const ERROR_MESSAGES = {
   DATAFILE_AND_SDK_KEY_MISSING: '%s: You must provide at least one of sdkKey or datafile. Cannot start Optimizely',
   EXPERIMENT_KEY_NOT_IN_DATAFILE: '%s: Experiment key %s is not in datafile.',
   FEATURE_NOT_IN_DATAFILE: '%s: Feature key %s is not in datafile.',
-  FETCH_SEGMENTS_FAILED_INVALID_IDENTIFIER: '%s: Audience segments fetch failed. (invalid identifier)',
   FETCH_SEGMENTS_FAILED_NETWORK_ERROR: '%s: Audience segments fetch failed. (network error)',
   FETCH_SEGMENTS_FAILED_DECODE_ERROR: '%s: Audience segments fetch failed. (decode error)',
   IMPROPERLY_FORMATTED_EXPERIMENT: '%s: Experiment key %s is improperly formatted.',
@@ -56,6 +55,7 @@ export const ERROR_MESSAGES = {
   NO_DATAFILE_SPECIFIED: '%s: No datafile specified. Cannot start optimizely.',
   NO_JSON_PROVIDED: '%s: No JSON object to validate against schema.',
   NO_VARIATION_FOR_EXPERIMENT_KEY: '%s: No variation key %s defined in datafile for experiment %s.',
+  ODP_CONFIG_NOT_AVAILABLE: '%s: ODP is not integrated to the project.',
   ODP_EVENT_FAILED: 'ODP event send failed.',
   ODP_FETCH_QUALIFIED_SEGMENTS_SEGMENTS_MANAGER_MISSING:
     '%s: ODP unable to fetch qualified segments (Segments Manager not initialized).',
@@ -79,8 +79,6 @@ export const ERROR_MESSAGES = {
     '%s: ODP send event %s was not dispatched (Event Manager not instantiated).',
   ODP_SEND_EVENT_FAILED_UID_MISSING: '%s: ODP send event %s was not dispatched (No valid user identifier provided).',
   ODP_SEND_EVENT_FAILED_VUID_MISSING: '%s: ODP send event %s was not dispatched (Unable to fetch VUID).',
-  ODP_SDK_KEY_MISSING_NOTIFICATION_CENTER_FAILURE:
-    '%s: You must provide an sdkKey. Cannot start Notification Center for ODP Integration.',
   ODP_VUID_INITIALIZATION_FAILED: '%s: ODP VUID initialization failed.',
   ODP_VUID_REGISTRATION_FAILED: '%s: ODP VUID failed to be registered.',
   ODP_VUID_REGISTRATION_FAILED_EVENT_MANAGER_MISSING: '%s: ODP register vuid failed. (Event Manager not instantiated).',

--- a/lib/utils/promise/resolvablePromise.ts
+++ b/lib/utils/promise/resolvablePromise.ts
@@ -1,0 +1,18 @@
+const noop = () => {};
+
+export type ResolvablePromise<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+  then: Promise<T>['then'];
+};
+
+export function resolvablePromise<T>(): ResolvablePromise<T> {
+  let resolve: (value: T | PromiseLike<T>) => void = noop;
+  let reject: (reason?: any) => void = noop;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject, then: promise.then.bind(promise) };
+}

--- a/lib/utils/promise/resolvablePromise.ts
+++ b/lib/utils/promise/resolvablePromise.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const noop = () => {};
 
 export type ResolvablePromise<T> = {

--- a/tests/odpEventApiManager.spec.ts
+++ b/tests/odpEventApiManager.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/odpEventManager.spec.ts
+++ b/tests/odpEventManager.spec.ts
@@ -313,6 +313,28 @@ describe('OdpEventManager', () => {
       mockLogger.log(LogLevel.WARNING, 'Failed to Process ODP Event. Event Queue full. queueSize = %s.', 1)
     ).once();
   });
+  
+  it('should log a max queue hit and discard ', () => {
+    // set queue to maximum of 1
+    const eventManager = new OdpEventManager({
+      odpConfig,
+      apiManager,
+      logger,
+      clientEngine,
+      clientVersion,
+      queueSize: 1, // With max queue size set to 1...
+    });
+
+    eventManager.start();
+
+    eventManager['queue'].push(EVENTS[0]); // simulate 1 event already in the queue then...
+    // ...try adding the second event
+    eventManager.sendEvent(EVENTS[1]);
+
+    verify(
+      mockLogger.log(LogLevel.WARNING, 'Failed to Process ODP Event. Event Queue full. queueSize = %s.', 1)
+    ).once();
+  });
 
   it('should add additional information to each event', () => {
     const eventManager = new OdpEventManager({

--- a/tests/odpEventManager.spec.ts
+++ b/tests/odpEventManager.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/odpEventManager.spec.ts
+++ b/tests/odpEventManager.spec.ts
@@ -25,6 +25,7 @@ import { LogHandler, LogLevel } from '../lib/modules/logging';
 import { OdpEvent } from '../lib/core/odp/odp_event';
 import { IUserAgentParser } from '../lib/core/odp/user_agent_parser';
 import { UserAgentInfo } from '../lib/core/odp/user_agent_info';
+import exp from 'constants';
 
 const API_KEY = 'test-api-key';
 const API_HOST = 'https://odp.example.com';
@@ -157,73 +158,6 @@ describe('OdpEventManager', () => {
     resetCalls(mockApiManager);
   });
 
-  it('should update api manager setting with odp config on instantiation', () => {
-    when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
-
-    const apiManager = instance(mockApiManager);
-
-    const eventManager = new OdpEventManager({
-      odpConfig,
-      apiManager,
-      logger,
-      clientEngine,
-      clientVersion,
-    });
-
-    console.log(capture(mockApiManager.updateSettings));
-
-    verify(mockApiManager.updateSettings(anything())).once();
-    const [passedConfig] = capture(mockApiManager.updateSettings).last();
-    expect(passedConfig.equals(odpConfig)).toBeTruthy();
-  });
-
-  it('should update api manager setting with updatetd odp config on updateSettings', () => {
-    when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
-
-    const apiManager = instance(mockApiManager);
-
-    const eventManager = new OdpEventManager({
-      odpConfig,
-      apiManager,
-      logger,
-      clientEngine,
-      clientVersion,
-    });
-
-    const updatedOdpConfig = new OdpConfig(
-      'updated-key',
-      'https://updatedhost.test',
-      'https://pixel.test',
-      ['updated-seg'],
-    )
-
-    eventManager.updateSettings(updatedOdpConfig);
-
-    verify(mockApiManager.updateSettings(anything())).twice();
-
-    const [initConfig] = capture(mockApiManager.updateSettings).first();
-    expect(initConfig).toEqual(odpConfig);
-
-    const [finalConfig] = capture(mockApiManager.updateSettings).last();
-    expect(finalConfig).toEqual(updatedOdpConfig);
-  });
-
-  it.only('should log and discard events when event manager not running', () => {
-    const eventManager = new OdpEventManager({
-      odpConfig,
-      apiManager,
-      logger,
-      clientEngine,
-      clientVersion,
-    });
-    // since we've not called start() then...
-
-    eventManager.sendEvent(EVENTS[0]);
-
-    // ...we should get a notice after trying to send an event
-    verify(mockLogger.log(LogLevel.WARNING, 'Failed to Process ODP Event. ODPEventManager is not running.')).once();
-  });
-
   it('should log an error and not start if start() is called without a config', () => {
     const eventManager = new OdpEventManager({
       odpConfig: undefined,
@@ -238,7 +172,7 @@ describe('OdpEventManager', () => {
     expect(eventManager.status).toEqual(Status.Stopped);
   });
 
-  it.only('should start() correctly after odpConfig is provided', () => {
+  it('should start() correctly after odpConfig is provided', () => {
     const eventManager = new OdpEventManager({
       odpConfig,
       apiManager,
@@ -253,7 +187,7 @@ describe('OdpEventManager', () => {
     expect(eventManager.status).toEqual(Status.Running);
   });
 
-  it.only('should log and discard events when event manager is not running', () => {
+  it('should log and discard events when event manager is not running', () => {
     const eventManager = new OdpEventManager({
       odpConfig,
       apiManager,
@@ -265,10 +199,10 @@ describe('OdpEventManager', () => {
     expect(eventManager.status).toEqual(Status.Stopped);
     eventManager.sendEvent(EVENTS[0]);
     verify(mockLogger.log(LogLevel.WARNING, 'Failed to Process ODP Event. ODPEventManager is not running.')).once();
-    expect(eventManager.getQueue.length).toEqual(0);
+    expect(eventManager.getQueue().length).toEqual(0);
   });
 
-  it.only('should discard events with invalid data', () => {
+  it('should discard events with invalid data', () => {
     const eventManager = new OdpEventManager({
       odpConfig,
       apiManager,
@@ -276,6 +210,10 @@ describe('OdpEventManager', () => {
       clientEngine,
       clientVersion,
     });
+    eventManager.start();
+
+    expect(eventManager.status).toEqual(Status.Running);
+
     // make an event with invalid data key-value entry
     const badEvent = new OdpEvent(
       't3',
@@ -289,31 +227,9 @@ describe('OdpEventManager', () => {
     eventManager.sendEvent(badEvent);
 
     verify(mockLogger.log(LogLevel.ERROR, 'Event data found to be invalid.')).once();
-    expect(eventManager.getQueue.length).toEqual(0);
+    expect(eventManager.getQueue().length).toEqual(0);
   });
 
-  it('should log a max queue hit and discard ', () => {
-    // set queue to maximum of 1
-    const eventManager = new OdpEventManager({
-      odpConfig,
-      apiManager,
-      logger,
-      clientEngine,
-      clientVersion,
-      queueSize: 1, // With max queue size set to 1...
-    });
-
-    eventManager.start();
-
-    eventManager['queue'].push(EVENTS[0]); // simulate 1 event already in the queue then...
-    // ...try adding the second event
-    eventManager.sendEvent(EVENTS[1]);
-
-    verify(
-      mockLogger.log(LogLevel.WARNING, 'Failed to Process ODP Event. Event Queue full. queueSize = %s.', 1)
-    ).once();
-  });
-  
   it('should log a max queue hit and discard ', () => {
     // set queue to maximum of 1
     const eventManager = new OdpEventManager({
@@ -344,6 +260,8 @@ describe('OdpEventManager', () => {
       clientEngine,
       clientVersion,
     });
+    eventManager.start();
+
     const processedEventData = PROCESSED_EVENTS[0].data;
 
     const eventData = eventManager['augmentCommonData'](EVENTS[0].data);
@@ -369,17 +287,19 @@ describe('OdpEventManager', () => {
       clientVersion,
       flushInterval: 100,
     });
+
     const spiedEventManager = spy(eventManager);
 
     eventManager.start();
     // do not add events to the queue, but allow for...
-    await pause(400); // at least 3 flush intervals executions (giving a little longer)
+    jest.advanceTimersByTime(350); // 3 flush intervals executions (giving a little longer)
 
     verify(spiedEventManager['processQueue'](anything())).atLeast(3);
   });
 
-  it('should dispatch events in correct number of batches', async () => {
-    when(mockApiManager.sendEvents(anything())).thenResolve(false);
+  it('should dispatch events in correct batch sizes', async () => {
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
+
     const apiManager = instance(mockApiManager);
     const eventManager = new OdpEventManager({
       odpConfig,
@@ -392,14 +312,20 @@ describe('OdpEventManager', () => {
     });
 
     eventManager.start();
+
     for (let i = 0; i < 25; i += 1) {
       eventManager.sendEvent(makeEvent(i));
     }
-    await pause(1500);
 
+    jest.runAllTicks();
+    // as we are not advancing the jest fake timers, no flush should occur
     // ...there should be 3 batches:
     // batch #1 with 10, batch #2 with 10, and batch #3 (after flushInterval lapsed) with 5 = 25 events
-    verify(mockApiManager.sendEvents(anything())).thrice();
+    verify(mockApiManager.sendEvents(anything(), anything())).twice();
+
+    // rest of the events should now be flushed
+    jest.advanceTimersByTime(250);
+    verify(mockApiManager.sendEvents(anything(), anything())).thrice();
   });
 
   it('should dispatch events with correct payload', async () => {
@@ -415,16 +341,38 @@ describe('OdpEventManager', () => {
 
     eventManager.start();
     EVENTS.forEach(event => eventManager.sendEvent(event));
-    await pause(1000);
 
+    jest.advanceTimersByTime(100);
     // sending 1 batch of 2 events after flushInterval since batchSize is 10
-    verify(mockApiManager.sendEvents(anything())).once();
-    const [events] = capture(mockApiManager.sendEvents).last();
+    verify(mockApiManager.sendEvents(anything(), anything())).once();
+    const [_, events] = capture(mockApiManager.sendEvents).last();
     expect(events.length).toEqual(2);
     expect(events[0].identifiers.size).toEqual(PROCESSED_EVENTS[0].identifiers.size);
     expect(events[0].data.size).toEqual(PROCESSED_EVENTS[0].data.size);
     expect(events[1].identifiers.size).toEqual(PROCESSED_EVENTS[1].identifiers.size);
     expect(events[1].data.size).toEqual(PROCESSED_EVENTS[1].data.size);
+  });
+
+  it('should dispatch events with correct odpConfig', async () => {
+    const eventManager = new OdpEventManager({
+      odpConfig,
+      apiManager,
+      logger,
+      clientEngine,
+      clientVersion,
+      batchSize: 10,
+      flushInterval: 100,
+    });
+
+    eventManager.start();
+    EVENTS.forEach(event => eventManager.sendEvent(event));
+
+    jest.advanceTimersByTime(100);
+
+    // sending 1 batch of 2 events after flushInterval since batchSize is 10
+    verify(mockApiManager.sendEvents(anything(), anything())).once();
+    const [usedOdpConfig] = capture(mockApiManager.sendEvents).last();
+    expect(usedOdpConfig.equals(odpConfig)).toBeTruthy();
   });
 
   it('should augment events with data from user agent parser', async () => {
@@ -450,10 +398,10 @@ describe('OdpEventManager', () => {
 
     eventManager.start();
     EVENTS.forEach(event => eventManager.sendEvent(event));
-    await pause(1000);
+    jest.advanceTimersByTime(100);
 
-    verify(mockApiManager.sendEvents(anything())).called();
-    const [events] = capture(mockApiManager.sendEvents).last();
+    verify(mockApiManager.sendEvents(anything(), anything())).called();
+    const [_, events] = capture(mockApiManager.sendEvents).last();
     const event = events[0];
 
     expect(event.data.get('os')).toEqual('windows');
@@ -463,8 +411,9 @@ describe('OdpEventManager', () => {
   });
 
   it('should retry failed events', async () => {
-    // all events should fail ie shouldRetry = true
-    when(mockApiManager.sendEvents(anything())).thenResolve(true);
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(true)
+
+    const retries = 3;
     const apiManager = instance(mockApiManager);
     const eventManager = new OdpEventManager({
       odpConfig,
@@ -472,23 +421,27 @@ describe('OdpEventManager', () => {
       logger,
       clientEngine,
       clientVersion,
-      batchSize: 2, // batch size of 2
+      batchSize: 2, 
       flushInterval: 100,
+      retries,
     });
 
     eventManager.start();
-    // send 4 events
     for (let i = 0; i < 4; i += 1) {
       eventManager.sendEvent(makeEvent(i));
     }
-    await pause(1500);
 
-    // retry 3x (default) for 2 batches or 6 calls to attempt to process
-    verify(mockApiManager.sendEvents(anything())).times(6);
+    jest.runAllTicks();
+    jest.useRealTimers();
+    await pause(100);
+
+    // retry 3x for 2 batches or 6 calls to attempt to process
+    verify(mockApiManager.sendEvents(anything(), anything())).times(6);
   });
 
-  it('should flush all scheduled events before stopping', async () => {
-    when(mockApiManager.sendEvents(anything())).thenResolve(false);
+  it('should flush all queued events when flush() is called', async () => {
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
+  
     const apiManager = instance(mockApiManager);
     const eventManager = new OdpEventManager({
       odpConfig,
@@ -496,25 +449,133 @@ describe('OdpEventManager', () => {
       logger,
       clientEngine,
       clientVersion,
-      batchSize: 2, // batches of 2 with...
+      batchSize: 200, 
       flushInterval: 100,
     });
 
     eventManager.start();
-    // ...25 events should...
     for (let i = 0; i < 25; i += 1) {
       eventManager.sendEvent(makeEvent(i));
     }
-    await pause(300);
-    await eventManager.stop();
 
-    verify(mockLogger.log(LogLevel.DEBUG, 'Stop requested.')).once();
-    verify(mockLogger.log(LogLevel.DEBUG, 'Stopped. Queue Count: %s', 0)).once();
+    expect(eventManager.getQueue().length).toEqual(25);
+
+    eventManager.flush();
+  
+    jest.runAllTicks();
+
+    verify(mockApiManager.sendEvents(anything(), anything())).once();
+    expect(eventManager.getQueue().length).toEqual(0);
+  });
+
+  it('should flush all queued events before stopping', async () => {
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
+    const apiManager = instance(mockApiManager);
+    const eventManager = new OdpEventManager({
+      odpConfig,
+      apiManager,
+      logger,
+      clientEngine,
+      clientVersion,
+      batchSize: 200,
+      flushInterval: 100,
+    });
+
+    eventManager.start();
+    for (let i = 0; i < 25; i += 1) {
+      eventManager.sendEvent(makeEvent(i));
+    }
+
+    expect(eventManager.getQueue().length).toEqual(25);
+
+    eventManager.flush();
+  
+    jest.runAllTicks();
+
+    verify(mockApiManager.sendEvents(anything(), anything())).once();
+    expect(eventManager.getQueue().length).toEqual(0);
+  });
+
+  it('should flush all queued events using the old odpConfig when updateSettings is called()', async () => {
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
+
+    const odpConfig = new OdpConfig('old-key', 'old-host', 'https://new-odp.pixel.com', []);
+    const updatedConfig = new OdpConfig('new-key', 'new-host', 'https://new-odp.pixel.com', []);
+
+    const apiManager = instance(mockApiManager);
+    const eventManager = new OdpEventManager({
+      odpConfig,
+      apiManager,
+      logger,
+      clientEngine,
+      clientVersion,
+      batchSize: 200,
+      flushInterval: 100,
+    });
+
+    eventManager.start();
+    for (let i = 0; i < 25; i += 1) {
+      eventManager.sendEvent(makeEvent(i));
+    }
+
+    expect(eventManager.getQueue().length).toEqual(25);
+
+    eventManager.updateSettings(updatedConfig);
+  
+    jest.runAllTicks();
+
+    verify(mockApiManager.sendEvents(anything(), anything())).once();
+    expect(eventManager.getQueue().length).toEqual(0);
+    const [usedOdpConfig] = capture(mockApiManager.sendEvents).last();
+    expect(usedOdpConfig.equals(odpConfig)).toBeTruthy();
+  });
+
+  it('should use updated odpConfig to send events', async () => {
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
+
+    const odpConfig = new OdpConfig('old-key', 'old-host', 'https://new-odp.pixel.com', []);
+    const updatedConfig = new OdpConfig('new-key', 'new-host', 'https://new-odp.pixel.com', []);
+
+    const apiManager = instance(mockApiManager);
+    const eventManager = new OdpEventManager({
+      odpConfig,
+      apiManager,
+      logger,
+      clientEngine,
+      clientVersion,
+      batchSize: 200,
+      flushInterval: 100,
+    });
+
+    eventManager.start();
+    for (let i = 0; i < 25; i += 1) {
+      eventManager.sendEvent(makeEvent(i));
+    }
+
+    expect(eventManager.getQueue().length).toEqual(25);
+  
+    jest.advanceTimersByTime(100);
+
+    expect(eventManager.getQueue().length).toEqual(0);
+    let [usedOdpConfig] = capture(mockApiManager.sendEvents).first();
+    expect(usedOdpConfig.equals(odpConfig)).toBeTruthy();
+
+    eventManager.updateSettings(updatedConfig);
+    jest.runAllTicks();
+
+
+    for (let i = 0; i < 25; i += 1) {
+      eventManager.sendEvent(makeEvent(i));
+    }
+    jest.advanceTimersByTime(100);
+
+    expect(eventManager.getQueue().length).toEqual(0);
+    ([usedOdpConfig] = capture(mockApiManager.sendEvents).last());
+    expect(usedOdpConfig.equals(updatedConfig)).toBeTruthy();
   });
 
   it('should prepare correct payload for register VUID', async () => {
-    when(mockApiManager.sendEvents(anything())).thenResolve(false);
-    when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
 
     const apiManager = instance(mockApiManager);
 
@@ -533,9 +594,10 @@ describe('OdpEventManager', () => {
 
     eventManager.start();
     eventManager.registerVuid(vuid);
-    await pause(1500);
 
-    const [events] = capture(mockApiManager.sendEvents).last();
+    jest.advanceTimersByTime(250);
+
+    const [_, events] = capture(mockApiManager.sendEvents).last();
     expect(events.length).toBe(1);
 
     const [event] = events;
@@ -549,8 +611,7 @@ describe('OdpEventManager', () => {
   });
 
   it('should send correct event payload for identify user', async () => {
-    when(mockApiManager.sendEvents(anything())).thenResolve(false);
-    when(mockApiManager.updateSettings(anything())).thenReturn(undefined);
+    when(mockApiManager.sendEvents(anything(), anything())).thenResolve(false);
 
     const apiManager = instance(mockApiManager);
 
@@ -569,9 +630,10 @@ describe('OdpEventManager', () => {
 
     eventManager.start();
     eventManager.identifyUser(fsUserId, vuid);
-    await pause(1500);
 
-    const [events] = capture(mockApiManager.sendEvents).last();
+    jest.advanceTimersByTime(250);
+
+    const [_, events] = capture(mockApiManager.sendEvents).last();
     expect(events.length).toBe(1);
 
     const [event] = events;
@@ -598,6 +660,8 @@ describe('OdpEventManager', () => {
     eventManager.sendEvent(EVENT_WITH_UNDEFINED_IDENTIFIER);
     eventManager.stop();
 
+    jest.runAllTicks();
+
     verify(mockLogger.log(LogLevel.ERROR, 'ODP events should have at least one key-value pair in identifiers.')).twice();
   });
 
@@ -614,6 +678,8 @@ describe('OdpEventManager', () => {
     eventManager.sendEvent(EVENT_WITH_EMPTY_IDENTIFIER);
     eventManager.sendEvent(EVENT_WITH_UNDEFINED_IDENTIFIER);
     eventManager.stop();
+
+    jest.runAllTicks();
 
     verify(mockLogger.log(LogLevel.ERROR, 'ODP events should have at least one key-value pair in identifiers.')).never();
   });

--- a/tests/odpManager.browser.spec.ts
+++ b/tests/odpManager.browser.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, Optimizely
+ * Copyright 2023-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/odpManager.browser.spec.ts
+++ b/tests/odpManager.browser.spec.ts
@@ -27,7 +27,6 @@ import { BrowserOdpManager } from './../lib/plugins/odp_manager/index.browser';
 import { IOdpEventManager, OdpOptions } from './../lib/shared_types';
 import { OdpConfig } from '../lib/core/odp/odp_config';
 import { BrowserOdpEventApiManager } from '../lib/plugins/odp/event_api_manager/index.browser';
-import { BrowserOdpEventManager } from '../lib/plugins/odp/event_manager/index.browser';
 import { OdpSegmentManager } from './../lib/core/odp/odp_segment_manager';
 import { OdpSegmentApiManager } from '../lib/core/odp/odp_segment_api_manager';
 import { VuidManager } from '../lib/plugins/vuid_manager';
@@ -35,6 +34,9 @@ import { BrowserRequestHandler } from '../lib/utils/http_request_handler/browser
 import { IUserAgentParser } from '../lib/core/odp/user_agent_parser';
 import { UserAgentInfo } from '../lib/core/odp/user_agent_info';
 import { OdpEvent } from '../lib/core/odp/odp_event';
+import { LRUCache } from '../lib/utils/lru_cache';
+import { BrowserOdpEventManager } from '../lib/plugins/odp/event_manager/index.browser';
+import { OdpManager } from '../lib/core/odp/odp_manager';
 
 const keyA = 'key-a';
 const hostA = 'host-a';
@@ -80,7 +82,7 @@ describe('OdpManager', () => {
     mockLogger = mock<LogHandler>();
     mockRequestHandler = mock<RequestHandler>();
 
-    odpConfig = new OdpConfig();
+    odpConfig = new OdpConfig(keyA, hostA, pixelA, segmentsA);
     fakeLogger = instance(mockLogger);
     fakeRequestHandler = instance(mockRequestHandler);
 
@@ -106,181 +108,22 @@ describe('OdpManager', () => {
   });
 
   const browserOdpManagerInstance = () =>
-    new BrowserOdpManager({
+    BrowserOdpManager.createInstance({
       odpOptions: {
         eventManager: fakeEventManager,
         segmentManager: fakeSegmentManager,
       },
     });
 
-  it('should register VUID automatically on BrowserOdpManager initialization', async () => {
+  it('should create VUID automatically on BrowserOdpManager initialization', async () => {
     const browserOdpManager = browserOdpManagerInstance();
     const vuidManager = await VuidManager.instance(BrowserOdpManager.cache);
     expect(browserOdpManager.vuid).toBe(vuidManager.vuid);
   });
 
-  it('should drop relevant calls when OdpManager is initialized with the disabled flag, except for VUID', async () => {
-    const browserOdpManager = new BrowserOdpManager({ logger: fakeLogger, odpOptions: { disabled: true } });
-
-    verify(mockLogger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED)).once();
-
-    browserOdpManager.updateSettings(new OdpConfig('valid', 'host', 'pixel-url', []));
-    expect(browserOdpManager.odpConfig).toBeUndefined;
-
-    await browserOdpManager.fetchQualifiedSegments('vuid_user1', []);
-    verify(mockLogger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_ENABLED)).once();
-
-    await browserOdpManager.identifyUser('vuid_user1');
-    verify(mockLogger.log(LogLevel.DEBUG, LOG_MESSAGES.ODP_IDENTIFY_FAILED_ODP_DISABLED)).once();
-
-    expect(browserOdpManager.eventManager).toBeUndefined;
-    expect(browserOdpManager.segmentManager).toBeUndefined;
-
-    const vuidManager = await VuidManager.instance(BrowserOdpManager.cache);
-    expect(vuidManager.vuid.slice(0, 5)).toBe('vuid_');
-  });
-
-  it('should start ODP Event Manager when ODP Manager is initialized', () => {
-    const browserOdpManager = browserOdpManagerInstance();
-    verify(mockEventManager.start()).once();
-    expect(browserOdpManager.eventManager).not.toBeUndefined();
-  });
-
-  it('should stop ODP Event Manager when close is called', () => {
-    const browserOdpManager = browserOdpManagerInstance();
-    verify(mockEventManager.stop()).never();
-
-    browserOdpManager.close();
-    verify(mockEventManager.stop()).once();
-  });
-
-  it('should use new settings in event manager when ODP Config is updated', async () => {
-    const browserOdpManager = new BrowserOdpManager({
-      odpOptions: {
-        eventManager: fakeEventManager,
-      },
-    });
-
-    expect(browserOdpManager.eventManager).toBeDefined();
-    verify(mockEventManager.updateSettings(anything())).once();
-    verify(mockEventManager.start()).once();
-
-    await new Promise(resolve => setTimeout(resolve, 200)); // Wait for VuidManager to fetch from cache.
-
-    verify(mockEventManager.registerVuid(anything())).once();
-
-    const didUpdateA = browserOdpManager.updateSettings(odpConfigA);
-    expect(didUpdateA).toBe(true);
-    expect(browserOdpManager.odpConfig.equals(odpConfigA)).toBe(true);
-
-    const updateSettingsArgsA = capture(mockEventManager.updateSettings).last();
-    expect(updateSettingsArgsA[0]).toStrictEqual(odpConfigA);
-
-    await browserOdpManager.identifyUser(userA);
-    const identifyUserArgsA = capture(mockEventManager.identifyUser).last();
-    expect(identifyUserArgsA[0]).toStrictEqual(userA);
-
-    const didUpdateB = browserOdpManager.updateSettings(odpConfigB);
-    expect(didUpdateB).toBe(true);
-    expect(browserOdpManager.odpConfig.equals(odpConfigB)).toBe(true);
-
-    const updateSettingsArgsB = capture(mockEventManager.updateSettings).last();
-    expect(updateSettingsArgsB[0]).toStrictEqual(odpConfigB);
-
-    await browserOdpManager.eventManager!.identifyUser(userB);
-    const identifyUserArgsB = capture(mockEventManager.identifyUser).last();
-    expect(identifyUserArgsB[0]).toStrictEqual(userB);
-  });
-
-  it('should use new settings in segment manager when ODP Config is updated', () => {
-    const browserOdpManager = new BrowserOdpManager({
-      odpOptions: {
-        segmentManager: new OdpSegmentManager(
-          odpConfig,
-          new BrowserLRUCache<string, string[]>(),
-          fakeSegmentApiManager
-        ),
-      },
-    });
-
-    const didUpdateA = browserOdpManager.updateSettings(new OdpConfig(keyA, hostA, pixelA, segmentsA));
-    expect(didUpdateA).toBe(true);
-
-    browserOdpManager.fetchQualifiedSegments(vuidA);
-
-    verify(
-      mockLogger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_FETCH_QUALIFIED_SEGMENTS_SEGMENTS_MANAGER_MISSING)
-    ).never();
-
-    const fetchQualifiedSegmentsArgsA = capture(mockSegmentApiManager.fetchSegments).last();
-    expect(fetchQualifiedSegmentsArgsA).toStrictEqual([keyA, hostA, ODP_USER_KEY.VUID, vuidA, segmentsA]);
-
-    const didUpdateB = browserOdpManager.updateSettings(new OdpConfig(keyB, hostB, pixelB, segmentsB));
-    expect(didUpdateB).toBe(true);
-
-    browserOdpManager.fetchQualifiedSegments(vuidB);
-
-    const fetchQualifiedSegmentsArgsB = capture(mockSegmentApiManager.fetchSegments).last();
-    expect(fetchQualifiedSegmentsArgsB).toStrictEqual([keyB, hostB, ODP_USER_KEY.VUID, vuidB, segmentsB]);
-  });
-
-  it('should get event manager', () => {
-    const browserOdpManagerA = browserOdpManagerInstance();
-    expect(browserOdpManagerA.eventManager).not.toBe(null);
-
-    const browserOdpManagerB = new BrowserOdpManager({});
-    expect(browserOdpManagerB.eventManager).not.toBe(null);
-  });
-
-  it('should get segment manager', () => {
-    const browserOdpManagerA = browserOdpManagerInstance();
-    expect(browserOdpManagerA.segmentManager).not.toBe(null);
-
-    const browserOdpManagerB = new BrowserOdpManager({});
-    expect(browserOdpManagerB.eventManager).not.toBe(null);
-  });
-
-  // it("should call event manager's sendEvent if ODP Event is valid", async () => {
-  //   const browserOdpManager = new BrowserOdpManager({
-  //     odpOptions: {
-  //       eventManager: fakeEventManager,
-  //     },
-  //   });
-
-  //   const odpConfig = new OdpConfig('key', 'host', []);
-
-  //   browserOdpManager.updateSettings(odpConfig);
-
-  //   // Test Valid OdpEvent - calls event manager with valid OdpEvent object
-  //   const validIdentifiers = new Map();
-  //   validIdentifiers.set('vuid', vuidA);
-
-  //   const validOdpEvent = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.INITIALIZED, validIdentifiers);
-
-  //   await browserOdpManager.sendEvent(validOdpEvent);
-  //   verify(mockEventManager.sendEvent(anything())).once();
-
-  //   // Test Invalid OdpEvents - logs error and short circuits
-  //   // Does not include `vuid` in identifiers does not have a local this.vuid populated in BrowserOdpManager
-  //   browserOdpManager.vuid = undefined;
-  //   const invalidOdpEvent = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.INITIALIZED, undefined);
-
-  //   await expect(browserOdpManager.sendEvent(invalidOdpEvent)).rejects.toThrow(
-  //     ERROR_MESSAGES.ODP_SEND_EVENT_FAILED_VUID_MISSING
-  //   );
-  // });
-
   describe('Populates BrowserOdpManager correctly with all odpOptions', () => {
-    it('odpOptions.disabled = true disables BrowserOdpManager', () => {
-      const odpOptions: OdpOptions = {
-        disabled: true,
-      };
+    beforeAll(() => {
 
-      const browserOdpManager = new BrowserOdpManager({
-        odpOptions,
-      });
-
-      expect(browserOdpManager.enabled).toBe(false);
     });
 
     it('Custom odpOptions.segmentsCache overrides default LRUCache', () => {
@@ -289,17 +132,19 @@ describe('OdpManager', () => {
           maxSize: 2,
           timeout: 4000,
         }),
-      };
+      };        
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
-      // @ts-ignore
-      expect(browserOdpManager.segmentManager?._segmentsCache.maxSize).toBe(2);
+      const segmentManager = browserOdpManager['segmentManager'] as OdpSegmentManager;
 
       // @ts-ignore
-      expect(browserOdpManager.segmentManager?._segmentsCache.timeout).toBe(4000);
+      expect(browserOdpManager.segmentManager._segmentsCache.maxSize).toBe(2);
+
+      // @ts-ignore
+      expect(browserOdpManager.segmentManager._segmentsCache.timeout).toBe(4000);
     });
 
     it('Custom odpOptions.segmentsCacheSize overrides default LRUCache size', () => {
@@ -307,12 +152,12 @@ describe('OdpManager', () => {
         segmentsCacheSize: 2,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
       // @ts-ignore
-      expect(browserOdpManager.segmentManager?._segmentsCache.maxSize).toBe(2);
+      expect(browserOdpManager.segmentManager._segmentsCache.maxSize).toBe(2);
     });
 
     it('Custom odpOptions.segmentsCacheTimeout overrides default LRUCache timeout', () => {
@@ -320,12 +165,12 @@ describe('OdpManager', () => {
         segmentsCacheTimeout: 4000,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
       // @ts-ignore
-      expect(browserOdpManager.segmentManager?._segmentsCache.timeout).toBe(4000);
+      expect(browserOdpManager.segmentManager._segmentsCache.timeout).toBe(4000);
     });
 
     it('Custom odpOptions.segmentsApiTimeout overrides default Segment API Request Handler timeout', () => {
@@ -333,7 +178,7 @@ describe('OdpManager', () => {
         segmentsApiTimeout: 4000,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -342,7 +187,7 @@ describe('OdpManager', () => {
     });
 
     it('Browser default Segments API Request Handler timeout should be used when odpOptions does not include segmentsApiTimeout', () => {
-      const browserOdpManager = new BrowserOdpManager({});
+      const browserOdpManager = BrowserOdpManager.createInstance({});
 
       // @ts-ignore
       expect(browserOdpManager.segmentManager.odpSegmentApiManager.requestHandler.timeout).toBe(10000);
@@ -353,7 +198,7 @@ describe('OdpManager', () => {
         segmentsRequestHandler: new BrowserRequestHandler(fakeLogger, 4000),
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -367,7 +212,7 @@ describe('OdpManager', () => {
         segmentsRequestHandler: new BrowserRequestHandler(fakeLogger, 1),
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -377,16 +222,17 @@ describe('OdpManager', () => {
 
     it('Custom odpOptions.segmentManager overrides default Segment Manager', () => {
       const customSegmentManager = new OdpSegmentManager(
-        odpConfig,
         new BrowserLRUCache<string, string[]>(),
-        fakeSegmentApiManager
+        fakeSegmentApiManager,
+        fakeLogger,
+        odpConfig,
       );
 
       const odpOptions: OdpOptions = {
         segmentManager: customSegmentManager,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -396,12 +242,13 @@ describe('OdpManager', () => {
 
     it('Custom odpOptions.segmentManager override takes precedence over all other segments-related odpOptions', () => {
       const customSegmentManager = new OdpSegmentManager(
-        odpConfig,
         new BrowserLRUCache<string, string[]>({
           maxSize: 1,
           timeout: 1,
         }),
-        new OdpSegmentApiManager(new BrowserRequestHandler(fakeLogger, 1), fakeLogger)
+        new OdpSegmentApiManager(new BrowserRequestHandler(fakeLogger, 1), fakeLogger),
+        fakeLogger,
+        odpConfig,
       );
 
       const odpOptions: OdpOptions = {
@@ -413,7 +260,7 @@ describe('OdpManager', () => {
         segmentManager: customSegmentManager,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -435,7 +282,7 @@ describe('OdpManager', () => {
         eventApiTimeout: 4000,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -446,7 +293,7 @@ describe('OdpManager', () => {
     it('Browser default Events API Request Handler timeout should be used when odpOptions does not include eventsApiTimeout', () => {
       const odpOptions: OdpOptions = {};
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -459,7 +306,7 @@ describe('OdpManager', () => {
         eventFlushInterval: 4000,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -470,7 +317,7 @@ describe('OdpManager', () => {
     it('Default ODP event flush interval is used when odpOptions does not include eventFlushInterval', () => {
       const odpOptions: OdpOptions = {};
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -483,7 +330,7 @@ describe('OdpManager', () => {
         eventFlushInterval: 0,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -499,7 +346,7 @@ describe('OdpManager', () => {
         eventBatchSize: 2,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -512,7 +359,7 @@ describe('OdpManager', () => {
         eventQueueSize: 2,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -525,7 +372,7 @@ describe('OdpManager', () => {
         eventRequestHandler: new BrowserRequestHandler(fakeLogger, 4000),
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -542,7 +389,7 @@ describe('OdpManager', () => {
         eventRequestHandler: new BrowserRequestHandler(fakeLogger, 1),
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -566,7 +413,7 @@ describe('OdpManager', () => {
         eventManager: customEventManager,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -604,7 +451,7 @@ describe('OdpManager', () => {
         eventManager: customEventManager,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 
@@ -642,7 +489,7 @@ describe('OdpManager', () => {
         eventQueueSize: 4,
       };
 
-      const browserOdpManager = new BrowserOdpManager({
+      const browserOdpManager = BrowserOdpManager.createInstance({
         odpOptions,
       });
 

--- a/tests/odpManager.spec.ts
+++ b/tests/odpManager.spec.ts
@@ -68,6 +68,7 @@ class TestOdpManager extends OdpManager {
     super({ odpIntegrationConfig, segmentManager, eventManager, logger });
     this.vuidEnabled = vuidEnabled ?? false;
     this.vuid = vuid ?? 'vuid_123';
+    this.vuidInitializer = vuidInitializer ?? this.initializeVuid;
   }
   isVuidEnabled(): boolean {
     return this.vuidEnabled;

--- a/tests/odpManager.spec.ts
+++ b/tests/odpManager.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, Optimizely
+ * Copyright 2023-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/odpManager.spec.ts
+++ b/tests/odpManager.spec.ts
@@ -125,40 +125,6 @@ describe('OdpManager', () => {
     resetCalls(mockSegmentManager);
   });
 
-  // const odpManagerInstance = (config?: OdpConfig) =>
-  //   new OdpManager({
-  //     odpOptions: {
-  //       eventManager,
-  //       segmentManager,
-  //       segmentsRequestHandler: defaultRequestHandler,
-  //       eventRequestHandler: defaultRequestHandler,
-  //     },
-  //   });
-
-  // it('should drop relevant calls when OdpManager is initialized with the disabled flag', async () => {
-  //   const odpManager = new OdpManager({
-  //     logger,
-  //     odpOptions: {
-  //       disabled: true,
-  //       segmentsRequestHandler: defaultRequestHandler,
-  //       eventRequestHandler: defaultRequestHandler,
-  //     },
-  //   });
-  //   verify(mockLogger.log(LogLevel.INFO, LOG_MESSAGES.ODP_DISABLED)).once();
-
-  //   odpManager.updateSettings(new OdpConfig('valid', 'host', 'pixel-url', []));
-  //   expect(odpManager.odpConfig).toBeUndefined;
-
-  //   await odpManager.fetchQualifiedSegments('user1', []);
-  //   verify(mockLogger.log(LogLevel.ERROR, ERROR_MESSAGES.ODP_NOT_ENABLED)).once();
-
-  //   odpManager.identifyUser('user1');
-  //   verify(mockLogger.log(LogLevel.DEBUG, LOG_MESSAGES.ODP_IDENTIFY_FAILED_ODP_DISABLED)).once();
-
-  //   expect(odpManager.eventManager).toBeUndefined;
-  //   expect(odpManager.segmentManager).toBeUndefined;
-  // });
-
   
   it('should be in stopped status and not ready if constructed without odpIntegrationConfig', () => {
     const odpManager = testOdpManager({

--- a/tests/odpSegmentManager.spec.ts
+++ b/tests/odpSegmentManager.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/odpSegmentManager.spec.ts
+++ b/tests/odpSegmentManager.spec.ts
@@ -128,6 +128,19 @@ describe('OdpSegmentManager', () => {
     expect(cacheCount(manager)).toBe(1);
   });
 
+  it('should reset the cache on settings update.', async () => {
+    const oldConfig = new OdpConfig('old-key', 'old-host', 'pixel-url', ['new-customer']);
+    const manager = new OdpSegmentManager(getSegmentsCache(), apiManager, mockLogHandler, validTestOdpConfig);
+
+    setCache(manager, userKey, userValue, ['a']);
+    expect(cacheCount(manager)).toBe(1);
+
+    const newConfig = new OdpConfig('new-key', 'new-host', 'pixel-url', ['new-customer']);
+    manager.updateSettings(newConfig);
+
+    expect(cacheCount(manager)).toBe(0);
+  });
+
   it('should reset the cache if the option string is included in the options array.', async () => {
     const manager = new OdpSegmentManager(getSegmentsCache(), apiManager, mockLogHandler, validTestOdpConfig);
     setCache(manager, userKey, userValue, ['a']);

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -57,3 +57,7 @@ export const getTestPersistentCache = (): PersistentKeyValueCache => {
 
   return cache;
 }
+
+export const wait = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -42,7 +42,6 @@ export const getTestPersistentCache = (): PersistentKeyValueCache => {
     }),
 
     set: jest.fn().mockImplementation((): Promise<void> => {
-      console.log('mock set called');
       return Promise.resolve();
     }),
 

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022, Optimizely
+ * Copyright 2022, 2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Things fixed:
- ODPManager should not be running and scheduling timer if ODP is not integrated to the project (which causes memory leak if one sdk instance is created per request)
- CreateUserContext should work even when called before the datafile is downloaded and should send the `identify` ODP events after datafile download completes
- Other automatic odp events (vuid registration, client initialized) should also be sent after datafile is available and should not be dropped if batching is disabled.
- ODP manager should distinguish between when odp config is still not loaded and when odp is not integrated at all
- made ODP config  immutable
- ODP event manager should not schedule timers to flush events if event batching is disabled (ie batch size == 1)
- other code quality improvements

## Test plan
- added new tests where applicable, and updated old tests

## Issues
- FSSDK-10090
