### PR TITLE
[FSSDK-11073] Update GHA workflow to publish in GPR

### DIFF
--- a/.github/workflows/common_publish.yml
+++ b/.github/workflows/common_publish.yml
@@ -1,0 +1,83 @@
+name: Common Publish Steps
+
+on:
+  workflow_call:
+    inputs:
+      registry-url:
+        required: true
+        type: string
+      node-auth-token:
+        required: true
+        type: string
+      browserstack-username:
+        required: true
+        type: string
+      browserstack-access-key:
+        required: true
+        type: string
+
+jobs:
+  common-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: ${{ inputs.registry-url }}
+          always-auth: true
+        env:
+          NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - id: latest-release
+        name: Export latest release git tag
+        run: |
+          echo "latest-release-tag=$(curl -qsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/latest" \
+          | jq -r .tag_name)" >> $GITHUB_OUTPUT
+
+      - id: npm-tag
+        name: Determine NPM tag
+        env:
+          GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          LATEST_RELEASE_TAG="${{ steps.latest-release.outputs['latest-release-tag']}}"
+          
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          else
+            RELEASE_TAG=$GITHUB_RELEASE_TAG
+          fi
+
+          if [[ $RELEASE_TAG == $LATEST_RELEASE_TAG ]]; then
+            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-beta"* ]]; then
+            echo "npm-tag=beta" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-alpha"* ]]; then
+            echo "npm-tag=alpha" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == *"-rc"* ]]; then
+            echo "npm-tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm-tag=v$(echo $VERSION | awk -F. '{print $1}')-latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: release
+        name: Test, build and publish
+        env:
+          BROWSERSTACK_USERNAME: ${{ inputs.browserstack-username }}
+          BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }}
+          NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+        run: |
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            DRY_RUN="--dry-run"
+          fi
+          npm publish --tag=${{ steps.npm-tag.outputs['npm-tag'] }} --registry=${{ inputs.registry-url }} $DRY_RUN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,80 +1,25 @@
-name: Publish SDK to NPM
+name: Publish SDK to NPM and GPR
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
   workflow_dispatch: {}
 
 jobs:
-  publish:
+  publish_to_npm:
     name: Publish to NPM
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.draft }}
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
+    uses: ./.github/workflows/common_publish.yml
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+      node-auth-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      browserstack-username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: "https://registry.npmjs.org/"
-          always-auth: "true"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
-      - name: Install dependencies
-        run: npm install
-
-      - id: latest-release
-        name: Export latest release git tag
-        run: |
-          echo "latest-release-tag=$(curl -qsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/releases/latest" \
-          | jq -r .tag_name)" >> $GITHUB_OUTPUT
-
-      - id: npm-tag
-        name: Determine NPM tag
-        run: |
-          VERSION=$(jq -r '.version' package.json)
-          LATEST_RELEASE_TAG="${{ steps.latest-release.outputs['latest-release-tag']}}"
-
-          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            GITHUB_REF=${{ github.ref }}
-            RELEASE_TAG=${GITHUB_REF#refs/tags/}
-          else
-            RELEASE_TAG="${{ github.event.release.tag_name }}"
-          fi
-
-          if [[ $RELEASE_TAG == $LATEST_RELEASE_TAG ]]; then
-            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "$VERSION" == *"-beta"* ]]; then
-            echo "npm-tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$VERSION" == *"-alpha"* ]]; then
-            echo "npm-tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$VERSION" == *"-rc"* ]]; then
-            echo "npm-tag=rc" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm-tag=v$(echo $VERSION | awk -F. '{print $1}')-latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - id: release
-        name: Test, build and publish to npm
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: |
-          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            DRY_RUN="--dry-run"
-          fi
-          npm publish --tag=${{ steps.npm-tag.outputs['npm-tag'] }} $DRY_RUN
-
-      # - name: Report results to Jellyfish
-      #   uses: optimizely/jellyfish-deployment-reporter-action@main
-      #   if: ${{ always() && github.event_name == 'release' && (steps.release.outcome == 'success' || steps.release.outcome == 'failure') }}
-      #   with:
-      #     jellyfish_api_token: ${{ secrets.JELLYFISH_API_TOKEN }}
-      #     is_successful: ${{ steps.release.outcome == 'success' }}
+  publish_to_gpr:
+    name: Publish to GitHub Package Registry
+    uses: ./.github/workflows/common-publish.yml
+    with:
+      registry-url: 'https://npm.pkg.github.com/'
+      node-auth-token: ${{ secrets.GITHUB_TOKEN }}
+      browserstack-username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow to publish the JavaScript SDK to GitHub Package Registry (GPR).

## Test plan

- Verify that the JavaScript SDK is successfully published to GPR.
- Confirm that internal projects can install the SDK from GPR.
- Run all end-to-end tests to ensure no regressions.

## Issues
[FSSDK-11073](https://jira.sso.episerver.net/browse/FSSDK-11073)


[FSSDK-11073]: https://optimizely-ext.atlassian.net/browse/FSSDK-11073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ