### PR TITLE
[AI-FSSDK] [FSSDK-13070] prepare for release javascript v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 **Holdout Targeted Delivery Exclusion**: Holdouts can now be configured to exclude Targeted Delivery rules, so users held out of experiments still receive their Targeted Delivery experiences. This gives you a cleaner measure of experiment impact without holding users back from ongoing rollouts.
 
 - Add holdout exclusion logic for Targeted Delivery rules ([#1171](https://github.com/optimizely/javascript-sdk/pull/1171))
-- Switch npm publishing to OIDC trusted publishing ([#1169](https://github.com/optimizely/javascript-sdk/pull/1169))
-- Refactor message generator to use TS compiler API ([#1170](https://github.com/optimizely/javascript-sdk/pull/1170))
-- NPM to GPR backfill + release workflow update ([#1168](https://github.com/optimizely/javascript-sdk/pull/1168))
 
 ## [6.5.0] - July 8, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.6.0] - September 2, 2026
+## [6.6.0] - September 3, 2026
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.6.0] - September 2, 2026
+
+### New Features
+
+**Holdout Targeted Delivery Exclusion**: Holdouts can now be configured to exclude Targeted Delivery rules, so users held out of experiments still receive their Targeted Delivery experiences. This gives you a cleaner measure of experiment impact without holding users back from ongoing rollouts.
+
+- Add holdout exclusion logic for Targeted Delivery rules ([#1171](https://github.com/optimizely/javascript-sdk/pull/1171))
+- Switch npm publishing to OIDC trusted publishing ([#1169](https://github.com/optimizely/javascript-sdk/pull/1169))
+- Refactor message generator to use TS compiler API ([#1170](https://github.com/optimizely/javascript-sdk/pull/1170))
+- NPM to GPR backfill + release workflow update ([#1168](https://github.com/optimizely/javascript-sdk/pull/1168))
+
 ## [6.5.0] - July 8, 2026
 
 ### New Features

--- a/lib/utils/enums/index.ts
+++ b/lib/utils/enums/index.ts
@@ -44,7 +44,7 @@ export const CONTROL_ATTRIBUTES = {
 export const JAVASCRIPT_CLIENT_ENGINE = 'javascript-sdk';
 export const NODE_CLIENT_ENGINE = 'node-sdk';
 export const REACT_NATIVE_JS_CLIENT_ENGINE = 'react-native-js-sdk';
-export const CLIENT_VERSION = '6.5.0';
+export const CLIENT_VERSION = '6.6.0';
 
 /*
  * Represents the source of a decision for feature management. When a feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optimizely/optimizely-sdk",
-      "version": "6.5.0",
+      "version": "6.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "decompress-response": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/optimizely-sdk",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "JavaScript SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts",
   "main": "./dist/index.node.min.js",
   "browser": "./dist/index.browser.es.min.js",


### PR DESCRIPTION
## Summary

Prepare for releasing javascript v6.6.0

## Release Details
- Version Bump: v6.5.0 → v6.6.0 (minor)

## Jira Ticket
[FSSDK-13070](https://optimizely-ext.atlassian.net/browse/FSSDK-13070)

[FSSDK-13070]: https://optimizely-ext.atlassian.net/browse/FSSDK-13070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ