### PR TITLE
[FSSDK-12865] url parse fix

### DIFF
--- a/lib/message/error_message.ts
+++ b/lib/message/error_message.ts
@@ -87,6 +87,7 @@ export const OUT_OF_BOUNDS =
 export const REQUEST_TIMEOUT = 'Request timeout';
 export const REQUEST_ERROR = 'Request error';
 export const NO_STATUS_CODE_IN_RESPONSE = 'No status code in response';
+export const INVALID_REQUEST_URL = 'Invalid request URL: %s';
 export const UNSUPPORTED_PROTOCOL = 'Unsupported protocol: %s';
 export const RETRY_CANCELLED = 'Retry cancelled';
 export const ONLY_POST_REQUESTS_ARE_SUPPORTED = 'Only POST requests are supported';

--- a/lib/utils/http_request_handler/request_handler.node.spec.ts
+++ b/lib/utils/http_request_handler/request_handler.node.spec.ts
@@ -21,6 +21,8 @@ import nock from 'nock';
 import zlib from 'zlib';
 import { NodeRequestHandler } from './request_handler.node';
 import { getMockLogger } from '../../tests/mock/mock_logger';
+import { OptimizelyError } from '../../error/optimizly_error';
+import { INVALID_REQUEST_URL } from 'error_message';
 
 beforeAll(() => {
   nock.disableNetConnect();
@@ -174,9 +176,13 @@ describe('NodeRequestHandler', () => {
     });
 
     it('should return a rejected response promise when the URL is malformed', async () => {
-      const request = nodeRequestHandler.makeRequest('not a valid url', {}, 'get');
+      const malformedUrl = 'not a valid url';
+      const request = nodeRequestHandler.makeRequest(malformedUrl, {}, 'get');
 
-      await expect(request.responsePromise).rejects.toThrow();
+      const error = await request.responsePromise.catch((e) => e);
+      expect(error).toBeInstanceOf(OptimizelyError);
+      expect(error.baseMessage).toBe(INVALID_REQUEST_URL);
+      expect(error.params).toEqual([malformedUrl]);
     });
 
     it('should return a rejected promise when there is a request error', async () => {

--- a/lib/utils/http_request_handler/request_handler.node.spec.ts
+++ b/lib/utils/http_request_handler/request_handler.node.spec.ts
@@ -173,6 +173,12 @@ describe('NodeRequestHandler', () => {
       await expect(request.responsePromise).rejects.toThrow();
     });
 
+    it('should return a rejected response promise when the URL is malformed', async () => {
+      const request = nodeRequestHandler.makeRequest('not a valid url', {}, 'get');
+
+      await expect(request.responsePromise).rejects.toThrow();
+    });
+
     it('should return a rejected promise when there is a request error', async () => {
       const scope = nock(host)
         .get(path)

--- a/lib/utils/http_request_handler/request_handler.node.ts
+++ b/lib/utils/http_request_handler/request_handler.node.ts
@@ -19,7 +19,7 @@ import { AbortableRequest, Headers, RequestHandler, Response } from './http';
 import decompressResponse from 'decompress-response';
 import { LoggerFacade } from '../../logging/logger';
 import { REQUEST_TIMEOUT_MS } from '../enums';
-import { NO_STATUS_CODE_IN_RESPONSE, REQUEST_ERROR, REQUEST_TIMEOUT, UNSUPPORTED_PROTOCOL } from 'error_message';
+import { INVALID_REQUEST_URL, NO_STATUS_CODE_IN_RESPONSE, REQUEST_ERROR, REQUEST_TIMEOUT, UNSUPPORTED_PROTOCOL } from 'error_message';
 import { OptimizelyError } from '../../error/optimizly_error';
 import { Platform } from '../../platform_support';
 /**
@@ -50,7 +50,7 @@ export class NodeRequestHandler implements RequestHandler {
       parsedUrl = new URL(requestUrl);
     } catch {
       return {
-        responsePromise: Promise.reject(new OptimizelyError(UNSUPPORTED_PROTOCOL, requestUrl)),
+        responsePromise: Promise.reject(new OptimizelyError(INVALID_REQUEST_URL, requestUrl)),
         abort: () => {},
       };
     }

--- a/lib/utils/http_request_handler/request_handler.node.ts
+++ b/lib/utils/http_request_handler/request_handler.node.ts
@@ -15,7 +15,6 @@
  */
 import http from 'http';
 import https from 'https';
-import url from 'url';
 import { AbortableRequest, Headers, RequestHandler, Response } from './http';
 import decompressResponse from 'decompress-response';
 import { LoggerFacade } from '../../logging/logger';
@@ -46,7 +45,15 @@ export class NodeRequestHandler implements RequestHandler {
    * @returns AbortableRequest contains both the response Promise and capability to abort()
    */
   makeRequest(requestUrl: string, headers: Headers, method: string, data?: string): AbortableRequest {
-    const parsedUrl = url.parse(requestUrl);
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(requestUrl);
+    } catch {
+      return {
+        responsePromise: Promise.reject(new OptimizelyError(UNSUPPORTED_PROTOCOL, requestUrl)),
+        abort: () => {},
+      };
+    }
 
     if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
       return {
@@ -79,11 +86,11 @@ export class NodeRequestHandler implements RequestHandler {
    * @private
    * @returns http.RequestOptions Standard request options dictionary compatible with both http and https
    */
-  private getRequestOptionsFromUrl(url: url.UrlWithStringQuery): http.RequestOptions {
+  private getRequestOptionsFromUrl(url: URL): http.RequestOptions {
     return {
       hostname: url.hostname,
-      path: url.path,
-      port: url.port,
+      path: url.pathname + url.search,
+      port: url.port || null,
       protocol: url.protocol,
     };
   }


### PR DESCRIPTION
## Summary
- Replace deprecated url.parse() with the WHATWG URL
- Wrap new URL() in try/catch to gracefully handle invalid URLs (unlike url.parse(), the URL constructor throws on malformed input)

## Test plan
Existing tests should pass
## Issues
- FSSDK-12865
