### PR TITLE
[FSSDK-10867] ensure odpManager.setVuid is done before resolving onReady

### DIFF
--- a/lib/core/odp/odp_manager.ts
+++ b/lib/core/odp/odp_manager.ts
@@ -258,6 +258,10 @@ export abstract class OdpManager implements IOdpManager {
       return;
     }
 
+    if (!vuid && this.vuid) {
+      vuid = this.vuid;
+    }
+    
     this.eventManager.identifyUser(userId, vuid);
   }
 

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -181,28 +181,26 @@ export default class Optimizely implements Client {
     this.eventProcessor = config.eventProcessor;
 
     const eventProcessorStartedPromise = this.eventProcessor.start();
-
+    
     this.readyPromise = Promise.all([
       projectConfigManagerReadyPromise,
       eventProcessorStartedPromise,
       config.odpManager ? config.odpManager.onReady() : Promise.resolve(),
       config.vuidManager ? config.vuidManager.configure(this.vuidOptions ?? { enableVuid: false }) : Promise.resolve(),
     ]).then(promiseResults => {
-      // Only return status from project config promise because event processor promise does not return any status.
-      return promiseResults[0];
-    });
-
-    this.readyTimeouts = {};
-    this.nextReadyTimeoutId = 0;
-
-    this.onReady().then(({ success }) => {
-      if (success) {
+      // Only return status from project config promise because event processor promise does not return any status.      
+      const result = promiseResults[0];
+      if (result.success) {
         const vuid = this.vuidManager?.vuid;
         if (vuid) {
           this.odpManager?.setVuid(vuid);
         }
       }
+      return result;
     });
+
+    this.readyTimeouts = {};
+    this.nextReadyTimeoutId = 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure odpManager.setVuid is done before resolving onReady so that identify event contains the vuid.

## Test plan
- existing tests should pass

## Issues
- FSSDK-10867
