### PR TITLE
    [FSSDK-11879] flush events without closing client on page unload

### DIFF
--- a/lib/client_factory.ts
+++ b/lib/client_factory.ts
@@ -31,7 +31,7 @@ export type OptimizelyFactoryConfig = Config & {
   requestHandler: RequestHandler;
 }
 
-export const getOptimizelyInstance = (config: OptimizelyFactoryConfig): Client => {
+export const getOptimizelyInstance = (config: OptimizelyFactoryConfig): Optimizely => {
   const { 
     clientEngine,
     clientVersion,

--- a/lib/event_processor/batch_event_processor.spec.ts
+++ b/lib/event_processor/batch_event_processor.spec.ts
@@ -875,7 +875,7 @@ describe('BatchEventProcessor', async () => {
   });
 
   describe('retryFailedEvents', () => {
-    it('should disptach only failed events from the store and not dispatch queued events', async () => {
+    it('should dispatch only failed events from the store and not dispatch queued events', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       mockDispatch.mockResolvedValue({});
@@ -921,7 +921,7 @@ describe('BatchEventProcessor', async () => {
       ]));
     });
 
-    it('should disptach only failed events from the store and not dispatch events that are being dispatched', async () => {
+    it('should dispatch only failed events from the store and not dispatch events that are being dispatched', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       const mockResult1 = resolvablePromise();
@@ -977,7 +977,7 @@ describe('BatchEventProcessor', async () => {
       ]));
     });
 
-    it('should disptach events in correct batch size and separate events with differnt contexts in separate batch', async () => {
+    it('should dispatch events in correct batch size and separate events with differnt contexts in separate batch', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       mockDispatch.mockResolvedValue({});
@@ -1023,7 +1023,7 @@ describe('BatchEventProcessor', async () => {
   });
  
   describe('when failedEventRepeater is fired', () => {
-    it('should disptach only failed events from the store and not dispatch queued events', async () => {
+    it('should dispatch only failed events from the store and not dispatch queued events', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       mockDispatch.mockResolvedValue({});
@@ -1071,7 +1071,7 @@ describe('BatchEventProcessor', async () => {
       ]));
     });
 
-    it('should disptach only failed events from the store and not dispatch events that are being dispatched', async () => {
+    it('should dispatch only failed events from the store and not dispatch events that are being dispatched', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       const mockResult1 = resolvablePromise();
@@ -1129,7 +1129,7 @@ describe('BatchEventProcessor', async () => {
       ]));
     });
 
-    it('should disptach events in correct batch size and separate events with differnt contexts in separate batch', async () => {
+    it('should dispatch events in correct batch size and separate events with differnt contexts in separate batch', async () => {
       const eventDispatcher = getMockDispatcher();
       const mockDispatch: MockInstance<typeof eventDispatcher.dispatchEvent> = eventDispatcher.dispatchEvent;
       mockDispatch.mockResolvedValue({});
@@ -1277,7 +1277,7 @@ describe('BatchEventProcessor', async () => {
       expect(failedEventRepeater.stop).toHaveBeenCalledOnce();
     });
 
-    it('should disptach the events in queue using the closing dispatcher if available', async () => {
+    it('should dispatch the events in queue using the closing dispatcher if available', async () => {
       const eventDispatcher = getMockDispatcher();
       const closingEventDispatcher = getMockDispatcher();
       closingEventDispatcher.dispatchEvent.mockResolvedValue({});
@@ -1410,7 +1410,7 @@ describe('BatchEventProcessor', async () => {
   });
 
   describe('flushImmediately', () => {
-    it('should disptach the events in queue using the closing dispatcher if available', async () => {
+    it('should dispatch the events in queue using the closing dispatcher if available', async () => {
       const eventDispatcher = getMockDispatcher();
       const closingEventDispatcher = getMockDispatcher();
       closingEventDispatcher.dispatchEvent.mockResolvedValue({});
@@ -1447,7 +1447,7 @@ describe('BatchEventProcessor', async () => {
     });
 
 
-    it('should disptach the events in queue using eventDispatcher if closingEventDispatcher is not available', async () => {
+    it('should dispatch the events in queue using eventDispatcher if closingEventDispatcher is not available', async () => {
       const eventDispatcher = getMockDispatcher();
       eventDispatcher.dispatchEvent.mockResolvedValue({});
 
@@ -1471,7 +1471,6 @@ describe('BatchEventProcessor', async () => {
         await processor.process(event);
       }
   
-      expect(eventDispatcher.dispatchEvent).toHaveBeenCalledTimes(0);
       expect(eventDispatcher.dispatchEvent).toHaveBeenCalledTimes(0);
 
       processor.flushImmediately();

--- a/lib/event_processor/batch_event_processor.ts
+++ b/lib/event_processor/batch_event_processor.ts
@@ -333,6 +333,9 @@ export class BatchEventProcessor extends BaseService implements EventProcessor {
   }
 
   flushImmediately(): Promise<unknown> {
+    if (!this.isRunning()) {
+      return Promise.resolve();
+    }
     return this.flush(true);
   }
   

--- a/lib/event_processor/batch_event_processor.ts
+++ b/lib/event_processor/batch_event_processor.ts
@@ -230,14 +230,14 @@ export class BatchEventProcessor extends BaseService implements EventProcessor {
     });
   }
 
-  private async flush(closing = false): Promise<void> {
+  private async flush(useClosingDispatcher = false): Promise<void> {
     const batch = this.createNewBatch();
     if (!batch) {
       return;
     }
     
     this.dispatchRepeater.reset();
-    this.dispatchBatch(batch, closing);
+    this.dispatchBatch(batch, useClosingDispatcher);
   }
 
   async process(event: ProcessableEvent): Promise<void> {
@@ -332,6 +332,10 @@ export class BatchEventProcessor extends BaseService implements EventProcessor {
     }
   }
 
+  flushImmediately(): Promise<unknown> {
+    return this.flush(true);
+  }
+  
   stop(): void {
     if (this.isDone()) {
       return;

--- a/lib/event_processor/event_builder/log_event.ts
+++ b/lib/event_processor/event_builder/log_event.ts
@@ -222,7 +222,7 @@ function makeVisitor(data: ImpressionEvent | ConversionEvent): Visitor {
 
 export function buildLogEvent(events: UserEvent[]): LogEvent {
   const region = events[0]?.context.region || 'US';
-  const url = logxEndpoint[region];
+  const url = logxEndpoint[region] || logxEndpoint['US'];
 
   return {
     url,

--- a/lib/event_processor/event_processor.ts
+++ b/lib/event_processor/event_processor.ts
@@ -28,4 +28,5 @@ export interface EventProcessor extends Service {
   process(event: ProcessableEvent): Promise<unknown>;
   onDispatch(handler: Consumer<LogEvent>): Fn;
   setLogger(logger: LoggerFacade): void;
+  flushImmediately(): Promise<unknown>;
 }

--- a/lib/event_processor/forwarding_event_processor.ts
+++ b/lib/event_processor/forwarding_event_processor.ts
@@ -69,4 +69,8 @@ export class ForwardingEventProcessor extends BaseService implements EventProces
   onDispatch(handler: Consumer<LogEvent>): Fn {
     return this.eventEmitter.on('dispatch', handler);
   }
+
+  flushImmediately(): Promise<unknown> {
+    return Promise.resolve();
+  }
 }

--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -37,7 +37,7 @@ export const createInstance = function(config: Config): Client {
     window.addEventListener(
       unloadEvent,
       () => {
-        client.close();
+        client.flushImmediately();
       },
     );
   }

--- a/lib/odp/event_manager/odp_event_manager.ts
+++ b/lib/odp/event_manager/odp_event_manager.ts
@@ -162,6 +162,9 @@ export class DefaultOdpEventManager extends BaseService implements OdpEventManag
   }
 
   flushImmediately(): Promise<unknown> {
+    if (!this.isRunning()) {
+      return Promise.resolve();
+    }
     return this.flush();
   }
 

--- a/lib/odp/event_manager/odp_event_manager.ts
+++ b/lib/odp/event_manager/odp_event_manager.ts
@@ -42,6 +42,7 @@ export interface OdpEventManager extends Service {
   updateConfig(odpIntegrationConfig: OdpIntegrationConfig): void;
   sendEvent(event: OdpEvent): void;
   setLogger(logger: LoggerFacade): void;
+  flushImmediately(): Promise<unknown>;
 }
 
 export type RetryConfig = {
@@ -158,6 +159,10 @@ export class DefaultOdpEventManager extends BaseService implements OdpEventManag
   private goToRunningState() {
     this.state = ServiceState.Running;
     this.startPromise.resolve();
+  }
+
+  flushImmediately(): Promise<unknown> {
+    return this.flush();
   }
 
   stop(): void {

--- a/lib/odp/odp_manager.spec.ts
+++ b/lib/odp/odp_manager.spec.ts
@@ -53,6 +53,7 @@ const getMockOdpEventManager = () => {
     sendEvent: vi.fn(),
     makeDisposable: vi.fn(),
     setLogger: vi.fn(),
+    flushImmediately: vi.fn(),
   };
 };
 

--- a/lib/odp/odp_manager.spec.ts
+++ b/lib/odp/odp_manager.spec.ts
@@ -781,6 +781,29 @@ describe('DefaultOdpManager', () => {
     odpManager.makeDisposable();
 
     expect(eventManager.makeDisposable).toHaveBeenCalled();
+  });
+
+  it('should call flushImmediately() on eventManager when flushImmediately() is called on odpManager', async () => {
+    const eventManager = getMockOdpEventManager();
+    eventManager.onRunning.mockResolvedValue({});
+    const segmentManager = getMockOdpSegmentManager();
+
+    eventManager.flushImmediately.mockResolvedValue({});
+
+    const odpManager = new DefaultOdpManager({
+      segmentManager,
+      eventManager,
+    });
+
+    odpManager.updateConfig({ integrated: true, odpConfig: config });
+    odpManager.start();
+
+    await odpManager.onRunning();
+
+    odpManager.flushImmediately();
+
+    expect(eventManager.flushImmediately).toHaveBeenCalledOnce();
+    expect(odpManager.isRunning()).toBe(true);
   })
 });
 

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -40,6 +40,7 @@ export interface OdpManager extends Service {
   setClientInfo(clientEngine: string, clientVersion: string): void;
   setVuid(vuid: string): void;
   setLogger(logger: LoggerFacade): void;
+  flushImmediately(): Promise<unknown>;
 }
 
 export type OdpManagerConfig = {
@@ -143,6 +144,10 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
     this.state = ServiceState.Failed;
     this.startPromise.reject(error);
     this.stopPromise.reject(error);
+  }
+
+  flushImmediately(): Promise<unknown> {
+    return this.eventManager.flushImmediately();
   }
 
   stop(): void {

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -147,6 +147,9 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
   }
 
   flushImmediately(): Promise<unknown> {
+    if (!this.isRunning()) {
+      return Promise.resolve();
+    }
     return this.eventManager.flushImmediately();
   }
 

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -1244,21 +1244,21 @@ export default class Optimizely extends BaseService implements Client {
   }
 
   flushImmediately(): Promise<unknown> {
-    const ret = [];
+    const flushPromises = [];
     
     if (!this.isRunning()) {
       return Promise.resolve();
     }
 
     if (this.eventProcessor) {
-      ret.push(this.eventProcessor.flushImmediately());
+      flushPromises.push(this.eventProcessor.flushImmediately());
     }
 
     if(this.odpManager) {
-      ret.push(this.odpManager.flushImmediately());
+      flushPromises.push(this.odpManager.flushImmediately());
     }
 
-    return Promise.all(ret);
+    return Promise.all(flushPromises);
   }
 
   /**

--- a/lib/optimizely/index.ts
+++ b/lib/optimizely/index.ts
@@ -1243,6 +1243,24 @@ export default class Optimizely extends BaseService implements Client {
     }
   }
 
+  flushImmediately(): Promise<unknown> {
+    const ret = [];
+    
+    if (!this.isRunning()) {
+      return Promise.resolve();
+    }
+
+    if (this.eventProcessor) {
+      ret.push(this.eventProcessor.flushImmediately());
+    }
+
+    if(this.odpManager) {
+      ret.push(this.odpManager.flushImmediately());
+    }
+
+    return Promise.all(ret);
+  }
+
   /**
    * Stop background processes belonging to this instance, including:
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-plugin-prettier": "^3.1.2",
         "happy-dom": "^16.6.0",
         "jiti": "^2.4.1",
-        "json-loader": "^0.5.4",
         "karma": "^6.4.0",
         "karma-browserstack-launcher": "^1.5.1",
         "karma-chai": "^0.1.0",
@@ -57,7 +56,6 @@
         "ts-loader": "^9.3.1",
         "ts-node": "^8.10.2",
         "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.4.0",
         "typescript": "^4.7.4",
         "vitest": "^2.0.5",
         "webpack": "^5.74.0"
@@ -9109,12 +9107,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
-    "node_modules/json-loader": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-      "dev": true
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -13685,7 +13677,8 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "eslint-plugin-prettier": "^3.1.2",
     "happy-dom": "^16.6.0",
     "jiti": "^2.4.1",
-    "json-loader": "^0.5.4",
     "karma": "^6.4.0",
     "karma-browserstack-launcher": "^1.5.1",
     "karma-chai": "^0.1.0",
@@ -139,7 +138,6 @@
     "ts-loader": "^9.3.1",
     "ts-node": "^8.10.2",
     "tsconfig-paths": "^4.2.0",
-    "tslib": "^2.4.0",
     "typescript": "^4.7.4",
     "vitest": "^2.0.5",
     "webpack": "^5.74.0"


### PR DESCRIPTION
## Summary
Currently, in browser, when the page is unloaded, the sdk instance is being closed in order to flush pending events. But when the page is loaded from [bfcache](https://developer.mozilla.org/en-US/docs/Glossary/bfcache), the sdk instance stays closed as bfcache restores the Javascript heap as well, which causes further events to be not processed. 

This PR updates the code to flush events on page unload without closing the sdk instance.

## Test plan
- added tests

## Issues
- FSSDK-11879
- #1084 
