### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/lib/message/log_message.ts
+++ b/lib/message/log_message.ts
@@ -69,6 +69,7 @@ export const INVALIDATE_CMAB_CACHE = 'Invalidating CMAB cache for user %s and ru
 export const CMAB_CACHE_HIT = 'Cache hit for user %s and rule %s.';
 export const CMAB_CACHE_ATTRIBUTES_MISMATCH = 'CMAB cache attributes mismatch for user %s and rule %s, fetching new decision.';
 export const CMAB_CACHE_MISS = 'Cache miss for user %s and rule %s.'; 
+export const ODP_IDENTIFY_NOT_DISPATCHED= 'ODP identify event is not dispatched (fewer than 2 valid identifiers).'
 
 export const messages: string[] = [];
 

--- a/lib/odp/odp_manager.spec.ts
+++ b/lib/odp/odp_manager.spec.ts
@@ -618,7 +618,7 @@ describe('DefaultOdpManager', () => {
     expect(identifiers).toEqual(new Map([['fs_user_id', 'user'], ['vuid', 'vuid_a']]));
   });
 
-  it('sends identified event when called with just fs_user_id in first parameter', async () => {
+  it('does not send identified event when called with just fs_user_id (single identifier)', async () => {
     const eventManager = getMockOdpEventManager();
     eventManager.onRunning.mockReturnValue(Promise.resolve());
 
@@ -634,12 +634,10 @@ describe('DefaultOdpManager', () => {
     await odpManager.onRunning();
 
     odpManager.identifyUser('user');
-    expect(mockSendEvents).toHaveBeenCalledOnce();
-    const { identifiers } = mockSendEvents.mock.calls[0][0];
-    expect(identifiers).toEqual(new Map([['fs_user_id', 'user']]));
+    expect(mockSendEvents).not.toHaveBeenCalled();
   });
 
-  it('sends identified event when called with just vuid in first parameter', async () => {
+  it('does not send identified event when called with just vuid (single identifier)', async () => {
     const eventManager = getMockOdpEventManager();
     eventManager.onRunning.mockReturnValue(Promise.resolve());
 
@@ -655,9 +653,7 @@ describe('DefaultOdpManager', () => {
     await odpManager.onRunning();
 
     odpManager.identifyUser('vuid_a');
-    expect(mockSendEvents).toHaveBeenCalledOnce();
-    const { identifiers } = mockSendEvents.mock.calls[0][0];
-    expect(identifiers).toEqual(new Map([['vuid', 'vuid_a']]));
+    expect(mockSendEvents).not.toHaveBeenCalled();
   });
 
   it('should reject onRunning() if stopped in new state', async () => {

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -32,6 +32,7 @@ import { Maybe } from '../utils/type';
 import { sprintf } from '../utils/fns';
 import { SERVICE_STOPPED_BEFORE_RUNNING } from '../service';
 import { Platform } from '../platform_support';
+import { ODP_IDENTIFY_NOT_DISPATCHED } from '../message/log_message';
 
 export interface OdpManager extends Service {
   updateConfig(odpIntegrationConfig: OdpIntegrationConfig): boolean;
@@ -232,7 +233,7 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
     // Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
     // A single identifier has no cross-reference value and generates unnecessary traffic.
     if (identifiers.size < 2) {
-      this.logger.log(LogLevel.Debug, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).');
+      this.logger?.debug(ODP_IDENTIFY_NOT_DISPATCHED);
       return;
     }
 

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -229,6 +229,8 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
       identifiers.set(ODP_USER_KEY.FS_USER_ID, finalUserId);
     }
 
+    // Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+    // A single identifier has no cross-reference value and generates unnecessary traffic.
     if (identifiers.size < 2) {
       this.logger.log(LogLevel.Debug, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).');
       return;

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -230,7 +230,7 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
     }
 
     if (identifiers.size < 2) {
-      this.logger.log(LogLevel.Debug, 'ODP identify event is not dispatched (only one identifier provided).');
+      this.logger.log(LogLevel.Debug, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).');
       return;
     }
 

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -15,7 +15,7 @@
  */
 
 import { v4 as uuidV4} from 'uuid';
-import { LoggerFacade } from '../logging/logger';
+import { LoggerFacade, LogLevel } from '../logging/logger';
 
 import { OdpIntegrationConfig, odpIntegrationsAreEqual } from './odp_config';
 import { OdpEventManager } from './event_manager/odp_event_manager';
@@ -212,7 +212,7 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
 
   identifyUser(userId: string, vuid?: string): void {
     const identifiers = new Map<string, string>();
-    
+
     let finalUserId: Maybe<string> = userId;
     let finalVuid: Maybe<string> = vuid;
 
@@ -227,6 +227,11 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
 
     if (finalUserId) {
       identifiers.set(ODP_USER_KEY.FS_USER_ID, finalUserId);
+    }
+
+    if (identifiers.size < 2) {
+      this.logger.log(LogLevel.Debug, 'ODP identify event is not dispatched (only one identifier provided).');
+      return;
     }
 
     const event = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.IDENTIFIED, identifiers);


### PR DESCRIPTION
## Summary

Fixes ODP identify event to only send when multiple valid identifiers exist. Previously, the SDK sent an identify event even with a single identifier (just fs_user_id or just vuid), which provides no identity-linking value and generates unnecessary network traffic.

## Changes
- Added identifier count guard in `DefaultOdpManager.identifyUser` to skip event dispatch when fewer than 2 valid identifiers are present
- Added debug-level logging when the identify event is skipped due to single identifier
- Updated tests for single-identifier cases to expect no event sent

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Notes
- Reference implementation: Python SDK PR #513

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ