### PR TITLE
[FSSDK-11483] content-length header removal from browser

### DIFF
--- a/lib/event_processor/event_dispatcher/default_dispatcher.spec.ts
+++ b/lib/event_processor/event_dispatcher/default_dispatcher.spec.ts
@@ -69,8 +69,7 @@ describe('DefaultEventDispatcher', () => {
     expect(requestHnadler.makeRequest).toHaveBeenCalledWith(
       eventObj.url,
       {
-        'content-type': 'application/json',
-        'content-length': JSON.stringify(eventObj.params).length.toString(),
+        'content-type': 'application/json'
       },
       'POST',
       JSON.stringify(eventObj.params)

--- a/lib/event_processor/event_dispatcher/default_dispatcher.ts
+++ b/lib/event_processor/event_dispatcher/default_dispatcher.ts
@@ -37,7 +37,6 @@ export class DefaultEventDispatcher implements EventDispatcher {
   
     const headers = {
       'content-type': 'application/json',
-      'content-length': dataString.length.toString(),
     };
   
     const abortableRequest = this.requestHandler.makeRequest(eventObj.url, headers, 'POST', dataString);

--- a/lib/utils/http_request_handler/request_handler.node.ts
+++ b/lib/utils/http_request_handler/request_handler.node.ts
@@ -59,6 +59,7 @@ export class NodeRequestHandler implements RequestHandler {
       headers: {
         ...headers,
         'accept-encoding': 'gzip,deflate',
+        'content-length': String(data?.length || 0)
       },
       timeout: this.timeout,
     });


### PR DESCRIPTION
## Summary
`content-length` header has been moved to Node from common (Browser & Node).


## Test plan
Existing test has been modified accordingly

## Issues
[FSSDK-11483](https://jira.sso.episerver.net/browse/FSSDK-11483)