### PR TITLE
[FSSDK-10180] close http request after getting response to release memory immediately (node)

### DIFF
--- a/lib/plugins/event_dispatcher/index.node.ts
+++ b/lib/plugins/event_dispatcher/index.node.ts
@@ -51,19 +51,22 @@ export const dispatchEvent = function(
     },
   };
 
+  const reqWrapper: { req?: http.ClientRequest } = {};
+
   const requestCallback = function(response?: { statusCode: number }): void {
     if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400) {
+      reqWrapper.req?.destroy();
       callback(response);
     }
   };
 
-  const req = (parsedUrl.protocol === 'http:' ? http : https)
+  reqWrapper.req = (parsedUrl.protocol === 'http:' ? http : https)
     .request(requestOptions, requestCallback as (res: http.IncomingMessage) => void);
   // Add no-op error listener to prevent this from throwing
-  req.on('error', function() {});
-  req.write(dataString);
-  req.end();
-  return req;
+  reqWrapper.req.on('error', function() {});
+  reqWrapper.req.write(dataString);
+  reqWrapper.req.end();
+  return reqWrapper.req;
 };
 
 export default {

--- a/lib/plugins/event_dispatcher/index.node.ts
+++ b/lib/plugins/event_dispatcher/index.node.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018, 2020-2021, Optimizely
+ * Copyright 2016-2018, 2020-2021, 2024 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,15 +55,19 @@ export const dispatchEvent = function(
 
   const requestCallback = function(response?: { statusCode: number }): void {
     if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 400) {
-      reqWrapper.req?.destroy();
       callback(response);
     }
+    reqWrapper.req?.destroy();
+    reqWrapper.req = undefined;
   };
 
   reqWrapper.req = (parsedUrl.protocol === 'http:' ? http : https)
     .request(requestOptions, requestCallback as (res: http.IncomingMessage) => void);
   // Add no-op error listener to prevent this from throwing
-  reqWrapper.req.on('error', function() {});
+  reqWrapper.req.on('error', function() {
+    reqWrapper.req?.destroy();
+    reqWrapper.req = undefined;
+  });
   reqWrapper.req.write(dataString);
   reqWrapper.req.end();
   return reqWrapper.req;


### PR DESCRIPTION
## Summary
- close req after getting response to release memory immediately (node)

## Test plan

Existing tests should pass

## Issues
- [FSSDK-10180](https://jira.sso.episerver.net/browse/FSSDK-10180)
