### PR TITLE
[FSSDK-11879] use visibilitychange event for page hide detection

### DIFF
--- a/lib/index.browser.ts
+++ b/lib/index.browser.ts
@@ -33,13 +33,18 @@ export const createInstance = function(config: Config): Client {
   });
 
   if (client) {
-    const unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
-    window.addEventListener(
-      unloadEvent,
-      () => {
+    if ('onvisibilitychange' in document) {
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+          client.flushImmediately();
+        }
+      });
+    } else {
+      const unloadEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
+      window.addEventListener(unloadEvent, () => {
         client.flushImmediately();
-      },
-    );
+      });
+    }
   }
 
   return client;


### PR DESCRIPTION
## Summary
'pagehide' and 'unload' are not fired reliably on mobile devices. Use 'visibilitychange' event if available to detect page hide for flushing queued events.

## Test plan

## Issues
- FSSDK-11879