### PR TITLE
[FSSDK-12759] fix content-length header in NodeRequestHandler

### DIFF
--- a/lib/utils/http_request_handler/request_handler.node.spec.ts
+++ b/lib/utils/http_request_handler/request_handler.node.spec.ts
@@ -16,6 +16,7 @@
 
 import { describe, beforeEach, afterEach, beforeAll, afterAll, it, vi, expect } from 'vitest';
 
+import http from 'http';
 import nock from 'nock';
 import zlib from 'zlib';
 import { NodeRequestHandler } from './request_handler.node';
@@ -200,6 +201,90 @@ describe('NodeRequestHandler', () => {
         headers: {},
       });
       scope.done();
+    });
+
+    describe('content-length header', () => {
+      let server: http.Server;
+      let port: number;
+      let receivedContentLength: string | undefined;
+      let receivedBodyByteLength: number;
+
+      beforeAll(async () => {
+        nock.enableNetConnect('localhost');
+        server = http.createServer((req, res) => {
+          receivedContentLength = req.headers['content-length'];
+
+          const chunks: Buffer[] = [];
+          req.on('data', (chunk: Buffer) => chunks.push(chunk));
+          req.on('end', () => {
+            receivedBodyByteLength = Buffer.concat(chunks).length;
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ ok: true }));
+          });
+        });
+
+        await new Promise<void>((resolve) => {
+          server.listen(0, () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+          });
+        });
+      });
+
+      afterAll(async () => {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        nock.disableNetConnect();
+      });
+
+      it('should set correct content-length for ASCII-only data', async () => {
+        const data = '{"key":"value"}';
+
+        const { responsePromise } = nodeRequestHandler.makeRequest(
+          `http://localhost:${port}/test`,
+          { 'content-type': 'application/json' },
+          'POST',
+          data,
+        );
+        await responsePromise;
+
+        const expectedByteLength = Buffer.byteLength(data, 'utf8');
+        expect(Number(receivedContentLength)).toBe(expectedByteLength);
+        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+      });
+
+      it('should set correct content-length for multi-byte UTF-8 data (emoji)', async () => {
+        const data = JSON.stringify({ message: '🚀 launch' });
+
+        const { responsePromise } = nodeRequestHandler.makeRequest(
+          `http://localhost:${port}/test`,
+          { 'content-type': 'application/json' },
+          'POST',
+          data,
+        );
+        await responsePromise;
+
+        const expectedByteLength = Buffer.byteLength(data, 'utf8');
+        expect(data.length).not.toBe(expectedByteLength);
+        expect(Number(receivedContentLength)).toBe(expectedByteLength);
+        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+      });
+
+      it('should set correct content-length for multi-byte UTF-8 data (CJK characters)', async () => {
+        const data = JSON.stringify({ greeting: '你好世界' });
+
+        const { responsePromise } = nodeRequestHandler.makeRequest(
+          `http://localhost:${port}/test`,
+          { 'content-type': 'application/json' },
+          'POST',
+          data,
+        );
+        await responsePromise;
+
+        const expectedByteLength = Buffer.byteLength(data, 'utf8');
+        expect(data.length).not.toBe(expectedByteLength);
+        expect(Number(receivedContentLength)).toBe(expectedByteLength);
+        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+      });
     });
 
     describe('timeout', () => {

--- a/lib/utils/http_request_handler/request_handler.node.spec.ts
+++ b/lib/utils/http_request_handler/request_handler.node.spec.ts
@@ -203,21 +203,18 @@ describe('NodeRequestHandler', () => {
       scope.done();
     });
 
-    describe('content-length header', () => {
+    describe('multi-byte unicode data', () => {
       let server: http.Server;
       let port: number;
-      let receivedContentLength: string | undefined;
-      let receivedBodyByteLength: number;
+      let receivedBody: string;
 
       beforeAll(async () => {
         nock.enableNetConnect('localhost');
         server = http.createServer((req, res) => {
-          receivedContentLength = req.headers['content-length'];
-
           const chunks: Buffer[] = [];
           req.on('data', (chunk: Buffer) => chunks.push(chunk));
           req.on('end', () => {
-            receivedBodyByteLength = Buffer.concat(chunks).length;
+            receivedBody = Buffer.concat(chunks).toString('utf8');
             res.writeHead(200, { 'content-type': 'application/json' });
             res.end(JSON.stringify({ ok: true }));
           });
@@ -236,7 +233,7 @@ describe('NodeRequestHandler', () => {
         nock.disableNetConnect();
       });
 
-      it('should set correct content-length for ASCII-only data', async () => {
+      it('should correctly transmit ASCII data', async () => {
         const data = '{"key":"value"}';
 
         const { responsePromise } = nodeRequestHandler.makeRequest(
@@ -247,12 +244,10 @@ describe('NodeRequestHandler', () => {
         );
         await responsePromise;
 
-        const expectedByteLength = Buffer.byteLength(data, 'utf8');
-        expect(Number(receivedContentLength)).toBe(expectedByteLength);
-        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+        expect(receivedBody).toBe(data);
       });
 
-      it('should set correct content-length for multi-byte UTF-8 data (emoji)', async () => {
+      it('should correctly transmit emoji data', async () => {
         const data = JSON.stringify({ message: '🚀 launch' });
 
         const { responsePromise } = nodeRequestHandler.makeRequest(
@@ -263,13 +258,10 @@ describe('NodeRequestHandler', () => {
         );
         await responsePromise;
 
-        const expectedByteLength = Buffer.byteLength(data, 'utf8');
-        expect(data.length).not.toBe(expectedByteLength);
-        expect(Number(receivedContentLength)).toBe(expectedByteLength);
-        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+        expect(receivedBody).toBe(data);
       });
 
-      it('should set correct content-length for multi-byte UTF-8 data (CJK characters)', async () => {
+      it('should correctly transmit CJK character data', async () => {
         const data = JSON.stringify({ greeting: '你好世界' });
 
         const { responsePromise } = nodeRequestHandler.makeRequest(
@@ -280,10 +272,7 @@ describe('NodeRequestHandler', () => {
         );
         await responsePromise;
 
-        const expectedByteLength = Buffer.byteLength(data, 'utf8');
-        expect(data.length).not.toBe(expectedByteLength);
-        expect(Number(receivedContentLength)).toBe(expectedByteLength);
-        expect(Number(receivedContentLength)).toBe(receivedBodyByteLength);
+        expect(receivedBody).toBe(data);
       });
     });
 

--- a/lib/utils/http_request_handler/request_handler.node.ts
+++ b/lib/utils/http_request_handler/request_handler.node.ts
@@ -62,16 +62,13 @@ export class NodeRequestHandler implements RequestHandler {
       headers: {
         ...headers,
         'accept-encoding': 'gzip,deflate',
-        'content-length': String(data?.length || 0)
+        'content-length': String(data ? Buffer.byteLength(data) : 0),
       },
       timeout: this.timeout,
     });
     const abortableRequest = this.getAbortableRequestFromRequest(request);
 
-    if (data) {
-      request.write(data);
-    }
-    request.end();
+    request.end(data);
 
     return abortableRequest;
   }


### PR DESCRIPTION
## Summary
- prevously, body.length was being used for content-length header, which is incorrect (The length data property of a String value contains the length of the string in UTF-16 code units, we need the byte length of utf-8 endcoded string). This PR fixes it. 

## Test plan
- added tests
- also tested with real node/python servers

## Issues
- FSSDK-12759
- #1155 
