### PR TITLE
[AI-FSSDK] [TESTING] do not review

### DIFF
--- a/lib/odp/odp_manager.spec.ts
+++ b/lib/odp/odp_manager.spec.ts
@@ -618,7 +618,7 @@ describe('DefaultOdpManager', () => {
     expect(identifiers).toEqual(new Map([['fs_user_id', 'user'], ['vuid', 'vuid_a']]));
   });
 
-  it('sends identified event when called with just fs_user_id in first parameter', async () => {
+  it('does not send identified event when called with just fs_user_id and no vuid set', async () => {
     const eventManager = getMockOdpEventManager();
     eventManager.onRunning.mockReturnValue(Promise.resolve());
 
@@ -634,12 +634,10 @@ describe('DefaultOdpManager', () => {
     await odpManager.onRunning();
 
     odpManager.identifyUser('user');
-    expect(mockSendEvents).toHaveBeenCalledOnce();
-    const { identifiers } = mockSendEvents.mock.calls[0][0];
-    expect(identifiers).toEqual(new Map([['fs_user_id', 'user']]));
+    expect(mockSendEvents).not.toHaveBeenCalled();
   });
 
-  it('sends identified event when called with just vuid in first parameter', async () => {
+  it('does not send identified event when called with just vuid in first parameter and no stored vuid', async () => {
     const eventManager = getMockOdpEventManager();
     eventManager.onRunning.mockReturnValue(Promise.resolve());
 
@@ -655,9 +653,58 @@ describe('DefaultOdpManager', () => {
     await odpManager.onRunning();
 
     odpManager.identifyUser('vuid_a');
+    expect(mockSendEvents).not.toHaveBeenCalled();
+  });
+
+  it('sends identified event when called with fs_user_id and vuid is set via setVuid', async () => {
+    const eventManager = getMockOdpEventManager();
+    eventManager.onRunning.mockReturnValue(Promise.resolve());
+
+    const mockSendEvents = vi.mocked(eventManager.sendEvent as OdpEventManager['sendEvent']);
+
+    const odpManager = new DefaultOdpManager({
+      segmentManager: getMockOdpSegmentManager(),
+      eventManager,
+    });
+
+    odpManager.start();
+    odpManager.updateConfig({ integrated: true, odpConfig: config });
+    await odpManager.onRunning();
+
+    // Set vuid first, then identify with fs_user_id
+    odpManager.setVuid('vuid_123');
+
+    // Clear the client_initialized event call
+    mockSendEvents.mockClear();
+
+    odpManager.identifyUser('user');
+    expect(mockSendEvents).toHaveBeenCalledOnce();
+    const { type, action, identifiers } = mockSendEvents.mock.calls[0][0];
+    expect(type).toEqual('fullstack');
+    expect(action).toEqual('identified');
+    // identifyUser passes {fs_user_id: 'user'}, and sendEvent augments with stored vuid
+    expect(identifiers).toEqual(new Map([['fs_user_id', 'user'], ['vuid', 'vuid_123']]));
+  });
+
+  it('sends identified event with three identifiers (fs_user_id, explicit vuid, and stored vuid)', async () => {
+    const eventManager = getMockOdpEventManager();
+    eventManager.onRunning.mockReturnValue(Promise.resolve());
+
+    const mockSendEvents = vi.mocked(eventManager.sendEvent as OdpEventManager['sendEvent']);
+
+    const odpManager = new DefaultOdpManager({
+      segmentManager: getMockOdpSegmentManager(),
+      eventManager,
+    });
+
+    odpManager.start();
+    odpManager.updateConfig({ integrated: true, odpConfig: config });
+    await odpManager.onRunning();
+
+    odpManager.identifyUser('user', 'vuid_a');
     expect(mockSendEvents).toHaveBeenCalledOnce();
     const { identifiers } = mockSendEvents.mock.calls[0][0];
-    expect(identifiers).toEqual(new Map([['vuid', 'vuid_a']]));
+    expect(identifiers).toEqual(new Map([['fs_user_id', 'user'], ['vuid', 'vuid_a']]));
   });
 
   it('should reject onRunning() if stopped in new state', async () => {

--- a/lib/odp/odp_manager.ts
+++ b/lib/odp/odp_manager.ts
@@ -212,7 +212,7 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
 
   identifyUser(userId: string, vuid?: string): void {
     const identifiers = new Map<string, string>();
-    
+
     let finalUserId: Maybe<string> = userId;
     let finalVuid: Maybe<string> = vuid;
 
@@ -227,6 +227,21 @@ export class DefaultOdpManager extends BaseService implements OdpManager {
 
     if (finalUserId) {
       identifiers.set(ODP_USER_KEY.FS_USER_ID, finalUserId);
+    }
+
+    // Include the stored vuid when counting identifiers to determine if there
+    // are enough to warrant sending an identify event. The vuid would be added
+    // later in sendEvent(), but we need to account for it here for the count.
+    const allIdentifiers = new Map(identifiers);
+    if (!allIdentifiers.has(ODP_USER_KEY.VUID) && this.vuid) {
+      allIdentifiers.set(ODP_USER_KEY.VUID, this.vuid);
+    }
+
+    // An identify event requires at least 2 identifiers to link (e.g., vuid + fs_user_id).
+    // A single identifier has no cross-reference value and would generate unnecessary traffic.
+    if (allIdentifiers.size < 2) {
+      this.logger?.debug('ODP identify event is not dispatched (only one identifier provided).');
+      return;
     }
 
     const event = new OdpEvent(ODP_DEFAULT_EVENT_TYPE, ODP_EVENT_ACTION.IDENTIFIED, identifiers);


### PR DESCRIPTION
## Summary

Prevents the SDK from sending unnecessary ODP "identify" events when there are fewer than 2 valid identifiers. A single identifier has no cross-reference value for identity linking and would generate unnecessary network traffic.

## Changes

- Added identifier count check in `DefaultOdpManager.identifyUser()` that skips the ODP identify event when fewer than 2 valid identifiers are available (accounting for stored vuid)
- Added debug log message when identify event is skipped
- Updated tests to verify single-identifier identify calls are suppressed and multi-identifier calls continue to work

## Jira Ticket

[FSSDK-12721](https://optimizely-ext.atlassian.net/browse/FSSDK-12721)

[FSSDK-12721]: https://optimizely-ext.atlassian.net/browse/FSSDK-12721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ