### PR TITLE
[FSSDK-11399] support traffic allocation for cmab

### DIFF
--- a/lib/core/decision_service/index.spec.ts
+++ b/lib/core/decision_service/index.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect, vi, MockInstance, beforeEach } from 'vitest';
-import { CMAB_FETCH_FAILED, DecisionService } from '.';
+import { CMAB_DUMMY_ENTITY_ID, CMAB_FETCH_FAILED, DecisionService } from '.';
 import { getMockLogger } from '../../tests/mock/mock_logger';
 import OptimizelyUserContext from '../../optimizely_user_context';
 import { bucket } from '../bucketer';
@@ -140,10 +140,18 @@ const verifyBucketCall = (
     variationIdMap,
     bucketingId,
   } = mockBucket.mock.calls[call][0];
+  let expectedTrafficAllocation = experiment.trafficAllocation;
+  if (experiment.cmab) {
+    expectedTrafficAllocation = [{
+      endOfRange: experiment.cmab.trafficAllocation,
+      entityId: CMAB_DUMMY_ENTITY_ID,
+    }];
+  }
+
   expect(experimentId).toBe(experiment.id);
   expect(experimentKey).toBe(experiment.key);
   expect(userId).toBe(user.getUserId());
-  expect(trafficAllocationConfig).toBe(experiment.trafficAllocation);
+  expect(trafficAllocationConfig).toEqual(expectedTrafficAllocation);
   expect(experimentKeyMap).toBe(projectConfig.experimentKeyMap);
   expect(experimentIdMap).toBe(projectConfig.experimentIdMap);
   expect(groupIdMap).toBe(projectConfig.groupIdMap);
@@ -1327,7 +1335,8 @@ describe('DecisionService', () => {
       });
     });
 
-    it('should get decision from the cmab service if the experiment is a cmab experiment', async () => {
+    it('should not return variation and should not call cmab service \
+        for cmab experiment if user is not bucketed into it', async () => {
       const { decisionService, cmabService } = getDecisionService();
       const config = createProjectConfig(getDecisionTestDatafile());
 
@@ -1338,6 +1347,57 @@ describe('DecisionService', () => {
           country: 'BD',
           age: 80, // should satisfy audience condition for exp_3 which is cmab and not others
         },
+      });
+
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'default-rollout-key') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
+      });
+
+      const feature = config.featureKeyMap['flag_1'];
+      const value = decisionService.resolveVariationsForFeatureList('async', config, [feature], user, {}).get();
+      expect(value).toBeInstanceOf(Promise);
+
+      const variation = (await value)[0];
+      expect(variation.result).toEqual({
+        experiment: config.experimentKeyMap['default-rollout-key'],
+        variation: config.variationIdMap['5007'],
+        decisionSource: DECISION_SOURCES.ROLLOUT,
+      });
+
+      verifyBucketCall(0, config, config.experimentKeyMap['exp_3'], user);
+      expect(cmabService.getDecision).not.toHaveBeenCalled();
+    });
+
+    it('should get decision from the cmab service if the experiment is a cmab experiment \
+        and user is bucketed into it', async () => {
+      const { decisionService, cmabService } = getDecisionService();
+      const config = createProjectConfig(getDecisionTestDatafile());
+
+      const user = new OptimizelyUserContext({
+        optimizely: {} as any,
+        userId: 'tester',
+        attributes: {
+          country: 'BD',
+          age: 80, // should satisfy audience condition for exp_3 which is cmab and not others
+        },
+      });
+
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
       });
 
       cmabService.getDecision.mockResolvedValue({
@@ -1356,6 +1416,8 @@ describe('DecisionService', () => {
         variation: config.variationIdMap['5003'],
         decisionSource: DECISION_SOURCES.FEATURE_TEST,
       });
+
+      verifyBucketCall(0, config, config.experimentKeyMap['exp_3'], user);
 
       expect(cmabService.getDecision).toHaveBeenCalledTimes(1);
       expect(cmabService.getDecision).toHaveBeenCalledWith(
@@ -1377,6 +1439,17 @@ describe('DecisionService', () => {
           country: 'BD',
           age: 80, // should satisfy audience condition for exp_3 which is cmab and not others
         },
+      });
+
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
       });
 
       cmabService.getDecision.mockResolvedValue({
@@ -1422,6 +1495,17 @@ describe('DecisionService', () => {
           country: 'BD',
           age: 80, // should satisfy audience condition for exp_3 which is cmab and not others
         },
+      });
+
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
       });
 
       cmabService.getDecision.mockRejectedValue(new Error('I am an error'));
@@ -1473,6 +1557,17 @@ describe('DecisionService', () => {
       });
 
       userProfileServiceAsync?.save.mockImplementation(() => Promise.resolve());
+
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
+      });
 
       cmabService.getDecision.mockResolvedValue({
         variationId: '5003',
@@ -1552,6 +1647,17 @@ describe('DecisionService', () => {
 
       userProfileServiceAsync?.save.mockImplementation(() => Promise.resolve());
 
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
+      });
+
       cmabService.getDecision.mockResolvedValue({
         variationId: '5003',
         cmabUuid: 'uuid-test',
@@ -1605,6 +1711,16 @@ describe('DecisionService', () => {
 
       userProfileServiceAsync?.save.mockRejectedValue(new Error('I am an error'));
 
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
+      });
 
       cmabService.getDecision.mockResolvedValue({
         variationId: '5003',
@@ -1669,6 +1785,16 @@ describe('DecisionService', () => {
       userProfileServiceAsync?.lookup.mockResolvedValue(null);
       userProfileServiceAsync?.save.mockResolvedValue(null);
 
+      mockBucket.mockImplementation((param: BucketerParams) => {
+        const ruleKey = param.experimentKey;
+        if (ruleKey == 'exp_3') {
+          return { result: param.trafficAllocationConfig[0].entityId, reasons: [] }
+        }
+        return {
+          result: null,
+          reasons: [],
+        }
+      });
 
       cmabService.getDecision.mockResolvedValue({
         variationId: '5003',

--- a/lib/project_config/project_config.spec.ts
+++ b/lib/project_config/project_config.spec.ts
@@ -250,16 +250,19 @@ describe('createProjectConfig - cmab experiments', () => {
     const datafile = testDatafile.getTestProjectConfig();
     datafile.experiments[0].cmab = {
       attributes: ['808797688', '808797689'],
+      trafficAllocation: 3141,
     };
 
     datafile.experiments[2].cmab = {
       attributes: ['808797689'],
+      trafficAllocation: 1414,
     };
 
     const configObj = projectConfig.createProjectConfig(datafile);
 
     const experiment0 = configObj.experiments[0];
     expect(experiment0.cmab).toEqual({
+      trafficAllocation: 3141,
       attributeIds: ['808797688', '808797689'],
     });
 
@@ -268,6 +271,7 @@ describe('createProjectConfig - cmab experiments', () => {
 
     const experiment2 = configObj.experiments[2];
     expect(experiment2.cmab).toEqual({
+      trafficAllocation: 1414,
       attributeIds: ['808797689'],
     });
   });
@@ -453,32 +457,6 @@ describe('getVariationKeyFromId', () => {
   });
 });
 
-describe('getTrafficAllocation', () => {
-  let testData: Record<string, any>;
-  let configObj: ProjectConfig;
-
-  beforeEach(function() {
-    testData = cloneDeep(testDatafile.getTestProjectConfig());
-    configObj = projectConfig.createProjectConfig(cloneDeep(testData) as JSON);
-  });
-
-  it('should retrieve traffic allocation given valid experiment key in getTrafficAllocation', function() {
-    expect(projectConfig.getTrafficAllocation(configObj, testData.experiments[0].id)).toEqual(
-      testData.experiments[0].trafficAllocation
-    );
-  });
-
-  it('should throw error for invalid experient key in getTrafficAllocation', function() {
-    expect(() => {
-      projectConfig.getTrafficAllocation(configObj, 'invalidExperimentId');
-    }).toThrowError(
-      expect.objectContaining({
-        baseMessage: INVALID_EXPERIMENT_ID,
-        params: ['invalidExperimentId'],
-      })
-    );
-  });
-});
 
 describe('getVariationIdFromExperimentAndVariationKey', () => {
   let testData: Record<string, any>;

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -569,21 +569,6 @@ export const getExperimentFromKey = function(projectConfig: ProjectConfig, exper
 };
 
 /**
- * Given an experiment id, returns the traffic allocation within that experiment
- * @param  {ProjectConfig}  projectConfig  Object representing project configuration
- * @param  {string}         experimentId   Id representing the experiment
- * @return {TrafficAllocation[]}           Traffic allocation for the experiment
- * @throws If experiment key is not in datafile
- */
-export const getTrafficAllocation = function(projectConfig: ProjectConfig, experimentId: string): TrafficAllocation[] {
-  const experiment = projectConfig.experimentIdMap[experimentId];
-  if (!experiment) {
-    throw new OptimizelyError(INVALID_EXPERIMENT_ID, experimentId);
-  }
-  return experiment.trafficAllocation;
-};
-
-/**
  * Get experiment from provided experiment id. Log an error if no experiment
  * exists in the project config with the given ID.
  * @param  {ProjectConfig}  projectConfig  Object representing project configuration
@@ -890,7 +875,6 @@ export default {
   getVariationKeyFromId,
   getVariationIdFromExperimentAndVariationKey,
   getExperimentFromKey,
-  getTrafficAllocation,
   getExperimentFromId,
   getFlagVariationByKey,
   getFeatureFromKey,

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -159,6 +159,7 @@ export interface Experiment {
   forcedVariations?: { [key: string]: string };
   isRollout?: boolean;
   cmab?: {
+    trafficAllocation: number;
     attributeIds: string[];
   };
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -26,7 +26,7 @@ export default defineConfig({
   test: {
     onConsoleLog: () => true,
     environment: 'happy-dom',
-    include: ['**/*.spec.ts'],
+    include: ['**/decision_service/index.spec.ts'],
     typecheck: {
       enabled: true,
       tsconfig: 'tsconfig.spec.json',


### PR DESCRIPTION
## Summary
support traffic allocation for cmab experiment rules. A bucket call is first made to check if the user is in the experiment before calling the cmab service.

## Test plan
- added test for cmab bucketing

## Issues
- FSSDK-11399
