### PR TITLE
[FSSDK-11114] add type test for entrypoints

### DIFF
--- a/lib/common_exports.ts
+++ b/lib/common_exports.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024 Optimizely
+ * Copyright 2023-2025 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,4 +15,23 @@
  */
 
 export { createStaticProjectConfigManager } from './project_config/config_manager_factory';
-export { PollingConfigManagerConfig } from './project_config/config_manager_factory';
+
+export { LogLevel } from './logging/logger';
+
+export {
+  DebugLog,
+  InfoLog,
+  WarnLog,
+  ErrorLog,
+} from './logging/logger_factory';
+
+export { createLogger } from './logging/logger_factory';
+export { createErrorNotifier } from './error/error_notifier_factory';
+
+export { 
+  DECISION_SOURCES,
+  DECISION_NOTIFICATION_TYPES,
+  NOTIFICATION_TYPES,
+} from './utils/enums';
+
+export { OptimizelyDecideOption } from './shared_types';

--- a/lib/entrypoint.test-d.ts
+++ b/lib/entrypoint.test-d.ts
@@ -16,23 +16,91 @@
 
 import { expectTypeOf } from 'vitest';
 
-import * as browserEntrypoint from './index.browser';
-import * as nodeEntrypoint from './index.node';
-import * as reactNativeEntrypoint from './index.react_native';
+import * as browser from './index.browser';
+import * as node from './index.node';
+import * as reactNative from './index.react_native';
 
-import { Config, Client } from './shared_types';
+type WithoutReadonly<T> = { -readonly [P in keyof T]: T[P] };
+
+const nodeEntrypoint: WithoutReadonly<typeof node> = node;
+const browserEntrypoint: WithoutReadonly<typeof browser> = browser;
+const reactNativeEntrypoint: WithoutReadonly<typeof reactNative> = reactNative;
+
+import {
+  Config,
+  Client,
+  StaticConfigManagerConfig,
+  OpaqueConfigManager,
+  PollingConfigManagerConfig,
+  EventDispatcher,
+  OpaqueEventProcessor,
+  BatchEventProcessorOptions,
+  OdpManagerOptions,
+  OpaqueOdpManager,
+  VuidManagerOptions,
+  OpaqueVuidManager,
+  OpaqueLevelPreset,
+  LoggerConfig,
+  OpaqueLogger,
+  ErrorHandler,
+  OpaqueErrorNotifier,
+} from './export_types';
+
+import {
+  DECISION_SOURCES,
+  DECISION_NOTIFICATION_TYPES,
+  NOTIFICATION_TYPES,
+} from './utils/enums';
+
+import { LogLevel } from './logging/logger';
+
+import { OptimizelyDecideOption } from './shared_types';
 
 export type Entrypoint = {
+  // client factory
   createInstance: (config: Config) => Client | null;
+
+  // config manager related exports
+  createStaticProjectConfigManager: (config: StaticConfigManagerConfig) => OpaqueConfigManager;
+  createPollingProjectConfigManager: (config: PollingConfigManagerConfig) => OpaqueConfigManager;
+
+  // event processor related exports
+  eventDispatcher: EventDispatcher;
+  getSendBeaconEventDispatcher: () => EventDispatcher;
+  createForwardingEventProcessor: (eventDispatcher?: EventDispatcher) => OpaqueEventProcessor;
+  createBatchEventProcessor: (options: BatchEventProcessorOptions) => OpaqueEventProcessor;
+
+  // odp manager related exports
+  createOdpManager: (options: OdpManagerOptions) => OpaqueOdpManager;
+
+  // vuid manager related exports
+  createVuidManager: (options: VuidManagerOptions) => OpaqueVuidManager;
+
+  // logger related exports
+  LogLevel: typeof LogLevel;
+  DebugLog: OpaqueLevelPreset,
+  InfoLog: OpaqueLevelPreset,
+  WarnLog: OpaqueLevelPreset,
+  ErrorLog: OpaqueLevelPreset,
+  createLogger: (config: LoggerConfig) => OpaqueLogger;
+
+  // error related exports
+  createErrorNotifier: (errorHandler: ErrorHandler) => OpaqueErrorNotifier;
+
+  // enums
+  DECISION_SOURCES: typeof DECISION_SOURCES;
+  DECISION_NOTIFICATION_TYPES: typeof DECISION_NOTIFICATION_TYPES;
+  NOTIFICATION_TYPES: typeof NOTIFICATION_TYPES;
+
+  // decide options
+  OptimizelyDecideOption: typeof OptimizelyDecideOption;
 }
 
 
-// these type tests will be fixed in a future PR
+expectTypeOf(browserEntrypoint).toEqualTypeOf<Entrypoint>();
+expectTypeOf(nodeEntrypoint).toEqualTypeOf<Entrypoint>();
+expectTypeOf(reactNativeEntrypoint).toEqualTypeOf<Entrypoint>();
 
-// expectTypeOf(browserEntrypoint).toEqualTypeOf<Entrypoint>();
-// expectTypeOf(nodeEntrypoint).toEqualTypeOf<Entrypoint>();
-// expectTypeOf(reactNativeEntrypoint).toEqualTypeOf<Entrypoint>();
-
-// expectTypeOf(browserEntrypoint).toEqualTypeOf(nodeEntrypoint);
-// expectTypeOf(browserEntrypoint).toEqualTypeOf(reactNativeEntrypoint);
-// expectTypeOf(nodeEntrypoint).toEqualTypeOf(reactNativeEntrypoint);
+expectTypeOf(browserEntrypoint).toEqualTypeOf(nodeEntrypoint);
+expectTypeOf(browserEntrypoint).toEqualTypeOf(reactNativeEntrypoint);
+expectTypeOf(nodeEntrypoint).toEqualTypeOf(reactNativeEntrypoint);

--- a/lib/export_types.ts
+++ b/lib/export_types.ts
@@ -14,11 +14,62 @@
  * limitations under the License.
  */
 
-/**
- * This file contains a collection of all types to be externally exported.
- */
+// config manager related types
+export type { 
+  StaticConfigManagerConfig,
+  PollingConfigManagerConfig,
+  OpaqueConfigManager,
+} from './project_config/config_manager_factory';
 
-export {
+// event processor related types
+export type { 
+  LogEvent,
+  EventDispatcherResponse,
+  EventDispatcher,
+} from './event_processor/event_dispatcher/event_dispatcher';
+
+export type {
+  BatchEventProcessorOptions,
+  OpaqueEventProcessor,
+} from './event_processor/event_processor_factory';
+
+// Odp manager related types
+export type {
+  OdpManagerOptions,
+  OpaqueOdpManager,
+} from './odp/odp_manager_factory';
+
+// Vuid manager related types
+export type {
+  VuidManagerOptions,
+  OpaqueVuidManager,
+} from './vuid/vuid_manager_factory';
+
+// Logger related types
+export type {
+  LogHandler,
+} from './logging/logger';
+
+export type {
+  OpaqueLevelPreset,
+  LoggerConfig,
+  OpaqueLogger,
+} from './logging/logger_factory';
+
+// Error related types
+export type { ErrorHandler } from './error/error_handler';
+export type { OpaqueErrorNotifier } from './error/error_notifier_factory';
+
+export type { Cache } from './utils/cache/cache';
+
+export type {
+  NotificationType,
+  NotificationPayload,
+} from './notification_center/type';
+
+export type { OptimizelyDecideOption } from './shared_types';
+
+export type {
   UserAttributeValue,
   UserAttributes,
   OptimizelyConfig,
@@ -31,7 +82,6 @@ export {
   OptimizelyForcedDecision,
   EventTags,
   Event,
-  EventDispatcher,
   DatafileOptions,
   UserProfileService,
   UserProfile,

--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2019-2024 Optimizely
+ * Copyright 2016-2017, 2019-2025 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import configValidator from './utils/config_validator';
-import defaultEventDispatcher from './event_processor/event_dispatcher/default_dispatcher.browser';
+import { Config, Client } from './shared_types';
 import sendBeaconEventDispatcher from './event_processor/event_dispatcher/send_beacon_dispatcher.browser';
-import * as enums from './utils/enums';
-import { OptimizelyDecideOption, Client, Config } from './shared_types';
-import Optimizely from './optimizely';
-import { UserAgentParser } from './odp/ua_parser/user_agent_parser';
-import { getUserAgentParser } from './odp/ua_parser/ua_parser.browser';
-import * as commonExports from './common_exports';
-import { PollingConfigManagerConfig } from './project_config/config_manager_factory';
-import { createPollingProjectConfigManager } from './project_config/config_manager_factory.browser';
-import { createBatchEventProcessor, createForwardingEventProcessor } from './event_processor/event_processor_factory.browser';
-import { createVuidManager } from './vuid/vuid_manager_factory.browser';
-import { createOdpManager } from './odp/odp_manager_factory.browser';
-import { UNABLE_TO_ATTACH_UNLOAD } from 'error_message';
-import { extractLogger, createLogger } from './logging/logger_factory';
-import { extractErrorNotifier, createErrorNotifier } from './error/error_notifier_factory';
-import { LoggerFacade } from './logging/logger';
-import { Maybe } from './utils/type';
 import { getOptimizelyInstance } from './client_factory';
-
+import { EventDispatcher } from './event_processor/event_dispatcher/event_dispatcher';
 
 /**
  * Creates an instance of the Optimizely class
@@ -42,7 +24,7 @@ import { getOptimizelyInstance } from './client_factory';
  * @return {Client|null} the Optimizely client object
  *                           null on error
  */
-const createInstance = function(config: Config): Client | null {
+export const createInstance = function(config: Config): Client | null {
   const client = getOptimizelyInstance(config);
 
   if (client) {
@@ -58,23 +40,17 @@ const createInstance = function(config: Config): Client | null {
   return client;
 };
 
-
-export {
-  defaultEventDispatcher as eventDispatcher,
-  // sendBeaconEventDispatcher,
-  enums,
-  createInstance,
-  OptimizelyDecideOption,
-  UserAgentParser as IUserAgentParser,
-  getUserAgentParser,
-  createPollingProjectConfigManager,
-  createForwardingEventProcessor,
-  createBatchEventProcessor,
-  createOdpManager,
-  createVuidManager,
-  createLogger,
-  createErrorNotifier,
+export const getSendBeaconEventDispatcher = (): EventDispatcher => {
+  return sendBeaconEventDispatcher;
 };
+
+export { default as eventDispatcher } from './event_processor/event_dispatcher/default_dispatcher.browser';
+
+export { createPollingProjectConfigManager } from './project_config/config_manager_factory.browser';
+export { createForwardingEventProcessor, createBatchEventProcessor } from './event_processor/event_processor_factory.browser';
+
+export { createOdpManager } from './odp/odp_manager_factory.browser';
+export { createVuidManager } from './vuid/vuid_manager_factory.browser';
 
 export * from './common_exports';
 

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017, 2019-2024 Optimizely
+ * Copyright 2016-2017, 2019-2025 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import * as enums from './utils/enums';
-import defaultEventDispatcher from './event_processor/event_dispatcher/default_dispatcher.node';
-import { createNotificationCenter } from './notification_center';
-import { OptimizelyDecideOption, Client, Config } from './shared_types';
-import * as commonExports from './common_exports';
-import { createPollingProjectConfigManager } from './project_config/config_manager_factory.node';
-import { createForwardingEventProcessor, createBatchEventProcessor } from './event_processor/event_processor_factory.node';
-import { createVuidManager } from './vuid/vuid_manager_factory.node';
-import { createOdpManager } from './odp/odp_manager_factory.node';
-import { extractLogger, createLogger } from './logging/logger_factory';
-import { extractErrorNotifier, createErrorNotifier } from './error/error_notifier_factory';
-import { Maybe } from './utils/type';
-import { LoggerFacade } from './logging/logger';
-import { ErrorNotifier } from './error/error_notifier';
+import { NODE_CLIENT_ENGINE } from './utils/enums';
+import { Client, Config } from './shared_types';
 import { getOptimizelyInstance } from './client_factory';
+import { EventDispatcher } from './event_processor/event_dispatcher/event_dispatcher';
 
 /**
  * Creates an instance of the Optimizely class
@@ -36,33 +24,27 @@ import { getOptimizelyInstance } from './client_factory';
  * @return {Client|null} the Optimizely client object
  *                           null on error
  */
-const createInstance = function(config: Config): Client | null {
+export const createInstance = function(config: Config): Client | null {
   const nodeConfig = {
     ...config,
-    clientEnging: config.clientEngine || enums.NODE_CLIENT_ENGINE,
+    clientEnging: config.clientEngine || NODE_CLIENT_ENGINE,
   }
 
   return getOptimizelyInstance(nodeConfig);
 };
 
-/**
- * Entry point into the Optimizely Node testing SDK
- */
-export {
-  defaultEventDispatcher as eventDispatcher,
-  enums,
-  createInstance,
-  OptimizelyDecideOption,
-  createPollingProjectConfigManager,
-  createForwardingEventProcessor,
-  createBatchEventProcessor,
-  createOdpManager,
-  createVuidManager,
-  createLogger,
-  createErrorNotifier,
+export const getSendBeaconEventDispatcher = function(): EventDispatcher {
+  throw new Error('Send beacon event dispatcher is not supported in NodeJS');
 };
 
-export * from './common_exports';
+export { default as eventDispatcher } from './event_processor/event_dispatcher/default_dispatcher.node';
 
+export { createPollingProjectConfigManager } from './project_config/config_manager_factory.node';
+export { createForwardingEventProcessor, createBatchEventProcessor } from './event_processor/event_processor_factory.node';
+
+export { createOdpManager } from './odp/odp_manager_factory.node';
+export { createVuidManager } from './vuid/vuid_manager_factory.node';
+
+export * from './common_exports';
 
 export * from './export_types';

--- a/lib/index.react_native.ts
+++ b/lib/index.react_native.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, Optimizely
+ * Copyright 2019-2025, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Optimizely from './optimizely';
-import configValidator from './utils/config_validator';
-import defaultEventDispatcher from './event_processor/event_dispatcher/default_dispatcher.browser';
-import { createNotificationCenter } from './notification_center';
-import { OptimizelyDecideOption, Client, Config } from './shared_types';
-import * as commonExports from './common_exports';
-import { createPollingProjectConfigManager } from './project_config/config_manager_factory.react_native';
-import { createBatchEventProcessor, createForwardingEventProcessor } from './event_processor/event_processor_factory.react_native';
-import { createOdpManager } from './odp/odp_manager_factory.react_native';
-import { createVuidManager } from './vuid/vuid_manager_factory.react_native';
-
 import 'fast-text-encoding';
 import 'react-native-get-random-values';
-import { Maybe } from './utils/type';
-import { LoggerFacade } from './logging/logger';
-import { extractLogger, createLogger } from './logging/logger_factory';
-import { extractErrorNotifier, createErrorNotifier } from './error/error_notifier_factory';
+
+import { Client, Config } from './shared_types';
 import { getOptimizelyInstance } from './client_factory';
 import { REACT_NATIVE_JS_CLIENT_ENGINE } from './utils/enums';
+import { EventDispatcher } from './event_processor/event_dispatcher/event_dispatcher';
 
 /**
  * Creates an instance of the Optimizely class
@@ -39,7 +27,7 @@ import { REACT_NATIVE_JS_CLIENT_ENGINE } from './utils/enums';
  * @return {Client|null} the Optimizely client object
  *                           null on error
  */
-const createInstance = function(config: Config): Client | null {
+export const createInstance = function(config: Config): Client | null {
   const rnConfig = {
     ...config,
     clientEngine: config.clientEngine || REACT_NATIVE_JS_CLIENT_ENGINE,
@@ -48,21 +36,17 @@ const createInstance = function(config: Config): Client | null {
   return getOptimizelyInstance(rnConfig);
 };
 
-/**
- * Entry point into the Optimizely Javascript SDK for React Native
- */
-export {
-  defaultEventDispatcher as eventDispatcher,
-  createInstance,
-  OptimizelyDecideOption,
-  createPollingProjectConfigManager,
-  createForwardingEventProcessor,
-  createBatchEventProcessor,
-  createOdpManager,
-  createVuidManager,
-  createLogger,
-  createErrorNotifier,
+export const getSendBeaconEventDispatcher = function(): EventDispatcher {
+  throw new Error('Send beacon event dispatcher is not supported in React Native');
 };
+
+export { default as eventDispatcher } from './event_processor/event_dispatcher/default_dispatcher.browser';
+
+export { createPollingProjectConfigManager } from './project_config/config_manager_factory.react_native';
+export { createForwardingEventProcessor, createBatchEventProcessor } from './event_processor/event_processor_factory.react_native';
+
+export { createOdpManager } from './odp/odp_manager_factory.react_native';
+export { createVuidManager } from './vuid/vuid_manager_factory.react_native';
 
 export * from './common_exports';
 

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -324,7 +324,6 @@ export interface Client {
   onReady(options?: { timeout?: number }): Promise<unknown>;
   close(): Promise<unknown>;
   sendOdpEvent(action: string, type?: string, identifiers?: Map<string, string>, data?: Map<string, unknown>): void;
-  getProjectConfig(): ProjectConfig | null;
   isOdpIntegrated(): boolean;
 }
 


### PR DESCRIPTION
## Summary
- add vitest [type tests](https://vitest.dev/guide/testing-types) for the entrypoints to ensure that all three entrypoints export the same api


## Test plan
- added type test for entrypoints

## Issues
- FSSDK-11114
