### PR TITLE
[AI-FSSDK] prepare for release javascript-sdk v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.4.0] - May 4, 2026
+## [6.4.0] - May 7, 2026
 
 ### New Features
 
@@ -16,7 +16,10 @@ and confidence intervals.
 See [Feature Rollout docs](https://support.optimizely.com/hc/en-us/articles/45552846481037-Run-Feature-Rollouts-in-Feature-Experimentation) for more information.
 
 - Add Feature Rollout support ([#1140](https://github.com/optimizely/javascript-sdk/pull/1140))
-- Remove SourceClear scan workflow due to security vulnerability ([#1139](https://github.com/optimizely/javascript-sdk/pull/1139))
+
+### Bug Fixes
+- Export `UserProfileServiceAsync` type
+
 
 ## [6.3.1] - January 26, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.4.0] - May 4, 2026
+
+### New Features
+
+**Feature Rollout**: Added support for Feature Rollouts, a new experiment type
+combining Targeted Delivery simplicity with A/B test measurement capabilities.
+Feature Rollouts enable progressive rollouts with full impact analytics, metric tracking,
+and confidence intervals.
+See [Feature Rollout docs](https://support.optimizely.com/hc/en-us/articles/45552846481037-Run-Feature-Rollouts-in-Feature-Experimentation) for more information.
+
+- Add Feature Rollout support ([#1140](https://github.com/optimizely/javascript-sdk/pull/1140))
+- Remove SourceClear scan workflow due to security vulnerability ([#1139](https://github.com/optimizely/javascript-sdk/pull/1139))
+
 ## [6.3.1] - January 26, 2026
 
 ### Changed

--- a/lib/export_types.ts
+++ b/lib/export_types.ts
@@ -95,6 +95,7 @@ export type {
   Event,
   DatafileOptions,
   UserProfileService,
+  UserProfileServiceAsync,
   UserProfile,
   ListenerPayload,
   OptimizelyDecision,

--- a/lib/index.browser.tests.js
+++ b/lib/index.browser.tests.js
@@ -153,7 +153,7 @@ describe('javascript-sdk (Browser)', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '6.3.1');
+        assert.equal(optlyInstance.clientVersion, '6.4.0');
       });
 
       it('should set the JavaScript client engine and version', function() {

--- a/lib/index.node.tests.js
+++ b/lib/index.node.tests.js
@@ -88,7 +88,7 @@ describe('optimizelyFactory', function() {
         });
 
         assert.instanceOf(optlyInstance, Optimizely);
-        assert.equal(optlyInstance.clientVersion, '6.3.1');
+        assert.equal(optlyInstance.clientVersion, '6.4.0');
       });
       // TODO: user will create and inject an event processor
       // these tests will be refactored accordingly

--- a/lib/index.react_native.spec.ts
+++ b/lib/index.react_native.spec.ts
@@ -92,7 +92,7 @@ describe('javascript-sdk/react-native', () => {
         expect(optlyInstance).toBeInstanceOf(Optimizely);
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        expect(optlyInstance.clientVersion).toEqual('6.3.1');
+        expect(optlyInstance.clientVersion).toEqual('6.4.0');
       });
 
       it('should set the React Native JS client engine and javascript SDK version', () => {

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -44,7 +44,7 @@ export const CONTROL_ATTRIBUTES = {
 export const JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 export const NODE_CLIENT_ENGINE = 'node-sdk';
 export const REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
-export const CLIENT_VERSION = '6.3.1';
+export const CLIENT_VERSION = '6.4.0';
 
 /*
  * Represents the source of a decision for feature management. When a feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optimizely/optimizely-sdk",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "decompress-response": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "description": "JavaScript SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "main": "./dist/index.node.min.js",
   "browser": "./dist/index.browser.es.min.js",

--- a/srcclr.yml
+++ b/srcclr.yml
@@ -1,1 +1,0 @@
-scope: production


### PR DESCRIPTION
## Summary

Prepare for release v6.4.0

## Release Details
- Version Bump: v6.3.1 → v6.4.0 (minor)

[FSSDK-12546](https://optimizely-ext.atlassian.net/browse/FSSDK-12546)

[FSSDK-12546]: https://optimizely-ext.atlassian.net/browse/FSSDK-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ