### PR TITLE
Listener adjustment

### DIFF
--- a/lib/notification_center/index.ts
+++ b/lib/notification_center/index.ts
@@ -121,6 +121,7 @@ export class DefaultNotificationCenter implements NotificationCenter, Notificati
     const remover = this.removers.get(listenerId);
     if (remover) {
       remover();
+      this.removers.delete(listenerId);
       return true;
     }
     return false


### PR DESCRIPTION
## Summary
This pull request makes a small improvement to the `DefaultNotificationCenter` class by ensuring that listener removers are properly cleaned up after use.

* After calling a remover function for a listener, the corresponding entry is deleted from the `removers` map to prevent memory leaks and ensure accurate state tracking.

## Test plan
Existing tests should pass

## Issues
- "THING-1234" or "Fixes #123"
