### PR TITLE
[FSSDK-10989] refactor notification center using event emitter

### DIFF
--- a/lib/export_types.ts
+++ b/lib/export_types.ts
@@ -39,7 +39,6 @@ export {
   ListenerPayload,
   OptimizelyDecision,
   OptimizelyUserContext,
-  NotificationListener,
   Config,
   Client,
   ActivateListenerPayload,

--- a/lib/export_types.ts
+++ b/lib/export_types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023, Optimizely
+ * Copyright 2022-2024, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/notification_center/index.tests.js
+++ b/lib/notification_center/index.tests.js
@@ -63,47 +63,6 @@ describe('lib/core/notification_center', function() {
       });
 
       context('the listener type is a valid type', function() {
-        it('should return -1 if that same callback is already added', function() {
-          var activateCallback;
-          var decisionCallback;
-          var logEventCallback;
-          var configUpdateCallback;
-          var trackCallback;
-          // add a listener for each type
-          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallback);
-          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallback);
-          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallback);
-          notificationCenterInstance.addNotificationListener(
-            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
-            configUpdateCallback
-          );
-          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallback);
-          // assertions
-          assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallback),
-            -1
-          );
-          assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallback),
-            -1
-          );
-          assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallback),
-            -1
-          );
-          assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(
-              NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
-              configUpdateCallback
-            ),
-            -1
-          );
-          assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallback),
-            -1
-          );
-        });
-
         it('should return an id (listenerId) > 0 of the notification listener if callback is not already added', function() {
           var activateCallback;
           var decisionCallback;

--- a/lib/notification_center/index.tests.js
+++ b/lib/notification_center/index.tests.js
@@ -1,18 +1,18 @@
-/****************************************************************************
- * Copyright 2020, 2024, Optimizely, Inc. and contributors                        *
- *                                                                          *
- * Licensed under the Apache License, Version 2.0 (the "License");          *
- * you may not use this file except in compliance with the License.         *
- * You may obtain a copy of the License at                                  *
- *                                                                          *
- *    http://www.apache.org/licenses/LICENSE-2.0                            *
- *                                                                          *
- * Unless required by applicable law or agreed to in writing, software      *
- * distributed under the License is distributed on an "AS IS" BASIS,        *
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
- * See the License for the specific language governing permissions and      *
- * limitations under the License.                                           *
- ***************************************************************************/
+/**
+ * Copyright 2020, 2024, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import sinon from 'sinon';
 import { assert } from 'chai';
 

--- a/lib/notification_center/index.tests.js
+++ b/lib/notification_center/index.tests.js
@@ -20,6 +20,7 @@ import { createNotificationCenter } from './';
 import * as enums from '../utils/enums';
 import { createLogger } from '../plugins/logger';
 import errorHandler from '../plugins/error_handler';
+import { NOTIFICATION_TYPES } from './type';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 
@@ -69,36 +70,36 @@ describe('lib/core/notification_center', function() {
           var configUpdateCallback;
           var trackCallback;
           // add a listener for each type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallback);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallback);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallback);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallback);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallback);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallback);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallback
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallback);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallback);
           // assertions
           assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallback),
+            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallback),
             -1
           );
           assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallback),
+            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallback),
             -1
           );
           assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallback),
+            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallback),
             -1
           );
           assert.strictEqual(
             notificationCenterInstance.addNotificationListener(
-              enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+              NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
               configUpdateCallback
             ),
             -1
           );
           assert.strictEqual(
-            notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallback),
+            notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallback),
             -1
           );
         });
@@ -111,23 +112,23 @@ describe('lib/core/notification_center', function() {
           var trackCallback;
           // store a listenerId for each type
           var activateListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.ACTIVATE,
+            NOTIFICATION_TYPES.ACTIVATE,
             activateCallback
           );
           var decisionListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.DECISION,
+            NOTIFICATION_TYPES.DECISION,
             decisionCallback
           );
           var logEventListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.LOG_EVENT,
+            NOTIFICATION_TYPES.LOG_EVENT,
             logEventCallback
           );
           var configUpdateListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallback
           );
           var trackListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.TRACK,
+            NOTIFICATION_TYPES.TRACK,
             trackCallback
           );
           // assertions
@@ -157,23 +158,23 @@ describe('lib/core/notification_center', function() {
           var trackCallback;
           // add listeners for each type
           var activateListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.ACTIVATE,
+            NOTIFICATION_TYPES.ACTIVATE,
             activateCallback
           );
           var decisionListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.DECISION,
+            NOTIFICATION_TYPES.DECISION,
             decisionCallback
           );
           var logEventListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.LOG_EVENT,
+            NOTIFICATION_TYPES.LOG_EVENT,
             logEventCallback
           );
           var configListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallback
           );
           var trackListenerId = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.TRACK,
+            NOTIFICATION_TYPES.TRACK,
             trackCallback
           );
           // remove listeners for each type
@@ -204,34 +205,34 @@ describe('lib/core/notification_center', function() {
           var trackCallbackSpy2 = sinon.spy();
           // register listeners for each type
           var activateListenerId1 = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.ACTIVATE,
+            NOTIFICATION_TYPES.ACTIVATE,
             activateCallbackSpy1
           );
           var decisionListenerId1 = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.DECISION,
+            NOTIFICATION_TYPES.DECISION,
             decisionCallbackSpy1
           );
           var logeventlistenerId1 = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.LOG_EVENT,
+            NOTIFICATION_TYPES.LOG_EVENT,
             logEventCallbackSpy1
           );
           var configUpdateListenerId1 = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
           var trackListenerId1 = notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.TRACK,
+            NOTIFICATION_TYPES.TRACK,
             trackCallbackSpy1
           );
           // register second listeners for each type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy2
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
           // remove first listener
           var activateListenerRemoved1 = notificationCenterInstance.removeNotificationListener(activateListenerId1);
           var decisionListenerRemoved1 = notificationCenterInstance.removeNotificationListener(decisionListenerId1);
@@ -241,11 +242,11 @@ describe('lib/core/notification_center', function() {
           );
           var trackListenerRemoved1 = notificationCenterInstance.removeNotificationListener(trackListenerId1);
           // send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // Assertions
           assert.strictEqual(activateListenerRemoved1, true);
           sinon.assert.notCalled(activateCallbackSpy1);
@@ -274,22 +275,22 @@ describe('lib/core/notification_center', function() {
         var configUpdateCallbackSpy1 = sinon.spy();
         var trackCallbackSpy1 = sinon.spy();
         // add a listener for each notification type
-        notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-        notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-        notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+        notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+        notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+        notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
         notificationCenterInstance.addNotificationListener(
-          enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+          NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
           configUpdateCallbackSpy1
         );
-        notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+        notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
         // remove all listeners
         notificationCenterInstance.clearAllNotificationListeners();
         // trigger send notifications
-        notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-        notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-        notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-        notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-        notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+        notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+        notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+        notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+        notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+        notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
         // check that none of the now removed listeners were called
         sinon.assert.notCalled(activateCallbackSpy1);
         sinon.assert.notCalled(decisionCallbackSpy1);
@@ -305,12 +306,12 @@ describe('lib/core/notification_center', function() {
           var activateCallbackSpy1 = sinon.spy();
           var activateCallbackSpy2 = sinon.spy();
           //add 2 different listeners for ACTIVATE
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
           // remove ACTIVATE listeners
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.ACTIVATE);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.ACTIVATE);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
           // check that none of the ACTIVATE listeners were called
           sinon.assert.notCalled(activateCallbackSpy1);
           sinon.assert.notCalled(activateCallbackSpy2);
@@ -320,12 +321,12 @@ describe('lib/core/notification_center', function() {
           var decisionCallbackSpy1 = sinon.spy();
           var decisionCallbackSpy2 = sinon.spy();
           //add 2 different listeners for DECISION
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
           // remove DECISION listeners
-          notificationCenterInstance.clearAllNotificationListeners(enums.NOTIFICATION_TYPES.DECISION);
+          notificationCenterInstance.clearAllNotificationListeners(NOTIFICATION_TYPES.DECISION);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
           // check that none of the DECISION listeners were called
           sinon.assert.notCalled(decisionCallbackSpy1);
           sinon.assert.notCalled(decisionCallbackSpy2);
@@ -335,12 +336,12 @@ describe('lib/core/notification_center', function() {
           var logEventCallbackSpy1 = sinon.spy();
           var logEventCallbackSpy2 = sinon.spy();
           //add 2 different listeners for LOG_EVENT
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
           // remove LOG_EVENT listeners
-          notificationCenterInstance.clearAllNotificationListeners(enums.NOTIFICATION_TYPES.LOG_EVENT);
+          notificationCenterInstance.clearAllNotificationListeners(NOTIFICATION_TYPES.LOG_EVENT);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
           // check that none of the LOG_EVENT listeners were called
           sinon.assert.notCalled(logEventCallbackSpy1);
           sinon.assert.notCalled(logEventCallbackSpy2);
@@ -351,17 +352,17 @@ describe('lib/core/notification_center', function() {
           var configUpdateCallbackSpy2 = sinon.spy();
           //add 2 different listeners for OPTIMIZELY_CONFIG_UPDATE
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy2
           );
           // remove OPTIMIZELY_CONFIG_UPDATE listeners
-          notificationCenterInstance.clearAllNotificationListeners(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
+          notificationCenterInstance.clearAllNotificationListeners(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
           // check that none of the OPTIMIZELY_CONFIG_UPDATE listeners were called
           sinon.assert.notCalled(configUpdateCallbackSpy1);
           sinon.assert.notCalled(configUpdateCallbackSpy2);
@@ -371,12 +372,12 @@ describe('lib/core/notification_center', function() {
           var trackCallbackSpy1 = sinon.spy();
           var trackCallbackSpy2 = sinon.spy();
           //add 2 different listeners for TRACK
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
           // remove TRACK listeners
-          notificationCenterInstance.clearAllNotificationListeners(enums.NOTIFICATION_TYPES.TRACK);
+          notificationCenterInstance.clearAllNotificationListeners(NOTIFICATION_TYPES.TRACK);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that none of the TRACK listeners were called
           sinon.assert.notCalled(trackCallbackSpy1);
           sinon.assert.notCalled(trackCallbackSpy2);
@@ -392,24 +393,24 @@ describe('lib/core/notification_center', function() {
           var configUpdateCallbackSpy1 = sinon.spy();
           var trackCallbackSpy1 = sinon.spy();
           //add 2 different listeners for ACTIVATE
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy2);
           // add a listener for each notification type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
           // remove only ACTIVATE type
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.ACTIVATE);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.ACTIVATE);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that ACTIVATE listeners were note called
           sinon.assert.notCalled(activateCallbackSpy1);
           sinon.assert.notCalled(activateCallbackSpy2);
@@ -428,24 +429,24 @@ describe('lib/core/notification_center', function() {
           var configUpdateCallbackSpy1 = sinon.spy();
           var trackCallbackSpy1 = sinon.spy();
           // add 2 different listeners for DECISION
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy2);
           // add a listener for each notification type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
           // remove only DECISION type
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.DECISION);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.DECISION);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that DECISION listeners were not called
           sinon.assert.notCalled(decisionCallbackSpy1);
           sinon.assert.notCalled(decisionCallbackSpy2);
@@ -464,24 +465,24 @@ describe('lib/core/notification_center', function() {
           var configUpdateCallbackSpy1 = sinon.spy();
           var trackCallbackSpy1 = sinon.spy();
           // add 2 different listeners for LOG_EVENT
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy2);
           // add a listener for each notification type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
           // remove only LOG_EVENT type
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.LOG_EVENT);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.LOG_EVENT);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that LOG_EVENT listeners were not called
           sinon.assert.notCalled(logEventCallbackSpy1);
           sinon.assert.notCalled(logEventCallbackSpy2);
@@ -501,26 +502,26 @@ describe('lib/core/notification_center', function() {
           var trackCallbackSpy1 = sinon.spy();
           // add 2 different listeners for OPTIMIZELY_CONFIG_UPDATE
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy2
           );
           // add a listener for each notification type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
           // remove only OPTIMIZELY_CONFIG_UPDATE type
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that OPTIMIZELY_CONFIG_UPDATE listeners were not called
           sinon.assert.notCalled(configUpdateCallbackSpy1);
           sinon.assert.notCalled(configUpdateCallbackSpy2);
@@ -539,24 +540,24 @@ describe('lib/core/notification_center', function() {
           var logEventCallbackSpy1 = sinon.spy();
           var configUpdateCallbackSpy1 = sinon.spy();
           // add 2 different listeners for TRACK
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy2);
           // add a listener for each notification type
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
           // remove only TRACK type
-          notificationCenterInstance.clearNotificationListeners(enums.NOTIFICATION_TYPES.TRACK);
+          notificationCenterInstance.clearNotificationListeners(NOTIFICATION_TYPES.TRACK);
           // trigger send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, {});
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, {});
           // check that TRACK listeners were not called
           sinon.assert.notCalled(trackCallbackSpy1);
           sinon.assert.notCalled(trackCallbackSpy2);
@@ -604,23 +605,23 @@ describe('lib/core/notification_center', function() {
             eventTags: {},
           };
           // add listeners
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.LOG_EVENT, logEventCallbackSpy1);
           notificationCenterInstance.addNotificationListener(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateCallbackSpy1
           );
-          notificationCenterInstance.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
+          notificationCenterInstance.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackCallbackSpy1);
           // send notifications
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.ACTIVATE, activateData);
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.DECISION, decisionData);
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.LOG_EVENT, logEventData);
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, activateData);
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.DECISION, decisionData);
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, logEventData);
           notificationCenterInstance.sendNotifications(
-            enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+            NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
             configUpdateData
           );
-          notificationCenterInstance.sendNotifications(enums.NOTIFICATION_TYPES.TRACK, trackData);
+          notificationCenterInstance.sendNotifications(NOTIFICATION_TYPES.TRACK, trackData);
           // assertions
           sinon.assert.calledWithExactly(activateCallbackSpy1, activateData);
           sinon.assert.calledWithExactly(decisionCallbackSpy1, decisionData);

--- a/lib/notification_center/index.tests.js
+++ b/lib/notification_center/index.tests.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2020, 2024, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/lib/notification_center/index.ts
+++ b/lib/notification_center/index.ts
@@ -144,7 +144,7 @@ export class DefaultNotificationCenter implements NotificationCenter, Notificati
 
   /**
    * Remove all previously added notification listeners for the argument type
-   * @param   {NOTIFICATION_TYPES}    notificationType One of NOTIFICATION_TYPES
+   * @param   {NotificationType}    notificationType One of NotificationType
    */
   clearNotificationListeners(notificationType: NotificationType): void {
     this.eventEmitter.removeListeners(notificationType);
@@ -153,7 +153,7 @@ export class DefaultNotificationCenter implements NotificationCenter, Notificati
   /**
    * Fires notifications for the argument type. All registered callbacks for this type will be
    * called. The notificationData object will be passed on to callbacks called.
-   * @param {string} notificationType One of NOTIFICATION_TYPES
+   * @param {NotificationType} notificationType One of NotificationType
    * @param {Object} notificationData Will be passed to callbacks called
    */
   sendNotifications<N extends NotificationType>(

--- a/lib/notification_center/index.ts
+++ b/lib/notification_center/index.ts
@@ -58,7 +58,6 @@ export interface NotificationSender {
 export class DefaultNotificationCenter implements NotificationCenter, NotificationSender {
   private logger: LogHandler;
   private errorHandler: ErrorHandler;
-  private callbacks: Map<Fn, boolean> = new Map();
 
   private removerId = 1;
   private eventEmitter: EventEmitter<NotificationPayload> = new EventEmitter();

--- a/lib/notification_center/type.ts
+++ b/lib/notification_center/type.ts
@@ -67,11 +67,11 @@ export type NotificationPayload = {
 
 export type NotificationType = keyof NotificationPayload;
 
-export type NotiticationTypeValues = {
+export type NotificationTypeValues = {
   [key in NotificationType]: key;
 }
 
-export const NOTIFICATION_TYPES: NotiticationTypeValues = {
+export const NOTIFICATION_TYPES: NotificationTypeValues = {
   ACTIVATE: 'ACTIVATE',
   DECISION: 'DECISION',
   LOG_EVENT: 'LOG_EVENT',

--- a/lib/notification_center/type.ts
+++ b/lib/notification_center/type.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LogEvent } from '../event_processor/event_dispatcher/event_dispatcher';
 import { EventTags, Experiment, UserAttributes, Variation } from '../shared_types';
 

--- a/lib/notification_center/type.ts
+++ b/lib/notification_center/type.ts
@@ -1,0 +1,64 @@
+import { LogEvent } from '../event_processor/event_dispatcher/event_dispatcher';
+import { EventTags, Experiment, UserAttributes, Variation } from '../shared_types';
+
+export type UserEventListenerPayload = {
+  userId: string;
+  attributes?: UserAttributes;
+}
+
+export type ActivateListenerPayload = UserEventListenerPayload & {
+  experiment: Experiment | null;
+  variation: Variation | null;
+  logEvent: LogEvent;
+}
+
+export type TrackListenerPayload = UserEventListenerPayload & {
+  eventKey: string;
+  eventTags?: EventTags;
+  logEvent: LogEvent;
+}
+
+export const DECISION_NOTIFICATION_TYPES = {
+  AB_TEST: 'ab-test',
+  FEATURE: 'feature',
+  FEATURE_TEST: 'feature-test',
+  FEATURE_VARIABLE: 'feature-variable',
+  ALL_FEATURE_VARIABLES: 'all-feature-variables',
+  FLAG: 'flag',
+} as const;
+
+export type DecisionNotificationType = typeof DECISION_NOTIFICATION_TYPES[keyof typeof DECISION_NOTIFICATION_TYPES];
+
+// TODO: Add more specific types for decision info
+export type OptimizelyDecisionInfo = Record<string, any>;
+
+export type DecisionListenerPayload = UserEventListenerPayload & {
+  type: DecisionNotificationType;
+  decisionInfo: OptimizelyDecisionInfo;
+}
+
+export type LogEventListenerPayload = LogEvent;
+
+export type OptimizelyConfigUpdateListenerPayload = undefined;
+
+export type NotificationPayload = {
+  ACTIVATE: ActivateListenerPayload;
+  DECISION: DecisionListenerPayload;
+  TRACK: TrackListenerPayload;
+  LOG_EVENT: LogEventListenerPayload;
+  OPTIMIZELY_CONFIG_UPDATE: OptimizelyConfigUpdateListenerPayload;
+};
+
+export type NotificationType = keyof NotificationPayload;
+
+export type NotiticationTypeValues = {
+  [key in NotificationType]: key;
+}
+
+export const NOTIFICATION_TYPES: NotiticationTypeValues = {
+  ACTIVATE: 'ACTIVATE',
+  DECISION: 'DECISION',
+  LOG_EVENT: 'LOG_EVENT',
+  OPTIMIZELY_CONFIG_UPDATE: 'OPTIMIZELY_CONFIG_UPDATE',
+  TRACK: 'TRACK',
+};

--- a/lib/optimizely/index.tests.js
+++ b/lib/optimizely/index.tests.js
@@ -16,7 +16,7 @@
 import { assert, expect } from 'chai';
 import sinon from 'sinon';
 import { sprintf } from '../utils/fns';
-import { NOTIFICATION_TYPES } from '../utils/enums';
+import { NOTIFICATION_TYPES } from '../notification_center/type';
 import * as logging from '../modules/logging';
 
 import Optimizely from './';
@@ -37,13 +37,13 @@ import { getForwardingEventProcessor } from '../event_processor/forwarding_event
 import { createNotificationCenter } from '../notification_center';
 import { createProjectConfig } from '../project_config/project_config';
 import { getMockProjectConfigManager } from '../tests/mock/mock_project_config_manager';
+import { DECISION_NOTIFICATION_TYPES } from '../notification_center/type';
 
 var ERROR_MESSAGES = enums.ERROR_MESSAGES;
 var LOG_LEVEL = enums.LOG_LEVEL;
 var LOG_MESSAGES = enums.LOG_MESSAGES;
 var DECISION_SOURCES = enums.DECISION_SOURCES;
 var DECISION_MESSAGES = enums.DECISION_MESSAGES;
-var DECISION_NOTIFICATION_TYPES = enums.DECISION_NOTIFICATION_TYPES;
 var FEATURE_VARIABLE_TYPES = enums.FEATURE_VARIABLE_TYPES;
 
 var buildLogMessageFromArgs = args => sprintf(args[1], ...args.splice(2));
@@ -2316,14 +2316,14 @@ describe('lib/optimizely', function() {
       });
 
       it('should call a listener added for activate when activate is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
         var variationKey = optlyInstance.activate('testExperiment', 'testUser');
         assert.strictEqual(variationKey, 'variation');
         sinon.assert.calledOnce(activateListener);
       });
 
       it('should call a listener added for track when track is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
         optlyInstance.activate('testExperiment', 'testUser');
         optlyInstance.track('testEvent', 'testUser');
         sinon.assert.calledOnce(trackListener);
@@ -2331,7 +2331,7 @@ describe('lib/optimizely', function() {
 
       it('should not call a removed activate listener when activate is called', function() {
         var listenerId = optlyInstance.notificationCenter.addNotificationListener(
-          enums.NOTIFICATION_TYPES.ACTIVATE,
+          NOTIFICATION_TYPES.ACTIVATE,
           activateListener
         );
         optlyInstance.notificationCenter.removeNotificationListener(listenerId);
@@ -2342,7 +2342,7 @@ describe('lib/optimizely', function() {
 
       it('should not call a removed track listener when track is called', function() {
         var listenerId = optlyInstance.notificationCenter.addNotificationListener(
-          enums.NOTIFICATION_TYPES.TRACK,
+          NOTIFICATION_TYPES.TRACK,
           trackListener
         );
         optlyInstance.notificationCenter.removeNotificationListener(listenerId);
@@ -2352,9 +2352,9 @@ describe('lib/optimizely', function() {
       });
 
       it('removeNotificationListener should only remove the listener with the argument ID', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
         var trackListenerId = optlyInstance.notificationCenter.addNotificationListener(
-          enums.NOTIFICATION_TYPES.TRACK,
+          NOTIFICATION_TYPES.TRACK,
           trackListener
         );
         optlyInstance.notificationCenter.removeNotificationListener(trackListenerId);
@@ -2364,8 +2364,8 @@ describe('lib/optimizely', function() {
       });
 
       it('should clear all notification listeners when clearAllNotificationListeners is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
         optlyInstance.notificationCenter.clearAllNotificationListeners();
         optlyInstance.activate('testExperiment', 'testUser');
         optlyInstance.track('testEvent', 'testUser');
@@ -2375,9 +2375,9 @@ describe('lib/optimizely', function() {
       });
 
       it('should clear listeners of certain notification type when clearNotificationListeners is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
-        optlyInstance.notificationCenter.clearNotificationListeners(enums.NOTIFICATION_TYPES.ACTIVATE);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.clearNotificationListeners(NOTIFICATION_TYPES.ACTIVATE);
         optlyInstance.activate('testExperiment', 'testUser');
         optlyInstance.track('testEvent', 'testUser');
 
@@ -2386,8 +2386,8 @@ describe('lib/optimizely', function() {
       });
 
       it('should only call the listener once after the same listener was added twice', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
         optlyInstance.activate('testExperiment', 'testUser');
         sinon.assert.calledOnce(activateListener);
       });
@@ -2405,16 +2405,16 @@ describe('lib/optimizely', function() {
       });
 
       it('should call multiple notification listeners for activate when activate is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener2);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener2);
         optlyInstance.activate('testExperiment', 'testUser');
         sinon.assert.calledOnce(activateListener);
         sinon.assert.calledOnce(activateListener2);
       });
 
       it('should call multiple notification listeners for track when track is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener2);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener2);
         optlyInstance.activate('testExperiment', 'testUser');
         optlyInstance.track('testEvent', 'testUser');
         sinon.assert.calledOnce(trackListener);
@@ -2422,7 +2422,7 @@ describe('lib/optimizely', function() {
       });
 
       it('should pass the correct arguments to an activate listener when activate is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
         optlyInstance.activate('testExperiment', 'testUser');
         var expectedImpressionEvent = {
           httpVerb: 'POST',
@@ -2484,7 +2484,7 @@ describe('lib/optimizely', function() {
         var attributes = {
           browser_type: 'firefox',
         };
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.ACTIVATE, activateListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
         optlyInstance.activate('testExperiment', 'testUser', attributes);
         var expectedImpressionEvent = {
           httpVerb: 'POST',
@@ -2550,7 +2550,7 @@ describe('lib/optimizely', function() {
       });
 
       it('should pass the correct arguments to a track listener when track is called', function() {
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
         optlyInstance.activate('testExperiment', 'testUser');
         optlyInstance.track('testEvent', 'testUser');
         var expectedConversionEvent = {
@@ -2598,7 +2598,7 @@ describe('lib/optimizely', function() {
         var attributes = {
           browser_type: 'firefox',
         };
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
         optlyInstance.activate('testExperiment', 'testUser', attributes);
         optlyInstance.track('testEvent', 'testUser', attributes);
         var expectedConversionEvent = {
@@ -2657,7 +2657,7 @@ describe('lib/optimizely', function() {
           value: 1.234,
           non_revenue: 'abc',
         };
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.TRACK, trackListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.TRACK, trackListener);
         optlyInstance.activate('testExperiment', 'testUser', attributes);
         optlyInstance.track('testEvent', 'testUser', attributes, eventTags);
         var expectedConversionEvent = {
@@ -2738,7 +2738,7 @@ describe('lib/optimizely', function() {
             });
 
             optlyInstance.notificationCenter.addNotificationListener(
-              enums.NOTIFICATION_TYPES.DECISION,
+              NOTIFICATION_TYPES.DECISION,
               decisionListener
             );
           });
@@ -2802,7 +2802,7 @@ describe('lib/optimizely', function() {
             });
 
             optlyInstance.notificationCenter.addNotificationListener(
-              enums.NOTIFICATION_TYPES.DECISION,
+              NOTIFICATION_TYPES.DECISION,
               decisionListener
             );
           });
@@ -2857,7 +2857,7 @@ describe('lib/optimizely', function() {
               notificationCenter,
             });
 
-            optly.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionListener);
+            optly.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionListener);
 
             fakeDecisionResponse = {
               result: '594099',
@@ -2899,7 +2899,7 @@ describe('lib/optimizely', function() {
             });
 
             optlyInstance.notificationCenter.addNotificationListener(
-              enums.NOTIFICATION_TYPES.DECISION,
+              NOTIFICATION_TYPES.DECISION,
               decisionListener
             );
           });
@@ -6915,7 +6915,7 @@ describe('lib/optimizely', function() {
 
         var decisionListener = sinon.spy();
         var attributes = { test_attribute: 'test_value' };
-        optlyInstance.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, decisionListener);
+        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.DECISION, decisionListener);
         var result = optlyInstance.getEnabledFeatures('test_user', attributes);
         assert.strictEqual(result.length, 5);
         assert.deepEqual(result, [
@@ -10163,7 +10163,7 @@ describe('lib/optimizely', function() {
       it('emits a notification when the project config manager emits a new project config object', function() {
         var listener = sinon.spy();
         optlyInstance.notificationCenter.addNotificationListener(
-          enums.NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
+          NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE,
           listener
         );
         var newConfig = createProjectConfig(testData.getTestProjectConfigWithFeatures());
@@ -10214,7 +10214,7 @@ describe('lib/optimizely', function() {
     it('should trigger a log event notification when an impression event is dispatched', function() {
       var notificationListener = sinon.spy();
       optlyInstance.notificationCenter.addNotificationListener(
-        enums.NOTIFICATION_TYPES.LOG_EVENT,
+        NOTIFICATION_TYPES.LOG_EVENT,
         notificationListener
       );
       fakeDecisionResponse = {
@@ -10232,7 +10232,7 @@ describe('lib/optimizely', function() {
     it('should trigger a log event notification when a conversion event is dispatched', function() {
       var notificationListener = sinon.spy();
       optlyInstance.notificationCenter.addNotificationListener(
-        enums.NOTIFICATION_TYPES.LOG_EVENT,
+        NOTIFICATION_TYPES.LOG_EVENT,
         notificationListener
       );
       optlyInstance.track('testEvent', 'testUser');

--- a/lib/optimizely/index.tests.js
+++ b/lib/optimizely/index.tests.js
@@ -2385,13 +2385,6 @@ describe('lib/optimizely', function() {
         sinon.assert.calledOnce(trackListener);
       });
 
-      it('should only call the listener once after the same listener was added twice', function() {
-        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.notificationCenter.addNotificationListener(NOTIFICATION_TYPES.ACTIVATE, activateListener);
-        optlyInstance.activate('testExperiment', 'testUser');
-        sinon.assert.calledOnce(activateListener);
-      });
-
       it('should not add a listener with an invalid type argument', function() {
         var listenerId = optlyInstance.notificationCenter.addNotificationListener(
           'not a notification type',

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -16,7 +16,7 @@
 
 import { LoggerFacade, ErrorHandler } from '../modules/logging';
 import { sprintf, objectValues } from '../utils/fns';
-import { NotificationCenter } from '../notification_center';
+import { DefaultNotificationCenter, NotificationCenter } from '../notification_center';
 import { EventProcessor } from '../event_processor/event_processor';
 
 import { IOdpManager } from '../odp/odp_manager';
@@ -59,8 +59,8 @@ import {
   DECISION_SOURCES,
   DECISION_MESSAGES,
   FEATURE_VARIABLE_TYPES,
-  DECISION_NOTIFICATION_TYPES,
-  NOTIFICATION_TYPES,
+  // DECISION_NOTIFICATION_TYPES,
+  // NOTIFICATION_TYPES,
   NODE_CLIENT_ENGINE,
   CLIENT_VERSION,
   ODP_DEFAULT_EVENT_TYPE,
@@ -69,7 +69,8 @@ import {
 } from '../utils/enums';
 import { Fn } from '../utils/type';
 import { resolvablePromise } from '../utils/promise/resolvablePromise';
-import { time } from 'console';
+
+import { NOTIFICATION_TYPES, DecisionNotificationType, DECISION_NOTIFICATION_TYPES } from '../notification_center/type';
 
 const MODULE_NAME = 'OPTIMIZELY';
 
@@ -99,7 +100,7 @@ export default class Optimizely implements Client {
   private eventProcessor?: EventProcessor;
   private defaultDecideOptions: { [key: string]: boolean };
   protected odpManager?: IOdpManager;
-  public notificationCenter: NotificationCenter;
+  public notificationCenter: DefaultNotificationCenter;
 
   constructor(config: OptimizelyOptions) {
     let clientEngine = config.clientEngine;
@@ -142,7 +143,7 @@ export default class Optimizely implements Client {
         configObj.projectId
       );
 
-      this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE);
+      this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.OPTIMIZELY_CONFIG_UPDATE, undefined);
 
       this.updateOdpSettings();
     });
@@ -178,7 +179,7 @@ export default class Optimizely implements Client {
       Promise.resolve(undefined);
 
     this.eventProcessor?.onDispatch((event) => {
-      this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, event as any);
+      this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.LOG_EVENT, event);
     });
 
     this.readyPromise = Promise.all([
@@ -415,7 +416,7 @@ export default class Optimizely implements Client {
           experiment,
           this.createInternalUserContext(userId, attributes) as OptimizelyUserContext
         ).result;
-        const decisionNotificationType = projectConfig.isFeatureExperiment(configObj, experiment.id)
+        const decisionNotificationType: DecisionNotificationType = projectConfig.isFeatureExperiment(configObj, experiment.id)
           ? DECISION_NOTIFICATION_TYPES.FEATURE_TEST
           : DECISION_NOTIFICATION_TYPES.AB_TEST;
 

--- a/lib/optimizely_user_context/index.tests.js
+++ b/lib/optimizely_user_context/index.tests.js
@@ -19,7 +19,7 @@ import sinon from 'sinon';
 
 import * as logging from '../modules/logging';
 import { sprintf } from '../utils/fns';
-import { NOTIFICATION_TYPES } from '../utils/enums';
+import { NOTIFICATION_TYPES } from '../notification_center/type';
 
 import OptimizelyUserContext from './';
 import { createLogger } from '../plugins/logger';

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -21,8 +21,7 @@
 
 import { ErrorHandler, LogHandler, LogLevel, LoggerFacade } from './modules/logging';
 
-import { NotificationCenter as NotificationCenterImpl } from './notification_center';
-import { NOTIFICATION_TYPES } from './utils/enums';
+import { NotificationCenter, DefaultNotificationCenter } from './notification_center';
 
 import { IOptimizelyUserContext as OptimizelyUserContext } from './optimizely_user_context';
 
@@ -43,6 +42,8 @@ import { EventProcessor } from './event_processor/event_processor';
 
 export { EventDispatcher } from './event_processor/event_dispatcher/event_dispatcher';
 export { EventProcessor } from './event_processor/event_processor';
+export { NotificationCenter } from './notification_center';
+
 export interface BucketerParams {
   experimentId: string;
   experimentKey: string;
@@ -118,19 +119,6 @@ export interface OdpOptions {
 export interface ListenerPayload {
   userId: string;
   attributes?: UserAttributes;
-}
-
-export type NotificationListener<T extends ListenerPayload> = (notificationData: T) => void;
-
-// NotificationCenter-related types
-export interface NotificationCenter {
-  addNotificationListener<T extends ListenerPayload>(
-    notificationType: string,
-    callback: NotificationListener<T>
-  ): number;
-  removeNotificationListener(listenerId: number): boolean;
-  clearAllNotificationListeners(): void;
-  clearNotificationListeners(notificationType: NOTIFICATION_TYPES): void;
 }
 
 // An event to be submitted to Optimizely, enabling tracking the reach and impact of
@@ -295,7 +283,7 @@ export interface OptimizelyOptions {
   defaultDecideOptions?: OptimizelyDecideOption[];
   isSsr?:boolean;
   odpManager?: IOdpManager;
-  notificationCenter: NotificationCenterImpl;
+  notificationCenter: DefaultNotificationCenter;
 }
 
 /**

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -327,15 +327,15 @@ export const DECISION_MESSAGES = {
  *    - logEvent {Object}
  *
  */
-export enum NOTIFICATION_TYPES {
-  ACTIVATE = 'ACTIVATE:experiment, user_id,attributes, variation, event',
-  DECISION = 'DECISION:type, userId, attributes, decisionInfo',
-  LOG_EVENT = 'LOG_EVENT:logEvent',
-  OPTIMIZELY_CONFIG_UPDATE = 'OPTIMIZELY_CONFIG_UPDATE',
-  TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
-}
+// export enum NOTIFICATION_TYPES {
+//   ACTIVATE = 'ACTIVATE:experiment, user_id,attributes, variation, event',
+//   DECISION = 'DECISION:type, userId, attributes, decisionInfo',
+//   LOG_EVENT = 'LOG_EVENT:logEvent',
+//   OPTIMIZELY_CONFIG_UPDATE = 'OPTIMIZELY_CONFIG_UPDATE',
+//   TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
+// }
 
-
+export { NOTIFICATION_TYPES } from '../../notification_center/type';
 
 /**
  * Default milliseconds before request timeout

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -285,56 +285,6 @@ export const DECISION_MESSAGES = {
   VARIABLE_VALUE_INVALID: 'Variable value for key "%s" is invalid or wrong type.',
 };
 
-/*
- * Notification types for use with NotificationCenter
- * Format is EVENT: <list of parameters to callback>
- *
- * SDK consumers can use these to register callbacks with the notification center.
- *
- *  @deprecated since 3.1.0
- *  ACTIVATE: An impression event will be sent to Optimizely
- *  Callbacks will receive an object argument with the following properties:
- *    - experiment {Object}
- *    - userId {string}
- *    - attributes {Object|undefined}
- *    - variation {Object}
- *    - logEvent {Object}
- *
- *  DECISION: A decision is made in the system. i.e. user activation,
- *  feature access or feature-variable value retrieval
- *  Callbacks will receive an object argument with the following properties:
- *    - type {string}
- *    - userId {string}
- *    - attributes {Object|undefined}
- *    - decisionInfo {Object|undefined}
- *
- *  LOG_EVENT: A batch of events, which could contain impressions and/or conversions,
- *  will be sent to Optimizely
- *  Callbacks will receive an object argument with the following properties:
- *    - url {string}
- *    - httpVerb {string}
- *    - params {Object}
- *
- *  OPTIMIZELY_CONFIG_UPDATE: This Optimizely instance has been updated with a new
- *  config
- *
- *  TRACK: A conversion event will be sent to Optimizely
- *  Callbacks will receive the an object argument with the following properties:
- *    - eventKey {string}
- *    - userId {string}
- *    - attributes {Object|undefined}
- *    - eventTags {Object|undefined}
- *    - logEvent {Object}
- *
- */
-// export enum NOTIFICATION_TYPES {
-//   ACTIVATE = 'ACTIVATE:experiment, user_id,attributes, variation, event',
-//   DECISION = 'DECISION:type, userId, attributes, decisionInfo',
-//   LOG_EVENT = 'LOG_EVENT:logEvent',
-//   OPTIMIZELY_CONFIG_UPDATE = 'OPTIMIZELY_CONFIG_UPDATE',
-//   TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
-// }
-
 export { NOTIFICATION_TYPES } from '../../notification_center/type';
 
 /**

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -335,6 +335,8 @@ export enum NOTIFICATION_TYPES {
   TRACK = 'TRACK:event_key, user_id, attributes, event_tags, event',
 }
 
+
+
 /**
  * Default milliseconds before request timeout
  */

--- a/lib/utils/event_emitter/event_emitter.ts
+++ b/lib/utils/event_emitter/event_emitter.ts
@@ -47,6 +47,10 @@ export class EventEmitter<T> {
     }
   }
 
+  removeListeners<E extends keyof T>(eventName: E): void {
+    this.listeners[eventName]?.clear();
+  }
+
   removeAllListeners(): void {
     this.listeners = {};
   }


### PR DESCRIPTION
## Summary
- the notification center api is basically a slightly different version of the event emitter which we are already using in other components. This PR refactors notification center using the event emitter. This will allow us to achieve a slightly smaller bundle size.

## Test plan
- updated tests accordingly

## Issues
- FSSDK-10989