### PR TITLE
[FSSDK-11132] make entity validation configurable in bucketer

### DIFF
--- a/lib/core/bucketer/index.spec.ts
+++ b/lib/core/bucketer/index.spec.ts
@@ -80,6 +80,7 @@ describe('excluding groups', () => {
       experimentIdMap: configObj.experimentIdMap,
       groupIdMap: configObj.groupIdMap,
       logger: mockLogger,
+      validateEntity: true,
     };
 
     vi.spyOn(bucketValueGenerator, 'generateBucketValue')
@@ -127,6 +128,7 @@ describe('including groups: random', () => {
       groupIdMap: configObj.groupIdMap,
       logger: mockLogger,
       userId: 'testUser',
+      validateEntity: true,
     };
   });
 
@@ -228,6 +230,7 @@ describe('including groups: overlapping', () => {
       groupIdMap: configObj.groupIdMap,
       logger: mockLogger,
       userId: 'testUser',
+      validateEntity: true,
     };
   });
 
@@ -280,6 +283,7 @@ describe('bucket value falls into empty traffic allocation ranges', () => {
       experimentIdMap: configObj.experimentIdMap,
       groupIdMap: configObj.groupIdMap,
       logger: mockLogger,
+      validateEntity: true,
     };
   });
 
@@ -329,6 +333,7 @@ describe('traffic allocation has invalid variation ids', () => {
       experimentIdMap: configObj.experimentIdMap,
       groupIdMap: configObj.groupIdMap,
       logger: mockLogger,
+      validateEntity: true,
     };
   });
 
@@ -359,6 +364,7 @@ describe('testBucketWithBucketingId', () => {
       variationIdMap: configObj.variationIdMap,
       experimentIdMap: configObj.experimentIdMap,
       groupIdMap: configObj.groupIdMap,
+      validateEntity: true,
     };
   });
 

--- a/lib/core/bucketer/index.tests.js
+++ b/lib/core/bucketer/index.tests.js
@@ -74,6 +74,7 @@ describe('lib/core/bucketer', function () {
             experimentIdMap: configObj.experimentIdMap,
             groupIdMap: configObj.groupIdMap,
             logger: createdLogger,
+            validateEntity: true,
           };
           sinon
             .stub(bucketValueGenerator, 'generateBucketValue')
@@ -115,6 +116,7 @@ describe('lib/core/bucketer', function () {
             experimentIdMap: configObj.experimentIdMap,
             groupIdMap: configObj.groupIdMap,
             logger: createdLogger,
+            validateEntity: true,
           };
           bucketerStub = sinon.stub(bucketValueGenerator, 'generateBucketValue');
         });
@@ -135,6 +137,7 @@ describe('lib/core/bucketer', function () {
               groupIdMap: configObj.groupIdMap,
               logger: createdLogger,
               userId: 'testUser',
+              validateEntity: true,
             };
           });
 
@@ -225,6 +228,7 @@ describe('lib/core/bucketer', function () {
               groupIdMap: configObj.groupIdMap,
               logger: createdLogger,
               userId: 'testUser',
+              validateEntity: true,
             };
           });
 
@@ -269,6 +273,7 @@ describe('lib/core/bucketer', function () {
             experimentIdMap: configObj.experimentIdMap,
             groupIdMap: configObj.groupIdMap,
             logger: createdLogger,
+            validateEntity: true,
           };
         });
 
@@ -316,6 +321,7 @@ describe('lib/core/bucketer', function () {
             experimentIdMap: configObj.experimentIdMap,
             groupIdMap: configObj.groupIdMap,
             logger: createdLogger,
+            validateEntity: true,
           };
         });
 
@@ -365,6 +371,7 @@ describe('lib/core/bucketer', function () {
           experimentIdMap: configObj.experimentIdMap,
           groupIdMap: configObj.groupIdMap,
           logger: createdLogger,
+          validateEntity: true,
         };
       });
 

--- a/lib/core/bucketer/index.ts
+++ b/lib/core/bucketer/index.ts
@@ -138,17 +138,16 @@ export const bucket = function(bucketerParams: BucketerParams): DecisionResponse
   ]);
 
   const entityId = _findBucket(bucketValue, bucketerParams.trafficAllocationConfig);
-  if (entityId !== null) {
-    if (!bucketerParams.variationIdMap[entityId]) {
-      if (entityId) {        
-        bucketerParams.logger?.warn(INVALID_VARIATION_ID);
-        decideReasons.push([INVALID_VARIATION_ID]);
-      }
-      return {
-        result: null,
-        reasons: decideReasons,
-      };
+  
+  if (bucketerParams.validateEntity && entityId !== null && !bucketerParams.variationIdMap[entityId]) {
+    if (entityId) {        
+      bucketerParams.logger?.warn(INVALID_VARIATION_ID);
+      decideReasons.push([INVALID_VARIATION_ID]);
     }
+    return {
+      result: null,
+      reasons: decideReasons,
+    };
   }
 
   return {

--- a/lib/core/decision_service/index.tests.js
+++ b/lib/core/decision_service/index.tests.js
@@ -653,6 +653,7 @@ describe('lib/core/decision_service', function() {
           experimentIdMap: configObj.experimentIdMap,
           experimentKeyMap: configObj.experimentKeyMap,
           groupIdMap: configObj.groupIdMap,
+          validateEntity: true,
         };
 
         assert.deepEqual(bucketerParams, expectedParams);

--- a/lib/core/decision_service/index.ts
+++ b/lib/core/decision_service/index.ts
@@ -594,12 +594,16 @@ export class DecisionService {
     bucketingId: string,
     userId: string
   ): BucketerParams {
+    let validateEntity = true;
+
     let trafficAllocationConfig: TrafficAllocation[] = getTrafficAllocation(configObj, experiment.id);
     if (experiment.cmab) {
       trafficAllocationConfig = [{
         entityId: CMAB_DUMMY_ENTITY_ID,
         endOfRange: experiment.cmab.trafficAllocation
       }];
+
+      validateEntity = false;
     }
 
     return {
@@ -613,6 +617,7 @@ export class DecisionService {
       trafficAllocationConfig,
       userId,
       variationIdMap: configObj.variationIdMap,
+      validateEntity,
     }
   }
 

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -64,6 +64,7 @@ export interface BucketerParams {
   variationIdMap: { [id: string]: Variation };
   logger?: LoggerFacade;
   bucketingId: string;
+  validateEntity?: boolean;
 }
 
 export interface DecisionResponse<T> {


### PR DESCRIPTION
## Summary

for cmab, we are using a dummy entityId which is not a real variation id. We need to skip entity validation for cmab experiments.

## Test plan
- all existing tests should pass

## Issues
- FSSDK-11132
