### PR TITLE
[FSSDK-10586] rollout experiment key returns wrong decision

### DIFF
--- a/lib/core/decision_service/index.tests.js
+++ b/lib/core/decision_service/index.tests.js
@@ -1675,6 +1675,7 @@ describe('lib/core/decision_service', function() {
                 status: 'Not started',
                 key: '594031',
                 id: '594031',
+                isRollout: true,
                 variations: [
                   {
                     id: '594032',
@@ -1812,6 +1813,7 @@ describe('lib/core/decision_service', function() {
                 status: 'Not started',
                 key: '594037',
                 id: '594037',
+                isRollout: true,
                 variations: [
                   {
                     id: '594038',
@@ -1996,6 +1998,7 @@ describe('lib/core/decision_service', function() {
                 status: 'Not started',
                 key: '594037',
                 id: '594037',
+                isRollout: true,
                 variations: [
                   {
                     id: '594038',
@@ -2150,6 +2153,7 @@ describe('lib/core/decision_service', function() {
               layerId: '599055',
               forcedVariations: {},
               audienceIds: [],
+              isRollout: true,
               variations: [
                 {
                   key: '599057',

--- a/lib/core/project_config/index.ts
+++ b/lib/core/project_config/index.ts
@@ -167,6 +167,7 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
   projectConfig.rolloutIdMap = keyBy(projectConfig.rollouts || [], 'id');
   objectValues(projectConfig.rolloutIdMap || {}).forEach(rollout => {
     (rollout.experiments || []).forEach(experiment => {
+      experiment.isRollout = true
       projectConfig.experiments.push(experiment);
       // Creates { <variationKey>: <variation> } map inside of the experiment
       experiment.variationKeyMap = keyBy(experiment.variations, 'key');

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -479,7 +479,7 @@ export default class Optimizely implements Client {
         }
 
         const experiment = configObj.experimentKeyMap[experimentKey];
-        if (!experiment) {
+        if (!experiment || experiment.isRollout) {
           this.logger.log(LOG_LEVEL.DEBUG, ERROR_MESSAGES.INVALID_EXPERIMENT_KEY, MODULE_NAME, experimentKey);
           return null;
         }

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -178,6 +178,7 @@ export interface Experiment {
   audienceIds: string[];
   trafficAllocation: TrafficAllocation[];
   forcedVariations?: { [key: string]: string };
+  isRollout?: boolean;
 }
 
 export enum VariableType {

--- a/lib/tests/test_data.js
+++ b/lib/tests/test_data.js
@@ -1647,6 +1647,7 @@ export var datafileWithFeaturesExpectedData = {
           status: 'Not started',
           key: '599056',
           id: '599056',
+          isRollout: true,
           variationKeyMap: {
             599057: {
               key: '599057',
@@ -1711,6 +1712,7 @@ export var datafileWithFeaturesExpectedData = {
           ],
           key: '594031',
           id: '594031',
+          isRollout: true,
           variationKeyMap: {
             594032: {
               variables: [
@@ -1783,6 +1785,7 @@ export var datafileWithFeaturesExpectedData = {
           ],
           key: '594037',
           id: '594037',
+          isRollout: true,
           variationKeyMap: {
             594038: {
               variables: [
@@ -1856,6 +1859,7 @@ export var datafileWithFeaturesExpectedData = {
           ],
           key: '594060',
           id: '594060',
+          isRollout: true,
           variationKeyMap: {
             594061: {
               variables: [
@@ -1920,6 +1924,7 @@ export var datafileWithFeaturesExpectedData = {
           ],
           key: '594066',
           id: '594066',
+          isRollout: true,
           variationKeyMap: {
             594067: {
               variables: [


### PR DESCRIPTION
## Summary
When "activate" is called with a rollout experiment key (not ab-test), SDK is supposed to return "invalid experiment key". 
An optional `isRollout`  flag property has been added to the experiment object to identify if its a rollout experiment or not.

## Test plan
Existing test should pass
## Issues
[FSSDK-10586](https://jira.sso.episerver.net/browse/FSSDK-10586)