### PR TITLE
fix: Remove @babel/runtime as a peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
         "@react-native-async-storage/async-storage": "^1.2.0",
         "@react-native-community/netinfo": "^11.3.2",
         "fast-text-encoding": "^1.0.6",
@@ -2541,6 +2540,7 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
       "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -12925,6 +12925,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "peer": true
     },
     "node_modules/regenerator-transform": {
@@ -16855,6 +16856,7 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
       "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dev": true,
       "peer": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
@@ -24989,6 +24991,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "peer": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     "webpack": "^5.74.0"
   },
   "peerDependencies": {
-    "@babel/runtime": "^7.0.0",
     "@react-native-async-storage/async-storage": "^1.2.0",
     "@react-native-community/netinfo": "^11.3.2",
     "react-native-get-random-values": "^1.11.0",


### PR DESCRIPTION
## Summary

Removes `@babel/runtime` as a peerDependency which appears to be unused. It was added in https://github.com/optimizely/javascript-sdk/pull/761 but it's not clear why. 

## Test plan

Existing test should pass