### PR TITLE
[FSSDK-11823] make Activate listener payload type backwards compatible

### DIFF
--- a/lib/feature_toggle.ts
+++ b/lib/feature_toggle.ts
@@ -31,6 +31,6 @@
  * flag and all associated checks can be removed from the codebase.
  */
 
-export const holdout = () => false as const;
+export const holdout = () => true as const;
 
 export type IfActive<T extends () => boolean, Y, N = unknown> = ReturnType<T> extends true ? Y : N;

--- a/lib/feature_toggle.ts
+++ b/lib/feature_toggle.ts
@@ -31,4 +31,6 @@
  * flag and all associated checks can be removed from the codebase.
  */
 
-export const holdout = () => true;
+export const holdout = () => false as const;
+
+export type IfActive<T extends () => boolean, Y, N = unknown> = ReturnType<T> extends true ? Y : N;

--- a/lib/notification_center/type.ts
+++ b/lib/notification_center/type.ts
@@ -26,6 +26,7 @@ import {
 } from '../shared_types';
 import { DecisionSource } from '../utils/enums';
 import { Nullable } from '../utils/type';
+import { holdout, IfActive } from '../feature_toggle';
 
 export type UserEventListenerPayload = {
   userId: string;
@@ -33,7 +34,8 @@ export type UserEventListenerPayload = {
 }
 
 export type ActivateListenerPayload = UserEventListenerPayload & {
-  experiment: Experiment | Holdout | null;
+  experiment: Experiment | null;
+  holdout: IfActive<typeof holdout, Holdout | null>;
   variation: Variation | null;
   logEvent: LogEvent;
 }

--- a/lib/optimizely/index.tests.js
+++ b/lib/optimizely/index.tests.js
@@ -67,6 +67,7 @@ import {
 
 import { USER_BUCKETED_INTO_EXPERIMENT_IN_GROUP } from '../core/bucketer';
 import { resolvablePromise } from '../utils/promise/resolvablePromise';
+import { holdout } from '../feature_toggle';
 
 var LOG_LEVEL = enums.LOG_LEVEL;
 var DECISION_SOURCES = enums.DECISION_SOURCES;
@@ -2281,6 +2282,7 @@ describe('lib/optimizely', function() {
         var instanceExperiments = optlyInstance.projectConfigManager.getConfig().experiments;
         var expectedArgument = {
           experiment: instanceExperiments[0],
+          holdout: null,
           userId: 'testUser',
           attributes: undefined,
           variation: instanceExperiments[0].variations[1],
@@ -2351,6 +2353,7 @@ describe('lib/optimizely', function() {
         var instanceExperiments = optlyInstance.projectConfigManager.getConfig().experiments;
         var expectedArgument = {
           experiment: instanceExperiments[0],
+          holdout: null,
           userId: 'testUser',
           attributes: attributes,
           variation: instanceExperiments[0].variations[1],

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -405,7 +405,7 @@ export default class Optimizely extends BaseService implements Client {
   }
 
   /**
-   * Sends conversion event to Optimizely.`
+   * Sends conversion event to Optimizely.
    * @param  {string}         eventKey
    * @param  {string}         userId
    * @param  {UserAttributes} attributes

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -37,6 +37,7 @@ import {
   OptimizelyDecision,
   Client,
   UserProfileServiceAsync,
+  isHoldout,
 } from '../shared_types';
 import { newErrorDecision } from '../optimizely_decision';
 import OptimizelyUserContext from '../optimizely_user_context';
@@ -62,7 +63,7 @@ import {
 import { Fn, Maybe, OpType } from '../utils/type';
 import { resolvablePromise } from '../utils/promise/resolvablePromise';
 
-import { NOTIFICATION_TYPES, DecisionNotificationType, DECISION_NOTIFICATION_TYPES } from '../notification_center/type';
+import { NOTIFICATION_TYPES, DecisionNotificationType, DECISION_NOTIFICATION_TYPES, ActivateListenerPayload } from '../notification_center/type';
 import {
   FEATURE_NOT_IN_DATAFILE,
   INVALID_INPUT_FORMAT,
@@ -382,17 +383,29 @@ export default class Optimizely extends BaseService implements Client {
     this.eventProcessor.process(impressionEvent);
 
     const logEvent = buildLogEvent([impressionEvent]);
-    this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, {
-      experiment: decisionObj.experiment,
+
+    const activateNotificationPayload: ActivateListenerPayload = {
+      experiment: null,
+      holdout: null,
       userId: userId,
       attributes: attributes,
       variation: decisionObj.variation,
       logEvent,
-    });
+    };
+
+    if (decisionObj.experiment) {
+      if (isHoldout(decisionObj.experiment)) {
+        activateNotificationPayload.holdout = decisionObj.experiment;
+      } else {
+        activateNotificationPayload.experiment = decisionObj.experiment;
+      }
+    }
+
+    this.notificationCenter.sendNotifications(NOTIFICATION_TYPES.ACTIVATE, activateNotificationPayload);
   }
 
   /**
-   * Sends conversion event to Optimizely.
+   * Sends conversion event to Optimizely.`
    * @param  {string}         eventKey
    * @param  {string}         userId
    * @param  {UserAttributes} attributes

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -185,8 +185,8 @@ export function isHoldout(obj: Experiment | Holdout): obj is Holdout {
   // Holdout has 'status', 'includedFlags', and 'excludedFlags' properties
   return (
     (obj as Holdout).status !== undefined &&
-    Array.isArray((obj as Holdout).includeFlags) &&
-    Array.isArray((obj as Holdout).excludeFlags)
+    Array.isArray((obj as Holdout).includedFlags) &&
+    Array.isArray((obj as Holdout).excludedFlags)
   );
 }
 

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -181,6 +181,15 @@ export interface Holdout extends ExperimentCore {
   excludedFlags: string[];
 }
 
+export function isHoldout(obj: Experiment | Holdout): obj is Holdout {
+  // Holdout has 'status', 'includedFlags', and 'excludedFlags' properties
+  return (
+    (obj as Holdout).status !== undefined &&
+    Array.isArray((obj as Holdout).includeFlags) &&
+    Array.isArray((obj as Holdout).excludeFlags)
+  );
+}
+
 export enum VariableType {
   BOOLEAN = 'boolean',
   DOUBLE = 'double',


### PR DESCRIPTION
## Summary
The current type of activate listener payload is not backwards compatible with the type in v6.0.0. This PR makes it compatible.

## Test plan

## Issues
- FSSDK-11823