### PR TITLE
[FSSDK-11510] refactor unsupported factories to not throw

### DIFF
--- a/lib/entrypoint.test-d.ts
+++ b/lib/entrypoint.test-d.ts
@@ -55,6 +55,7 @@ import { NOTIFICATION_TYPES, DECISION_NOTIFICATION_TYPES } from './notification_
 import { LogLevel } from './logging/logger';
 
 import { OptimizelyDecideOption } from './shared_types';
+import { Maybe } from './utils/type';
 
 export type Entrypoint = {
   // client factory
@@ -66,7 +67,7 @@ export type Entrypoint = {
 
   // event processor related exports
   eventDispatcher: EventDispatcher;
-  getSendBeaconEventDispatcher: () => EventDispatcher;
+  getSendBeaconEventDispatcher: () => Maybe<EventDispatcher>;
   createForwardingEventProcessor: (eventDispatcher?: EventDispatcher) => OpaqueEventProcessor;
   createBatchEventProcessor: (options?: BatchEventProcessorOptions) => OpaqueEventProcessor;
 

--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -45,7 +45,7 @@ export const createInstance = function(config: Config): Client | null {
   return client;
 };
 
-export const getSendBeaconEventDispatcher = (): EventDispatcher => {
+export const getSendBeaconEventDispatcher = (): EventDispatcher | undefined => {
   return sendBeaconEventDispatcher;
 };
 

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -35,8 +35,8 @@ export const createInstance = function(config: Config): Client | null {
   return getOptimizelyInstance(nodeConfig);
 };
 
-export const getSendBeaconEventDispatcher = function(): EventDispatcher {
-  throw new Error('Send beacon event dispatcher is not supported in NodeJS');
+export const getSendBeaconEventDispatcher = function(): EventDispatcher | undefined {
+  return undefined;
 };
 
 export { default as eventDispatcher } from './event_processor/event_dispatcher/default_dispatcher.node';

--- a/lib/index.react_native.ts
+++ b/lib/index.react_native.ts
@@ -38,8 +38,8 @@ export const createInstance = function(config: Config): Client | null {
   return getOptimizelyInstance(rnConfig);
 };
 
-export const getSendBeaconEventDispatcher = function(): EventDispatcher {
-  throw new Error('Send beacon event dispatcher is not supported in React Native');
+export const getSendBeaconEventDispatcher = function(): EventDispatcher | undefined {
+  return undefined;
 };
 
 export { default as eventDispatcher } from './event_processor/event_dispatcher/default_dispatcher.browser';

--- a/lib/vuid/vuid_manager_factory.browser.spec.ts
+++ b/lib/vuid/vuid_manager_factory.browser.spec.ts
@@ -35,7 +35,7 @@ import { LocalStorageCache } from '../utils/cache/local_storage_cache.browser';
 import { DefaultVuidManager, VuidCacheManager } from './vuid_manager';
 import { extractVuidManager } from './vuid_manager_factory';
 
-describe('extractVuidManager(createVuidManager', () => {
+describe('createVuidManager', () => {
   const MockVuidCacheManager = vi.mocked(VuidCacheManager);
   const MockLocalStorageCache = vi.mocked(LocalStorageCache);
   const MockDefaultVuidManager = vi.mocked(DefaultVuidManager);

--- a/lib/vuid/vuid_manager_factory.node.spec.ts
+++ b/lib/vuid/vuid_manager_factory.node.spec.ts
@@ -17,11 +17,11 @@
 import { vi, describe, expect, it } from 'vitest';
 
 import { createVuidManager } from './vuid_manager_factory.node';
-import { VUID_IS_NOT_SUPPORTED_IN_NODEJS } from './vuid_manager_factory.node';
+import { extractVuidManager } from './vuid_manager_factory';
 
 describe('createVuidManager', () => {
-  it('should throw an error', () => {
-    expect(() => createVuidManager({ enableVuid: true }))
-      .toThrowError(VUID_IS_NOT_SUPPORTED_IN_NODEJS);
+  it('should return a undefined vuid manager wrapped as OpaqueVuidManager', () => {
+    expect(extractVuidManager(createVuidManager({ enableVuid: true })))
+      .toBeUndefined();
   });
 });

--- a/lib/vuid/vuid_manager_factory.node.ts
+++ b/lib/vuid/vuid_manager_factory.node.ts
@@ -13,11 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { VuidManager } from './vuid_manager';
-import { OpaqueVuidManager, VuidManagerOptions } from './vuid_manager_factory';
-
-export const VUID_IS_NOT_SUPPORTED_IN_NODEJS= 'VUID is not supported in Node.js environment';
+import { OpaqueVuidManager, VuidManagerOptions, wrapVuidManager } from './vuid_manager_factory';
 
 export const createVuidManager = (options: VuidManagerOptions = {}): OpaqueVuidManager => {
-  throw new Error(VUID_IS_NOT_SUPPORTED_IN_NODEJS);
+  return wrapVuidManager(undefined);
 };

--- a/lib/vuid/vuid_manager_factory.ts
+++ b/lib/vuid/vuid_manager_factory.ts
@@ -15,6 +15,7 @@
  */
 
 import { Store } from '../utils/cache/store';
+import { Maybe } from '../utils/type';
 import { VuidManager } from './vuid_manager';
 
 export type VuidManagerOptions = {
@@ -28,11 +29,11 @@ export type OpaqueVuidManager = {
   [vuidManagerSymbol]: unknown;
 };
 
-export const extractVuidManager = (opaqueVuidManager: OpaqueVuidManager): VuidManager => { 
-  return opaqueVuidManager[vuidManagerSymbol] as VuidManager;
+export const extractVuidManager = (opaqueVuidManager: OpaqueVuidManager): Maybe<VuidManager> => { 
+  return opaqueVuidManager[vuidManagerSymbol] as Maybe<VuidManager>;
 };
 
-export const wrapVuidManager = (vuidManager: VuidManager): OpaqueVuidManager => {
+export const wrapVuidManager = (vuidManager: Maybe<VuidManager>): OpaqueVuidManager => {
   return {
     [vuidManagerSymbol]: vuidManager
   }


### PR DESCRIPTION
## Summary
- previously we were throwing from unsupported factories. This PR changes them to return undefined instead. It will make writing isomorphic apps easier.

## Test plan

## Issues
- FSSDK-11510
