### PR TITLE
[AI-FSSDK] (DO NOT REVIEW) [FSSDK-12275] Skip unsupported experiment type during flag decision

### DIFF
--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -163,6 +163,7 @@ export interface Experiment extends ExperimentCore {
   status: string;
   forcedVariations?: { [key: string]: string };
   isRollout?: boolean;
+  type?: string;
   cmab?: {
     trafficAllocation: number;
     attributeIds: string[];


### PR DESCRIPTION
## Summary

Implements experiment type filtering in the decision service to skip unsupported experiment types during flag decision evaluation.

### Changes

- **Experiment Interface**: Added optional `type` field to the `Experiment` interface in `shared_types.ts`
- **Supported Types**: Defined `SUPPORTED_EXPERIMENT_TYPES` constant with values: `a/b`, `mab`, `cmab`, `feature_rollouts`
- **Decision Logic**: Updated `traverseFeatureExperimentList` in decision service to:
  - Check experiment type before evaluation
  - Skip to next experiment if type is defined but not in supported list
  - Evaluate normally if type is undefined/null or is in supported list
- **Testing**: Added comprehensive unit tests covering:
  - Skipping experiments with unsupported types
  - Evaluating experiments with all supported types
  - Handling undefined/null type fields
  - Logging behavior

### Implementation Details

The decision service now checks the experiment `type` field during flag decision:
- If `type` is **undefined** or **null**: Experiment is evaluated (backward compatible)
- If `type` is in supported list: Experiment is evaluated
- If `type` is defined but NOT in supported list: Experiment is skipped with debug log

This ensures the SDK can gracefully handle new experiment types introduced in the datafile without breaking existing functionality.

## Test Plan

- ✅ All existing tests pass
- ✅ New unit tests verify type filtering logic
- ✅ Build succeeds without TypeScript errors

## Related

- Jira: [FSSDK-12275](https://optimizely-ext.atlassian.net/browse/FSSDK-12275)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12275]: https://optimizely-ext.atlassian.net/browse/FSSDK-12275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ