### PR TITLE
[FSSDK-11787] fix config parsing performance

### DIFF
--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { find, objectEntries, objectValues, keyBy } from '../utils/fns';
+import { find, objectEntries, objectValues, keyBy, assignBy } from '../utils/fns';
 
 import { FEATURE_VARIABLE_TYPES } from '../utils/enums';
 import configValidator from '../utils/config_validator';
@@ -182,8 +182,8 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
 
 
   projectConfig.audiencesById = {};
-  keyBy(projectConfig.audiences, 'id', projectConfig.audiencesById);
-  keyBy(projectConfig.typedAudiences, 'id', projectConfig.audiencesById);
+  assignBy(projectConfig.audiences, 'id', projectConfig.audiencesById);
+  assignBy(projectConfig.typedAudiences, 'id', projectConfig.audiencesById);
 
   projectConfig.attributes = projectConfig.attributes || [];
   projectConfig.attributeKeyMap = {};
@@ -267,7 +267,7 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
     // Creates { <variationKey>: <variation> } map inside of the experiment
     experiment.variationKeyMap = keyBy(experiment.variations, 'key');
 
-    keyBy(experiment.variations, 'id', projectConfig.variationIdMap);
+    assignBy(experiment.variations, 'id', projectConfig.variationIdMap);
 
     objectValues(experiment.variationKeyMap || {}).forEach(variation => {
       if (variation.variables) {
@@ -369,7 +369,7 @@ const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
 
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');
 
-    keyBy(holdout.variations, 'id', projectConfig.variationIdMap);
+    assignBy(holdout.variations, 'id', projectConfig.variationIdMap);
 
     if (holdout.includedFlags.length === 0) {
       projectConfig.globalHoldouts.push(holdout);

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -180,10 +180,10 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
     audience.conditions = JSON.parse(audience.conditions as string);
   });
 
-  projectConfig.audiencesById = {
-    ...keyBy(projectConfig.audiences, 'id'),
-    ...keyBy(projectConfig.typedAudiences, 'id'),
-  }
+
+  projectConfig.audiencesById = {};
+  keyBy(projectConfig.audiences, 'id', projectConfig.audiencesById);
+  keyBy(projectConfig.typedAudiences, 'id', projectConfig.audiencesById);
 
   projectConfig.attributes = projectConfig.attributes || [];
   projectConfig.attributeKeyMap = {};
@@ -267,11 +267,7 @@ export const createProjectConfig = function(datafileObj?: JSON, datafileStr: str
     // Creates { <variationKey>: <variation> } map inside of the experiment
     experiment.variationKeyMap = keyBy(experiment.variations, 'key');
 
-    // Creates { <variationId>: { key: <variationKey>, id: <variationId> } } mapping for quick lookup
-    projectConfig.variationIdMap = {
-      ...projectConfig.variationIdMap,
-      ...keyBy(experiment.variations, 'id')
-    };
+    keyBy(experiment.variations, 'id', projectConfig.variationIdMap);
 
     objectValues(experiment.variationKeyMap || {}).forEach(variation => {
       if (variation.variables) {
@@ -373,10 +369,7 @@ const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
 
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');
 
-    projectConfig.variationIdMap = {
-      ...projectConfig.variationIdMap,
-      ...keyBy(holdout.variations, 'id'),
-    };
+    keyBy(holdout.variations, 'id', projectConfig.variationIdMap);
 
     if (holdout.includedFlags.length === 0) {
       projectConfig.globalHoldouts.push(holdout);

--- a/lib/utils/fns/index.spec.ts
+++ b/lib/utils/fns/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { groupBy, objectEntries, objectValues, find, keyByUtil, sprintf } from '.'
+import { groupBy, objectEntries, objectValues, find, sprintf, keyBy } from '.'
 
 describe('utils', () => {
   describe('groupBy', () => {
@@ -68,7 +68,7 @@ describe('utils', () => {
         { key: 'baz', firstName: 'james', lastName: 'foxy' },
       ]
 
-      expect(keyByUtil(input, item => item.key)).toEqual({
+      expect(keyBy(input, 'key')).toEqual({
         foo: { key: 'foo', firstName: 'jordan', lastName: 'foo' },
         bar: { key: 'bar', firstName: 'jordan', lastName: 'bar' },
         baz: { key: 'baz', firstName: 'james', lastName: 'foxy' },

--- a/lib/utils/fns/index.spec.ts
+++ b/lib/utils/fns/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { groupBy, objectEntries, objectValues, find, sprintf, keyBy } from '.'
+import { groupBy, objectEntries, objectValues, find, sprintf, keyBy, assignBy } from '.'
 
 describe('utils', () => {
   describe('groupBy', () => {
@@ -72,6 +72,78 @@ describe('utils', () => {
         foo: { key: 'foo', firstName: 'jordan', lastName: 'foo' },
         bar: { key: 'bar', firstName: 'jordan', lastName: 'bar' },
         baz: { key: 'baz', firstName: 'james', lastName: 'foxy' },
+      })
+    })
+  })
+
+  describe('assignBy', () => {
+    it('should assign array elements to an object using the specified key', () => {
+      const input = [
+        { key: 'foo', firstName: 'jordan', lastName: 'foo' },
+        { key: 'bar', firstName: 'jordan', lastName: 'bar' },
+        { key: 'baz', firstName: 'james', lastName: 'foxy' },
+      ]
+      const base = {}
+
+      assignBy(input, 'key', base)
+
+      expect(base).toEqual({
+        foo: { key: 'foo', firstName: 'jordan', lastName: 'foo' },
+        bar: { key: 'bar', firstName: 'jordan', lastName: 'bar' },
+        baz: { key: 'baz', firstName: 'james', lastName: 'foxy' },
+      })
+    })
+
+    it('should append to an existing object', () => {
+      const input = [
+        { key: 'foo', firstName: 'jordan', lastName: 'foo' },
+        { key: 'bar', firstName: 'jordan', lastName: 'bar' },
+      ]
+      const base: any = { existing: 'value' }
+
+      assignBy(input, 'key', base)
+
+      expect(base).toEqual({
+        existing: 'value',
+        foo: { key: 'foo', firstName: 'jordan', lastName: 'foo' },
+        bar: { key: 'bar', firstName: 'jordan', lastName: 'bar' },
+      })
+    })
+
+    it('should handle empty array', () => {
+      const base: any = { existing: 'value' }
+
+      assignBy([], 'key', base)
+
+      expect(base).toEqual({ existing: 'value' })
+    })
+
+    it('should handle null/undefined array', () => {
+      const base: any = { existing: 'value' }
+
+      assignBy(null as any, 'key', base)
+      expect(base).toEqual({ existing: 'value' })
+
+      assignBy(undefined as any, 'key', base)
+      expect(base).toEqual({ existing: 'value' })
+    })
+
+    it('should override existing values with the same key', () => {
+      const input = [
+        { key: 'foo', firstName: 'jordan', lastName: 'updated' },
+        { key: 'bar', firstName: 'james', lastName: 'new' },
+      ]
+      const base: any = {
+        foo: { key: 'foo', firstName: 'john', lastName: 'original' },
+        existing: 'value'
+      }
+
+      assignBy(input, 'key', base)
+
+      expect(base).toEqual({
+        existing: 'value',
+        foo: { key: 'foo', firstName: 'jordan', lastName: 'updated' },
+        bar: { key: 'bar', firstName: 'james', lastName: 'new' },
       })
     })
   })

--- a/lib/utils/fns/index.ts
+++ b/lib/utils/fns/index.ts
@@ -25,12 +25,14 @@ export function isSafeInteger(number: unknown): boolean {
   return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
 }
 
-export function keyBy<K>(arr: K[], key: string): { [key: string]: K } {
-  if (!arr) return {};
-  return keyByUtil(arr, function(item) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (item as any)[key];
+export function keyBy<K>(arr: K[], key: string, base: Record<string, K> = {}): Record<string, K> {
+  if (!arr) return base;
+
+  arr.forEach((e) => {
+    base[(e as any)[key]] = e;
   });
+
+  return base;
 }
 
 
@@ -81,15 +83,6 @@ export function find<K>(arr: K[], cond: (arg: K) => boolean): K | undefined {
   return found;
 }
 
-export function keyByUtil<K>(arr: K[], keyByFn: (item: K) => string): { [key: string]: K } {
-  const map: { [key: string]: K } = {};
-  arr.forEach(item => {
-    const key = keyByFn(item);
-    map[key] = item;
-  });
-  return map;
-}
-
 // TODO[OASIS-6649]: Don't use any type
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function sprintf(format: string, ...args: any[]): string {
@@ -129,6 +122,5 @@ export default {
   objectValues,
   objectEntries,
   find,
-  keyByUtil,
   sprintf,
 };

--- a/lib/utils/fns/index.ts
+++ b/lib/utils/fns/index.ts
@@ -25,14 +25,20 @@ export function isSafeInteger(number: unknown): boolean {
   return typeof number == 'number' && Math.abs(number) <= MAX_SAFE_INTEGER_LIMIT;
 }
 
-export function keyBy<K>(arr: K[], key: string, base: Record<string, K> = {}): Record<string, K> {
-  if (!arr) return base;
+export function keyBy<K>(arr: K[], key: string): Record<string, K> {
+  if (!arr) return {};
+
+  const base: Record<string, K> = {};
+  assignBy(arr, key, base);
+  return base;
+}
+
+export function assignBy<K>(arr: K[], key: string, base: Record<string, K>): void {
+  if (!arr) return;
 
   arr.forEach((e) => {
     base[(e as any)[key]] = e;
   });
-
-  return base;
 }
 
 


### PR DESCRIPTION
## Summary
Currently, variationIdMap is being populated as follows:

```
projectConfig.variationIdMap = {
      ...projectConfig.variationIdMap,
      ...keyBy(experiment.variations, 'id')
    };
```

This creates a new objects for each experiment unnecessarily. This causes large slowdown in project config parsing for datafiles containing a large number of experiments containing a large number of variations. 

This PR makes this more efficient.


## Test plan
- all existing tests should pass

## Issues
- FSSDK-11787
- #1079 