### PR TITLE
Fix typo for experiment ids array on projectConfig events

### DIFF
--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -63,7 +63,7 @@ interface TryCreatingProjectConfigConfig {
 interface Event {
   key: string;
   id: string;
-  experimentsIds: string[];
+  experimentIds: string[];
 }
 
 interface VariableUsageMap {

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -413,7 +413,7 @@ export type OptimizelyAudience = {
 export type OptimizelyEvent = {
   id: string;
   key: string;
-  experimentsIds: string[];
+  experimentIds: string[];
 };
 
 export interface OptimizelyFeature {


### PR DESCRIPTION
## Summary
- When I was using the optimizely client I saw a problem related to type for the getOptimizelyConfig.events object. Since the type inform that the object is


```ts
export type OptimizelyEvent = {
    id: string;
    key: string;
    experimentsIds: string[];
};
```

but the reality it returns
```ts
export type OptimizelyEvent = {
    id: string;
    key: string;
    experimentIds: string[]; // singular
};
```

![image](https://github.com/user-attachments/assets/df6a8c4d-f8e9-4fa6-989f-961419f7dc9e)


## Test plan

## Issues
- Fixes https://github.com/optimizely/javascript-sdk/issues/991
