### PR TITLE
Extend EventTags type to support Event Properties

### DIFF
--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -76,9 +76,17 @@ export interface UserProfile {
   experiment_bucket_map: ExperimentBucketMap;
 }
 
-export type EventTags = {
-  [key: string]: string | number | null;
+export type EventPropertyValue = string | number | boolean;
+
+export type EventProperties = {
+    '$opt_event_properties'?: {
+        [key: string]: EventPropertyValue;
+    };
 };
+
+export type EventTags = {
+    [key: string]: string | number | null;
+} | EventProperties;
 
 export interface UserProfileService {
   lookup(userId: string): UserProfile;

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -79,13 +79,13 @@ export interface UserProfile {
 export type EventPropertyValue = string | number | boolean;
 
 export type EventProperties = {
-    '$opt_event_properties'?: {
-        [key: string]: EventPropertyValue;
-    };
+  '$opt_event_properties'?: {
+    [key: string]: EventPropertyValue;
+  };
 };
 
 export type EventTags = {
-    [key: string]: string | number | null;
+  [key: string]: string | number | null;
 } | EventProperties;
 
 export interface UserProfileService {


### PR DESCRIPTION
## Summary
- Extend EventTags type to support Event Properties

The beta capability of [Event Properties](https://docs.developers.optimizely.com/feature-experimentation/docs/track-events#event-properties) isn't support by the current EventTags type. The PR extends the type to support the reserved key `$opt_event_properties` and the types available in the UI:

![Fullscreen_08_11_2024__16_12](https://github.com/user-attachments/assets/d645832c-7136-4050-90e8-2bdcbb96551e)

## Test plan

See this [TypeScript Playground](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBDAnmYcCiA3YA7GAFKCFWRANQEMAbAV1QF44BnGKAS2wHM4AfObagLYAjYFB5whECJWDlsAbgBQi0JFgJkqTDnyFiMVsEZwGAb0Vw4AcgAkRGAH1gWXA7B7RBo1YD8ALjhTOABtAGtgRADmNk4AXQDtXAIiTzIqWjgAXyVs5VVoeCQUdBcYABVyDmMzCxDwyKYWdg54xpiuXn5hUXF+Skoc8UTdFNhDRiVFAGMIbGY4Zx0KqoBGBNLl6sDauzBHRdd3Ua9GAPNLSyP9RDW4ACIMdOAVu4AaWsuPEgAmAJXvgDM7wucCuqQBAQAZlRGMBgVl4RAYAALUTLAJ3RgQATACg0YBvWpYnHouAAVgB33hciRqKgpL6lHeuWms3mB3KlUYvxKSy5Jm2ljuHIc2HIOLuGLAlWADgwhgA7oShdRYVAHKwACaSuD-IG1O67falNxfE4684XO7SjiygwwGQ6u4ACWxqDwMuVVqgwEhoh9UCdyJgMDApwA9OHQOKwDIAHQzAR3WqZRQs1lzeAczYQ3m4TYCy3Ck1iiVSmVyxVeu6q0Qa7V-QFpyYZ9kbLkAFnWfKqhYNRqcJrBYyMFo+9xtdtYDoJGNdOLgHttXqFPr9UADQZDYb8kejAljwAT2OTllTuSAA) for example usage.

## Issues
- Let me know if you want me to create one.
