### PR TITLE
[ISSUE-922] - un-restrict user attribute type definition, add tests...

### DIFF
--- a/lib/shared_types.tests.ts
+++ b/lib/shared_types.tests.ts
@@ -1,0 +1,43 @@
+import { UserAttributes } from "./shared_types";
+import { assert } from "chai";
+
+describe("shared_types", () => {
+    describe("UserAttributes", () => {
+        it("allows any attribute to be defined", () => {
+            const booleanValue: UserAttributes = {
+                fixed: true,
+                broken: false
+            };
+            const numberValue: UserAttributes = {
+                first: 1,
+                last: 999
+            };
+            const stringValue: UserAttributes = {
+                name: "Rick Sanchez",
+                dimension: "c137"
+            };
+            const nullValue: UserAttributes = {
+                no: null,
+                empty: null
+            };
+            const custom = {
+                sidekick1: "Morty Smith",
+                sidekick2: "Summer Smith"
+            }
+            const objectValue: UserAttributes = {
+                custom
+            };
+            assert.isBoolean(booleanValue.fixed);
+            assert.equal(booleanValue.broken, false);
+            assert.isNumber(numberValue.last)
+            assert.equal(numberValue.last, 999);
+            assert.isString(stringValue.name);
+            assert.equal(stringValue.dimension, "c137");
+            assert.isNull(nullValue.no);
+            assert.equal(nullValue.empty, null);
+            assert.isObject(objectValue.custom);
+            assert.equal(objectValue.custom.sidekick1, "Morty Smith");
+            assert.deepEqual(objectValue.custom, custom);
+        });
+    });
+})

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -57,7 +57,8 @@ export interface DecisionResponse<T> {
   readonly reasons: (string | number)[][];
 }
 
-export type UserAttributeValue = string | number | boolean | null;
+/** Purposely allow any here. The definition of an attribute should allow any type. **/
+export type UserAttributeValue = any;
 
 export type UserAttributes = {
   [name: string]: UserAttributeValue;


### PR DESCRIPTION
## Summary
- Reverts functionality for the type definition on user attributes (allow _any_ type)
- adds some tests


## Test plan
See [#922]

## Issues
- Fixes #922 
