### PR TITLE
fix: remove polyfills from the library

### DIFF
--- a/lib/index.react_native.ts
+++ b/lib/index.react_native.ts
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'fast-text-encoding';
-import 'react-native-get-random-values';
-
 import { Client, Config } from './shared_types';
 import { getOptimizelyInstance, OptimizelyFactoryConfig } from './client_factory';
 import { REACT_NATIVE_JS_CLIENT_ENGINE } from './utils/enums';


### PR DESCRIPTION
Removing two import statements that are no not needed. Polyfills should be imported/configured by the user in their project. Some people might want to use https://github.com/margelo/react-native-quick-crypto 

/cc @mrousavy