### PR TITLE
[AI-FSSDK] [FSSDK-12368] Remove legacy flag-level holdout fields

### DIFF
--- a/lib/core/decision_service/index.spec.ts
+++ b/lib/core/decision_service/index.spec.ts
@@ -1960,55 +1960,7 @@ describe('DecisionService', () => {
         });
       });
 
-      it("should consider global holdout even if local holdout is present", async () => {
-        const { decisionService } = getDecisionService();
-        const datafile = getHoldoutTestDatafile();
-        const newEntry = {
-          id: 'holdout_included_id',
-          key: 'holdout_included',
-          status: 'Running',
-          includedFlags: ['1001'],
-          excludedFlags: [],
-          audienceIds: ['4002'], // age_40 audience
-          audienceConditions: ['or', '4002'],
-          variations: [
-            {
-              id: 'holdout_variation_included_id',
-              key: 'holdout_variation_included',
-              variables: [],
-            },
-          ],
-          trafficAllocation: [
-            {
-              entityId: 'holdout_variation_included_id',
-              endOfRange: 5000,
-            },
-          ],
-        };
-        datafile.holdouts = [newEntry, ...datafile.holdouts];
-        const config = createProjectConfig(datafile);
-        const user = new OptimizelyUserContext({
-          optimizely: {} as any,
-          userId: 'tester',
-          attributes: {
-            age: 20, // satisfies both global holdout (age_22) and included holdout (age_40) audiences
-          },
-        });
-        const feature = config.featureKeyMap['flag_1'];
-        const value = decisionService.resolveVariationsForFeatureList('async', config, [feature], user, {}).get();
-
-        expect(value).toBeInstanceOf(Promise);
-
-        const variation = (await value)[0];
-
-        expect(variation.result).toEqual({
-          experiment: config.holdoutIdMap && config.holdoutIdMap['holdout_running_id'],
-          variation: config.variationIdMap['holdout_variation_running_id'],
-          decisionSource: DECISION_SOURCES.HOLDOUT,
-        });
-      });
-
-      it("should consider local holdout if misses global holdout", async () => {
+      it("should consider next global holdout if misses previous holdouts", async () => {
         const { decisionService } = getDecisionService();
         const datafile = getHoldoutTestDatafile();
         
@@ -2016,7 +1968,7 @@ describe('DecisionService', () => {
           id: 'holdout_included_specific_id',
           key: 'holdout_included_specific',
           status: 'Running',
-          includedFlags: ['1001'],
+          includedFlags: [],
           excludedFlags: [], 
           audienceIds: ['4002'], // age_60 audience (age <= 60)
           audienceConditions: ['or', '4002'],
@@ -2039,7 +1991,7 @@ describe('DecisionService', () => {
           optimizely: {} as any,
           userId: 'test_holdout_user',
           attributes: {
-            age: 50, // Does not satisfy global holdout (age_22, age <= 22) but satisfies included holdout (age_60, age <= 60)
+            age: 50, // Does not satisfy first global holdout (age_22, age <= 22) but satisfies newly added holdout (age_60, age <= 60)
           },
         });
         const feature = config.featureKeyMap['flag_1'];
@@ -2192,42 +2144,6 @@ describe('DecisionService', () => {
           experiment: config.experimentKeyMap['delivery_2'],
           variation: config.variationIdMap['5005'],
           decisionSource: DECISION_SOURCES.ROLLOUT,
-        });
-      });
-
-      it('should skip holdouts excluded for specific flags', async () => {
-        const { decisionService } = getDecisionService();
-        const datafile = getHoldoutTestDatafile();
-        
-        datafile.holdouts = datafile.holdouts.map((holdout: any) => {
-          if(holdout.id === 'holdout_running_id') {
-            return {
-              ...holdout,
-              excludedFlags: ['1001']
-            }
-          }
-          return holdout;
-        });
-
-        const config = createProjectConfig(datafile);
-        const user = new OptimizelyUserContext({
-          optimizely: {} as any,
-          userId: 'tester',
-          attributes: {
-            age: 15, // satisfies age_22 audience condition (age <= 22) for global holdout, but holdout excludes flag_1
-          },
-        });
-        const feature = config.featureKeyMap['flag_1'];
-        const value = decisionService.resolveVariationsForFeatureList('async', config, [feature], user, {}).get();
-
-        expect(value).toBeInstanceOf(Promise);
-
-        const variation = (await value)[0];
-
-        expect(variation.result).toEqual({
-          experiment: config.experimentKeyMap['exp_1'],
-          variation: config.variationIdMap['5001'],
-          decisionSource: DECISION_SOURCES.FEATURE_TEST,
         });
       });
 

--- a/lib/core/decision_service/index.ts
+++ b/lib/core/decision_service/index.ts
@@ -31,7 +31,6 @@ import {
   getVariationKeyFromId,
   isActive,
   ProjectConfig,
-  getHoldoutsForFlag,
 } from '../../project_config/project_config';
 import { AudienceEvaluator, createAudienceEvaluator } from '../audience_evaluator';
 import * as stringValidator from '../../utils/string_value_validator';
@@ -943,7 +942,10 @@ export class DecisionService {
         reasons: decideReasons,
       });
     }
-    const holdouts = getHoldoutsForFlag(configObj, feature.key);
+
+    // all global holouts should be evaluated for all flags
+    // global holdouts are available in configObj.holdouts
+    const { holdouts } = configObj;
 
     for (const holdout of holdouts) {
       const holdoutDecision = this.getVariationForHoldout(configObj, holdout, user);

--- a/lib/project_config/project_config.spec.ts
+++ b/lib/project_config/project_config.spec.ts
@@ -329,7 +329,7 @@ const getHoldoutDatafile = () => {
       key: 'holdout_2',
       status: 'Running',
       includedFlags: [],
-      excludedFlags: ['44829230000'],
+      excludedFlags: [],
       audienceIds: [],
       audienceConditions: [],
       variations: [
@@ -350,7 +350,7 @@ const getHoldoutDatafile = () => {
       id: 'holdout_id_3',
       key: 'holdout_3',
       status: 'Draft',
-      includedFlags: ['4482920077'],
+      includedFlags: [],
       excludedFlags: [],
       audienceIds: [],
       audienceConditions: [],
@@ -401,6 +401,18 @@ describe('createProjectConfig - holdouts', () => {
 
     expect(configObj.holdouts).toEqual([]);
     expect(configObj.holdoutIdMap).toEqual({});
+  });
+
+  it('should handle undefined includedFlags and excludedFlags in holdout', function() {
+    const datafile = getHoldoutDatafile();
+    datafile.holdouts[0].includedFlags = undefined;
+    datafile.holdouts[0].excludedFlags = undefined;
+
+    const configObj = projectConfig.createProjectConfig(JSON.parse(JSON.stringify(datafile)));
+
+    expect(configObj.holdouts).toHaveLength(3);
+    expect(configObj.holdouts[0].includedFlags).toEqual([]);
+    expect(configObj.holdouts[0].excludedFlags).toEqual([]);
   });
 });
 

--- a/lib/project_config/project_config.spec.ts
+++ b/lib/project_config/project_config.spec.ts
@@ -30,7 +30,7 @@ import testDatafile from '../tests/test_data';
 import configValidator from '../utils/config_validator';
 import { FEATURE_VARIABLE_TYPES } from '../utils/enums';
 import { keyBy, sprintf } from '../utils/fns';
-import projectConfig, { ProjectConfig, getHoldoutsForFlag } from './project_config';
+import projectConfig, { ProjectConfig } from './project_config';
 
 const cloneDeep = (obj: any) => JSON.parse(JSON.stringify(obj));
 const logger = getMockLogger();
@@ -392,8 +392,6 @@ describe('createProjectConfig - holdouts', () => {
       holdout_id_2: configObj.holdouts[1],
       holdout_id_3: configObj.holdouts[2],
     });
-
-    expect(configObj.flagHoldoutsMap).toEqual({});
   });
 
   it('should handle empty holdouts array', function() {
@@ -403,27 +401,6 @@ describe('createProjectConfig - holdouts', () => {
 
     expect(configObj.holdouts).toEqual([]);
     expect(configObj.holdoutIdMap).toEqual({});
-    expect(configObj.flagHoldoutsMap).toEqual({});
-  });
-});
-
-describe('getHoldoutsForFlag', () => {
-  it('should return all holdouts for any flag', () => {
-    const datafile = getHoldoutDatafile();
-    const configObj = projectConfig.createProjectConfig(JSON.parse(JSON.stringify(datafile)));
-
-    // All holdouts now apply globally to all flags
-    const feature1Holdouts = getHoldoutsForFlag(configObj, 'feature_1');
-    expect(feature1Holdouts).toHaveLength(3);
-    expect(feature1Holdouts).toEqual(configObj.holdouts);
-
-    const feature2Holdouts = getHoldoutsForFlag(configObj, 'feature_2');
-    expect(feature2Holdouts).toHaveLength(3);
-    expect(feature2Holdouts).toEqual(configObj.holdouts);
-
-    const feature3Holdouts = getHoldoutsForFlag(configObj, 'feature_3');
-    expect(feature3Holdouts).toHaveLength(3);
-    expect(feature3Holdouts).toEqual(configObj.holdouts);
   });
 });
 

--- a/lib/project_config/project_config.spec.ts
+++ b/lib/project_config/project_config.spec.ts
@@ -393,20 +393,6 @@ describe('createProjectConfig - holdouts', () => {
       holdout_id_3: configObj.holdouts[2],
     });
 
-    expect(configObj.globalHoldouts).toHaveLength(2);
-    expect(configObj.globalHoldouts).toEqual([
-      configObj.holdouts[0], // holdout_1 has empty includedFlags
-      configObj.holdouts[1]  // holdout_2 has empty includedFlags
-    ]);
-
-    expect(configObj.includedHoldouts).toEqual({
-      feature_1: [configObj.holdouts[2]], // holdout_3 includes feature_1 (ID: 4482920077)
-    });
-
-    expect(configObj.excludedHoldouts).toEqual({
-      feature_3: [configObj.holdouts[1]]  // holdout_2 excludes feature_3 (ID: 44829230000)
-    });
-
     expect(configObj.flagHoldoutsMap).toEqual({});
   });
 
@@ -417,50 +403,27 @@ describe('createProjectConfig - holdouts', () => {
 
     expect(configObj.holdouts).toEqual([]);
     expect(configObj.holdoutIdMap).toEqual({});
-    expect(configObj.globalHoldouts).toEqual([]);
-    expect(configObj.includedHoldouts).toEqual({});
-    expect(configObj.excludedHoldouts).toEqual({});
     expect(configObj.flagHoldoutsMap).toEqual({});
-  });
-
-  it('should handle undefined includedFlags and excludedFlags in holdout', function() {
-    const datafile = getHoldoutDatafile();
-    datafile.holdouts[0].includedFlags = undefined;
-    datafile.holdouts[0].excludedFlags = undefined;
-
-    const configObj = projectConfig.createProjectConfig(JSON.parse(JSON.stringify(datafile)));
-
-    expect(configObj.holdouts).toHaveLength(3);
-    expect(configObj.holdouts[0].includedFlags).toEqual([]);
-    expect(configObj.holdouts[0].excludedFlags).toEqual([]);
   });
 });
 
 describe('getHoldoutsForFlag', () => {
-  it('should return all applicable holdouts for a flag', () => {
+  it('should return all holdouts for any flag', () => {
     const datafile = getHoldoutDatafile();
     const configObj = projectConfig.createProjectConfig(JSON.parse(JSON.stringify(datafile)));
 
+    // All holdouts now apply globally to all flags
     const feature1Holdouts = getHoldoutsForFlag(configObj, 'feature_1');
     expect(feature1Holdouts).toHaveLength(3);
-    expect(feature1Holdouts).toEqual([
-      configObj.holdouts[0],
-      configObj.holdouts[1],
-      configObj.holdouts[2],
-    ]);
+    expect(feature1Holdouts).toEqual(configObj.holdouts);
 
     const feature2Holdouts = getHoldoutsForFlag(configObj, 'feature_2');
-    expect(feature2Holdouts).toHaveLength(2);
-    expect(feature2Holdouts).toEqual([
-      configObj.holdouts[0],
-      configObj.holdouts[1],
-    ]);
+    expect(feature2Holdouts).toHaveLength(3);
+    expect(feature2Holdouts).toEqual(configObj.holdouts);
 
     const feature3Holdouts = getHoldoutsForFlag(configObj, 'feature_3');
-    expect(feature3Holdouts).toHaveLength(1);
-    expect(feature3Holdouts).toEqual([
-      configObj.holdouts[0],
-    ]);
+    expect(feature3Holdouts).toHaveLength(3);
+    expect(feature3Holdouts).toEqual(configObj.holdouts);
   });
 });
 

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -113,9 +113,6 @@ export interface ProjectConfig {
   odpIntegrationConfig: OdpIntegrationConfig;
   holdouts: Holdout[];
   holdoutIdMap?: { [id: string]: Holdout };
-  globalHoldouts: Holdout[];
-  includedHoldouts: { [key: string]: Holdout[]; } 
-  excludedHoldouts: { [key: string]: Holdout[]; }
   flagHoldoutsMap: { [key: string]: Holdout[]; }
 }
 
@@ -390,51 +387,11 @@ const getEveryoneElseVariation = function(
 const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
   projectConfig.holdouts = projectConfig.holdouts || [];
   projectConfig.holdoutIdMap = keyBy(projectConfig.holdouts, 'id');
-  projectConfig.globalHoldouts = [];
-  projectConfig.includedHoldouts = {};
-  projectConfig.excludedHoldouts = {};
   projectConfig.flagHoldoutsMap = {};
 
-  const featureFlagIdMap = keyBy(projectConfig.featureFlags, 'id');
-
   projectConfig.holdouts.forEach((holdout) => {
-    if (!holdout.includedFlags) {
-      holdout.includedFlags = [];
-    }
-
-    if (!holdout.excludedFlags) {
-      holdout.excludedFlags = [];
-    }
-
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');
-
     assignBy(holdout.variations, 'id', projectConfig.variationIdMap);
-
-    if (holdout.includedFlags.length === 0) {
-      projectConfig.globalHoldouts.push(holdout);
-
-      holdout.excludedFlags.forEach((flagId: string) => {
-        const flag = featureFlagIdMap[flagId];
-        if (flag) {
-          const flagKey = flag.key;
-          if (!projectConfig.excludedHoldouts[flagKey]) {
-            projectConfig.excludedHoldouts[flagKey] = [];
-          }
-          projectConfig.excludedHoldouts[flagKey].push(holdout);
-        }
-      });
-    } else {
-      holdout.includedFlags.forEach((flagId: string) => {
-        const flag = featureFlagIdMap[flagId];
-        if (flag) {
-          const flagKey = flag.key;
-          if (!projectConfig.includedHoldouts[flagKey]) {
-            projectConfig.includedHoldouts[flagKey] = [];
-          }
-          projectConfig.includedHoldouts[flagKey].push(holdout);
-        }
-      })
-    }
   });
 }
 
@@ -443,15 +400,9 @@ export const getHoldoutsForFlag = (projectConfig: ProjectConfig, flagKey: string
     return projectConfig.flagHoldoutsMap[flagKey];
   }
 
-  const flagHoldouts: Holdout[] = [
-    ...projectConfig.globalHoldouts.filter((holdout) => {
-      return !(projectConfig.excludedHoldouts[flagKey] || []).includes(holdout);
-    }),
-    ...(projectConfig.includedHoldouts[flagKey] || []),
-  ];
-
-  projectConfig.flagHoldoutsMap[flagKey] = flagHoldouts;
-  return flagHoldouts;
+  // All holdouts now apply to all flags (global holdouts)
+  projectConfig.flagHoldoutsMap[flagKey] = projectConfig.holdouts;
+  return projectConfig.holdouts;
 }
 
 /**

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -388,6 +388,12 @@ const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
   projectConfig.holdoutIdMap = keyBy(projectConfig.holdouts, 'id');
 
   projectConfig.holdouts.forEach((holdout) => {
+
+    // Original design of the global holdouts made use of the includeFlags and excludeFlags fields to identify local holdouts.
+    // But this was never released. In the current design, these fields are no longer user. These fields are kept
+    // and assinged empty array to keep the published type `Holdout` unchanged.
+    holdout.includedFlags = [];
+    holdout.excludedFlags = [];
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');
     assignBy(holdout.variations, 'id', projectConfig.variationIdMap);
   });

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -113,7 +113,6 @@ export interface ProjectConfig {
   odpIntegrationConfig: OdpIntegrationConfig;
   holdouts: Holdout[];
   holdoutIdMap?: { [id: string]: Holdout };
-  flagHoldoutsMap: { [key: string]: Holdout[]; }
 }
 
 const EXPERIMENT_RUNNING_STATUS = 'Running';
@@ -387,22 +386,11 @@ const getEveryoneElseVariation = function(
 const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
   projectConfig.holdouts = projectConfig.holdouts || [];
   projectConfig.holdoutIdMap = keyBy(projectConfig.holdouts, 'id');
-  projectConfig.flagHoldoutsMap = {};
 
   projectConfig.holdouts.forEach((holdout) => {
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');
     assignBy(holdout.variations, 'id', projectConfig.variationIdMap);
   });
-}
-
-export const getHoldoutsForFlag = (projectConfig: ProjectConfig, flagKey: string): Holdout[] => {
-  if (projectConfig.flagHoldoutsMap[flagKey]) {
-    return projectConfig.flagHoldoutsMap[flagKey];
-  }
-
-  // All holdouts now apply to all flags (global holdouts)
-  projectConfig.flagHoldoutsMap[flagKey] = projectConfig.holdouts;
-  return projectConfig.holdouts;
 }
 
 /**

--- a/lib/project_config/project_config.ts
+++ b/lib/project_config/project_config.ts
@@ -389,9 +389,9 @@ const parseHoldoutsConfig = (projectConfig: ProjectConfig): void => {
 
   projectConfig.holdouts.forEach((holdout) => {
 
-    // Original design of the global holdouts made use of the includeFlags and excludeFlags fields to identify local holdouts.
-    // But this was never released. In the current design, these fields are no longer user. These fields are kept
-    // and assinged empty array to keep the published type `Holdout` unchanged.
+    // Original design of holdouts made use of the includeFlags and excludeFlags fields to identify local holdouts.
+    // But this was never released. In the current design, these fields are no longer used. These fields are kept
+    // and assigned empty array to keep the published type `Holdout` unchanged.
     holdout.includedFlags = [];
     holdout.excludedFlags = [];
     holdout.variationKeyMap = keyBy(holdout.variations, 'key');

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -174,17 +174,11 @@ export type HoldoutStatus = 'Draft' | 'Running' | 'Concluded' | 'Archived';
 
 export interface Holdout extends ExperimentCore {
   status: HoldoutStatus;
-  includedFlags: string[];
-  excludedFlags: string[];
 }
 
 export function isHoldout(obj: Experiment | Holdout): obj is Holdout {
-  // Holdout has 'status', 'includedFlags', and 'excludedFlags' properties
-  return (
-    (obj as Holdout).status !== undefined &&
-    Array.isArray((obj as Holdout).includedFlags) &&
-    Array.isArray((obj as Holdout).excludedFlags)
-  );
+  // Holdout doesn't have 'layerId' property, while Experiment does
+  return (obj as Experiment).layerId === undefined;
 }
 
 export enum VariableType {

--- a/lib/shared_types.ts
+++ b/lib/shared_types.ts
@@ -174,6 +174,8 @@ export type HoldoutStatus = 'Draft' | 'Running' | 'Concluded' | 'Archived';
 
 export interface Holdout extends ExperimentCore {
   status: HoldoutStatus;
+  includedFlags: string[];
+  excludedFlags: string[];
 }
 
 export function isHoldout(obj: Experiment | Holdout): obj is Holdout {


### PR DESCRIPTION
## Summary
simplify holdout handling to treat all holdouts as global.

## Changes
- Removed `includedHoldouts`, `excludedHoldouts`, and `globalHoldouts` from ProjectConfig
- Removed `getHoldoutsForFlag()` method from ProjectConfig
- Removed 3 test cases for deleted functionality
- Updated remaining tests to use new global holdout behavior

## Testing
- All tests pass

## Quality Metrics
- **Iterations**: 1/5 (AI-driven quality loop)
- **Tests**: PASS (3079 tests, 0 failures)
- **Review**: APPROVED (0 critical issues, 0 warnings)

## Related
- Jira: [FSSDK-12368](https://optimizely-ext.atlassian.net/browse/FSSDK-12368)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12368]: https://optimizely-ext.atlassian.net/browse/FSSDK-12368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ