### PR TITLE
[FSSDK-11098] setTimeout issue in akamai edge worker fix

### DIFF
--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -584,6 +584,7 @@ describe('javascript-sdk (Browser)', function() {
       const fakeOptimizely = {
         onReady: () => Promise.resolve({ success: true }),
         identifyUser: sinon.stub().returns(),
+        isOdpIntegrated: sinon.stub().returns(true)
       };
 
       const fakeErrorHandler = { handleError: function() {} };

--- a/lib/optimizely_user_context/index.ts
+++ b/lib/optimizely_user_context/index.ts
@@ -63,7 +63,7 @@ export default class OptimizelyUserContext implements IOptimizelyUserContext {
     this.attributes = { ...attributes } ?? {};
     this.forcedDecisionsMap = {};
 
-    if (shouldIdentifyUser) {
+    if (shouldIdentifyUser && optimizely.isOdpIntegrated()) {
       this.optimizely.onReady().then(({ success }) => {
         if (success) {
           this.identifyUser();


### PR DESCRIPTION
## Summary
- If ODP is not integrated, no reason to identify user
- #924 has been addressed
## Test plan
Existing tests should work as expected

## Issues
- [FSSDK-11098](https://jira.sso.episerver.net/browse/FSSDK-11098)